### PR TITLE
Add "BOM" (Bill Of Material) for easier use with Maven

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.inject</groupId>
+    <artifactId>guice-parent</artifactId>
+    <version>4.0-SNAPSHOT</version>
+  </parent>
+
+  <packaging>pom</packaging>
+
+  <artifactId>guice-bom</artifactId>
+
+  <name>Google Guice - Bill of Materials</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>${project.version}</version>
+        <classifier>no_aop</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>${project.version}</version>
+        <classifier>classes</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-assistedinject</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-grapher</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-jmx</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-jndi</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-multibindings</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-persist</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-servlet</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-spring</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-struts2</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-testlib</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-throwingproviders</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+<!--
+ |  not yet promoted...
+- -
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-mini</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-service</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+-->
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
   </distributionManagement>
 
   <modules>
+    <module>bom</module>
     <module>core</module>
     <module>extensions</module>
     <!-- jdk8-tests module activated only when running under JDK8, below -->


### PR DESCRIPTION
Guice extensions must generally have their version match the one of Guice. Maven provides an easy way to make sure this is the case with “BOMs” that you later import using `<dependencyManagement>`, `<type>pom</type>` and `<scope>import</scope>`: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies

Use cases:
1. GIN 2.1.2 depends on Guice 3.0 and uses assistedinject; if you want to use GIN 2.1.2 and Guice 4, you have to explicitly declare a dependency (or _dependency management_) on `guice-assistedinject` even if you don't use it, otherwise you'll have Guice 4 and guice-assistedinject 3.0 in your classpath and it won't work.
2. Closure Templates also uses Guice 3.0 and uses assistedinject and multibindings.

By just importing a BOM you'd make sure you use the same version of all your Guice dependencies, either direct or transitive.
