### PR TITLE
Fix a flaky test that runs afoul of GC timing issues.

### DIFF
--- a/core/test/com/google/inject/JitBindingsTest.java
+++ b/core/test/com/google/inject/JitBindingsTest.java
@@ -323,8 +323,13 @@ public class JitBindingsTest extends TestCase {
     });
     ensureWorks(child, Foo.class, Bar.class);
     ensureFails(child, ALLOW_BINDING, FooImpl.class);
-    ensureInChild(parent, FooImpl.class, FooBar.class, Foo.class);
-    
+    ensureInChild(parent, FooImpl.class, Foo.class);
+    // TODO(sameb): FooBar may or may not be in a child injector, depending on if GC has run.
+    // We should fix failed child injectors to remove their contents from the parent blacklist
+    // immediately, rather than waiting on GC to do it.
+    // FooBar was succesfully inserted into the child injector (and parent blacklist), but then
+    // JIT bindings it depended on failed, making the child injector invalid.
+
     Injector grandchild = child.createChildInjector(new AbstractModule() {
       @Override
       protected void configure() {


### PR DESCRIPTION
Fix last flaky test (that I know of).  The problem was we were asserting that something existed in a child injector (through inference, by checking it was in the parent blacklist), but if GC ran it could have been ejected from the parent blacklist (since the child injector isn't strongly referenced anywhere).

There's an actual problem here that we should fix (remove items from the parent blacklist immediately if the child injector fails to create itself), but before fixing that we can at least make the test not flake.
`-------------`
Created by MOE: http://code.google.com/p/moe-java
MOE_MIGRATED_REVID=71369181
