### PR TITLE
Request For Enhancement: Scopes.getCachingProvider(Binding)

### DIFF
--- a/core/src/com/google/inject/Scopes.java
+++ b/core/src/com/google/inject/Scopes.java
@@ -115,15 +115,15 @@ public class Scopes {
   }
 
   /**
-   * Returns singleton-scoped {@link Provider} for {@code binding} regardless of original scope.
+   * Returns a caching {@link Provider} for {@code binding} that lazily caches the result.
    *
    * @since 4.0
    */
-  public static <T> Provider<T> asSingleton(Binding<T> binding) {
+  public static <T> Provider<T> getCachingProvider(Binding<T> binding) {
     if (isSingleton(binding)) {
       return binding.getProvider();
     }
-    return SingletonScope.asSingleton(binding);
+    return SingletonScope.getCachingProvider(binding);
   }
 
   /**

--- a/core/src/com/google/inject/internal/SingletonScope.java
+++ b/core/src/com/google/inject/internal/SingletonScope.java
@@ -97,9 +97,9 @@ public class SingletonScope implements Scope {
   }
 
   /**
-   * Returns singleton-scoped {@link Provider} for {@code binding} regardless of original scope.
+   * Returns a caching {@link Provider} for {@code binding} that lazily caches the result.
    */
-  public static <T> Provider<T> asSingleton(Binding<T> binding) {
+  public static <T> Provider<T> getCachingProvider(Binding<T> binding) {
     InjectorImpl injector = null;
     if (binding instanceof BindingImpl<?>) {
       injector = ((BindingImpl<T>) binding).getInjector();

--- a/core/test/com/google/inject/ScopesTest.java
+++ b/core/test/com/google/inject/ScopesTest.java
@@ -636,15 +636,15 @@ public class ScopesTest extends TestCase {
     assertFalse(Scopes.isSingleton(injector.getBinding(f)));
   }
 
-  private static void checkAsSingleton(Binding<?> binding) {
-    // check prototype binding can be made into singleton
-    Provider<?> prototypeProvider = binding.getProvider();
-    assertNotSame(prototypeProvider.get(), prototypeProvider.get());
-    Provider<?> singletonProvider = Scopes.asSingleton(binding);
-    assertSame(singletonProvider.get(), singletonProvider.get());
+  private static void checkCachingProvider(Binding<?> binding) {
+    // check binding can be made into a caching provider
+    Provider<?> originalProvider = binding.getProvider();
+    assertNotSame(originalProvider.get(), originalProvider.get());
+    Provider<?> cachingProvider = Scopes.getCachingProvider(binding);
+    assertSame(cachingProvider.get(), cachingProvider.get());
   }
 
-  public void testAsSingleton() {
+  public void testCachingProvider() {
     final Key<String> a = Key.get(String.class, named("A"));
     final Key<String> b = Key.get(String.class, named("B"));
     final Key<String> c = Key.get(String.class, named("C"));
@@ -676,12 +676,12 @@ public class ScopesTest extends TestCase {
     };
 
     Injector injector = Guice.createInjector(prototypeBindings);
-    checkAsSingleton(injector.getBinding(a));
-    checkAsSingleton(injector.getBinding(b));
-    checkAsSingleton(injector.getBinding(c));
-    checkAsSingleton(injector.getBinding(d));
-    checkAsSingleton(injector.getBinding(e));
-    checkAsSingleton(injector.getBinding(f));
+    checkCachingProvider(injector.getBinding(a));
+    checkCachingProvider(injector.getBinding(b));
+    checkCachingProvider(injector.getBinding(c));
+    checkCachingProvider(injector.getBinding(d));
+    checkCachingProvider(injector.getBinding(e));
+    checkCachingProvider(injector.getBinding(f));
   }
 
   public void testIsScopedPositive() {


### PR DESCRIPTION
The recent change to support finer-grained singleton locks removed the ability to take a prototype binding from the injector and turn it into a lazy caching provider, using the same lock as if it had originally been bound as a singleton. It's important that the same lock is used, otherwise there is potential for deadlock when mixing these caching providers with singletons already bound in the injector inside the same app.

This RFE introduces a new method Scopes.getCachingProvider(Binding) which takes a binding and returns a lazy caching provider backed by the binding. If the binding is associated with an injector then it
will use the injector's singletonCreationLock. If the binding is for some reason not associated with an injector then it will use the binding itself to synchronize caching of the provided value.
