### PR TITLE
Move the references to javax.servlet classes into the anonymous class

### DIFF
--- a/extensions/servlet/src/com/google/inject/servlet/ServletScopes.java
+++ b/extensions/servlet/src/com/google/inject/servlet/ServletScopes.java
@@ -44,12 +44,6 @@ public class ServletScopes {
 
   private ServletScopes() {}
 
-  /** Keys bound in request-scope which are handled directly by GuiceFilter. */
-  private static final ImmutableSet<Key<?>> REQUEST_CONTEXT_KEYS = ImmutableSet.of(
-      Key.get(HttpServletRequest.class),
-      Key.get(HttpServletResponse.class),
-      new Key<Map<String, String[]>>(RequestParameters.class) {});
-
   /**
    * A threadlocal scope map for non-http request scopes. The {@link #REQUEST}
    * scope falls back to this scope map if no http request is available, and
@@ -67,6 +61,13 @@ public class ServletScopes {
   public static final Scope REQUEST = new Scope() {
     public <T> Provider<T> scope(final Key<T> key, final Provider<T> creator) {
       return new Provider<T>() {
+
+        /** Keys bound in request-scope which are handled directly by GuiceFilter. */
+        private final ImmutableSet<Key<?>> REQUEST_CONTEXT_KEYS = ImmutableSet.of(
+                Key.get(HttpServletRequest.class),
+                Key.get(HttpServletResponse.class),
+                new Key<Map<String, String[]>>(RequestParameters.class) {});
+
         public T get() {
           // Check if the alternate request scope should be used, if no HTTP
           // request is in progress.


### PR DESCRIPTION
This fixes an issue I encountered when trying to upgrade to Guice 4. These static references were added to `ServletScopes` that reference `HttpServletRequest` and `HttpServletResponse`. This causes a `NoClassDefFoundError` if you reference `ServletScopes` without javax.servlet:servlet-api on the classpath (the guice-servlet dependency on this JAR has provided scope).

Our use-case is that we have a custom scope annotation that is bound to request-scoped in our API's, and no scope in our background jobs. We have a module that determines what environment we're running in and binds the scope annotation automatically. It looks something like this:

``` java
@Override
protected void configure() {
    bindScope(CustomScope.class, isApi() ? ServletScopes.REQUEST : Scopes.NO_SCOPE);
}
```

This worked fine in Guice 3. The problem is that in Guice 4, simply referencing `ServletScopes.REQUEST` (even if you don't end up using it) throws a `NoClassDefFoundError` unless you have javax.servlet:servlet-api on the classpath (which we don't in our background jobs).

Let me know if I'm missing an obvious workaround, we don't want to have to add javax.servlet:servlet-api to the classpath for our background jobs (for philosophical and practical reasons).
