### PR TITLE
Proof of concept: Providers.cache(Binding)

### DIFF
--- a/core/src/com/google/inject/util/Providers.java
+++ b/core/src/com/google/inject/util/Providers.java
@@ -21,9 +21,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.google.inject.Binding;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
+import com.google.inject.Scopes;
+import com.google.inject.internal.Scoping;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.ProviderWithDependencies;
@@ -152,5 +155,17 @@ public final class Providers {
     public Set<Dependency<?>> getDependencies() {
       return dependencies;
     }
+  }
+
+  /**
+   * Returns a {@link Provider} for {@code binding} that lazily caches the first result.
+   * 
+   * @param binding to cache the result of
+   * @return Provider that lazily caches the first result
+   * 
+   * @since 4.0
+   */
+  public static <T> Provider<T> cache(Binding<T> binding) {
+    return Scopes.isSingleton(binding) ? binding.getProvider() : Scoping.cache(binding);
   }
 }


### PR DESCRIPTION
**This is more of an FYI to give background why I was originally (mis)using Scopes.SINGLETON.scope.**
**On reflection this change doesn't pull enough weight to justify its addition as the use-case is narrow.**

The recent change to support per-injector singleton locks removed
the ability to take a prototype binding from the injector and use
`Scopes.SINGLETON.scope(...);` to create a local caching provider
that lazily caches the first result.

This POC introduces a new method Providers.cache(Binding) which
takes a binding and returns a provider that lazily caches the
initial result from the binding. This acts like a local cache
which is useful when integrating with third-party frameworks.

The same feature can be implemented outside of Guice, however it
would then use a different lock to the one used to synchronize
creation of singletons, and this could potentially lead to a
deadlock if you had a multi-threaded application with singleton
components that interacted with these caching providers for their
injected dependencies.
