### PR TITLE
Miscellaneous build improvements

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,49 +17,39 @@
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
-      <version>1</version>
     </dependency>
     <dependency>
       <groupId>aopalliance</groupId>
       <artifactId>aopalliance</artifactId>
-      <version>1.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava-testlib</artifactId>
-      <version>16.0.1</version>
-      <scope>test</scope>
     </dependency>
     <!--
      | CGLIB is embedded by default by the JarJar build profile
     -->
     <dependency>
-      <groupId>cglib</groupId>
-      <artifactId>cglib</artifactId>
-      <version>3.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-      <version>5.0.3</version>
+      <groupId>cglib</groupId>
+      <artifactId>cglib</artifactId>
       <optional>true</optional>
     </dependency>
+    <!--
+     | Test dependencies
+    -->
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject-tck</artifactId>
-      <version>1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -91,7 +81,7 @@
         <artifactId>maven-remote-resources-plugin</artifactId>
       </plugin>
       <!--
-       | Enable Java5 conformance checks
+       | Enable Java6 conformance checks
       -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -121,6 +111,7 @@
         <configuration>
           <instructions>
             <Bundle-Name>${project.artifactId}$(if;$(classes;NAMED;*.MethodAspect);; (no_aop))</Bundle-Name>
+            <Import-Package>!net.sf.cglib.*,!org.objectweb.asm.*,!com.google.inject.*,*</Import-Package>
             <Eclipse-ExtensibleAPI>true</Eclipse-ExtensibleAPI>
           </instructions>
         </configuration>
@@ -235,7 +226,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>jarjar-maven-plugin</artifactId>
-            <version>1.8</version>
+            <version>1.9</version>
             <executions>
               <execution>
                 <id>jarjar</id>
@@ -276,22 +267,25 @@
           </plugin>
           <plugin>
             <!--
-             | Package the original non-JarJar'd classes so extensions can compile against them
+             | Attach the original non-JarJar'd classes so extensions can compile against them
             -->
-            <artifactId>maven-jar-plugin</artifactId>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>1.8</version>
             <executions>
               <execution>
                 <id>classes</id>
                 <phase>package</phase>
                 <goals>
-                  <goal>jar</goal>
+                  <goal>attach-artifact</goal>
                 </goals>
                 <configuration>
-                  <classesDirectory>${project.build.directory}/original-classes</classesDirectory>
-                  <classifier>classes</classifier>
-                  <archive>
-                    <manifestFile combine.self="override" />
-                  </archive>
+                  <artifacts>
+                    <artifact>
+                      <file>${project.build.directory}/original-${project.build.finalName}.jar</file>
+                      <classifier>classes</classifier>
+                    </artifact>
+                  </artifacts>
                 </configuration>
               </execution>
             </executions>

--- a/extensions/mini/pom.xml
+++ b/extensions/mini/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.inject.extensions</groupId>
     <artifactId>extensions-parent</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>guice-mini</artifactId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -62,7 +62,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>16.0.1</version>
       <scope>test</scope>
     </dependency>
     <!--
@@ -70,21 +69,13 @@
      | in an execution that doesn't include package.
     -->
     <dependency>
-      <groupId>cglib</groupId>
-      <artifactId>cglib</artifactId>
-      <version>3.1</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>5.0.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>cglib</groupId>
+      <artifactId>cglib</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -98,7 +89,7 @@
         <artifactId>maven-remote-resources-plugin</artifactId>
       </plugin>
       <!--
-       | Enable Java5 conformance checks
+       | Enable Java6 conformance checks
       -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/extensions/service/pom.xml
+++ b/extensions/service/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.inject.extensions</groupId>
     <artifactId>extensions-parent</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>guice-service</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,46 @@ See the Apache License Version 2.0 for the specific language governing permissio
     <gpg.skip>true</gpg.skip>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>javax.inject</groupId>
+        <artifactId>javax.inject</artifactId>
+        <version>1</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.inject</groupId>
+        <artifactId>javax.inject-tck</artifactId>
+        <version>1</version>
+      </dependency>
+      <dependency>
+        <groupId>aopalliance</groupId>
+        <artifactId>aopalliance</artifactId>
+        <version>1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>16.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-testlib</artifactId>
+        <version>16.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>5.0.3</version>
+      </dependency>
+      <dependency>
+        <groupId>cglib</groupId>
+        <artifactId>cglib</artifactId>
+        <version>3.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -173,7 +213,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
           </executions>
         </plugin>
         <!--
-         | Make sure we only use Java5 methods
+         | Make sure we only use Java6 methods
         -->
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
@@ -253,12 +293,10 @@ See the Apache License Version 2.0 for the specific language governing permissio
               <Bundle-DocURL>https://github.com/google/guice</Bundle-DocURL>
               <Bundle-Name>${project.artifactId}</Bundle-Name>
               <Bundle-SymbolicName>$(module)</Bundle-SymbolicName>
-              <Bundle-RequiredExecutionEnvironment>
-                J2SE-1.5,JavaSE-1.6
-              </Bundle-RequiredExecutionEnvironment>
+              <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
               <Import-Package>!com.google.inject.*,*</Import-Package>
               <_exportcontents>!*.internal.*,$(module).*;version=${guice.api.version}</_exportcontents>
-              <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>
+              <_versionpolicy>$(version;==;$(@))</_versionpolicy>
               <_nouses>true</_nouses>
               <_removeheaders>
                 Embed-Dependency,Embed-Transitive,


### PR DESCRIPTION
- consolidate common versions in dependencyManagement section
- clean up OSGi metadata (remove asm/cglib imports, fix version range to account for Guava's versioning scheme)
- update jarjar-maven-plugin to 1.9 (makes sure manifest is first entry in final jar)
- attach correct pre-jarjar'd classes
- fix old references to Java5
- remove out-of-date asm:asm exclusion
- fix versions of mini/service extensions
