### PR TITLE
Avoid duplicate failures if a Singleton fails to create

### DIFF
--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -527,6 +527,12 @@ public final class Errors implements Serializable {
     if (root.errors == null) {
       root.errors = Lists.newArrayList();
     }
+    // If this message has already been noted, don't add it again
+    for (Message m : root.errors) {
+      if (m.getCause() == message.getCause() && m.getMessage().equals(message.getMessage())) {
+        return this;
+      }
+    }
     root.errors.add(message);
     return this;
   }

--- a/core/src/com/google/inject/internal/MembersInjectorImpl.java
+++ b/core/src/com/google/inject/internal/MembersInjectorImpl.java
@@ -84,7 +84,7 @@ final class MembersInjectorImpl<T> implements MembersInjector<T> {
         try {
           if (provisionCallback != null && provisionCallback.hasListeners()) {
             provisionCallback.provision(errors, context, new ProvisionCallback<T>() {
-              @Override public T call() {
+              @Override public T call() throws ErrorsException {
                 injectMembers(instance, errors, context, toolableOnly);
                 return instance;
               }
@@ -124,7 +124,9 @@ final class MembersInjectorImpl<T> implements MembersInjector<T> {
     errors.throwIfNewErrors(numErrorsBefore);
   }
 
-  void injectMembers(T t, Errors errors, InternalContext context, boolean toolableOnly) {
+  void injectMembers(T t, Errors errors, InternalContext context, boolean toolableOnly) throws ErrorsException {
+    int numErrorsBefore = errors.size();
+
     // optimization: use manual for/each to save allocating an iterator here
     for (int i = 0, size = memberInjectors.size(); i < size; i++) {
       SingleMemberInjector injector = memberInjectors.get(i);
@@ -143,6 +145,8 @@ final class MembersInjectorImpl<T> implements MembersInjector<T> {
         }
       }
     }
+
+    errors.throwIfNewErrors(numErrorsBefore);
   }
 
   @Override public String toString() {

--- a/core/test/com/google/inject/BinderTest.java
+++ b/core/test/com/google/inject/BinderTest.java
@@ -187,8 +187,7 @@ public class BinderTest extends TestCase {
       fail();
     } catch (CreationException expected) {
       assertContains(expected.getMessage(),
-          "1) Binding to null instances is not allowed. Use toProvider(Providers.of(null))",
-          "2) Binding to null instances is not allowed. Use toProvider(Providers.of(null))");
+          "1) Binding to null instances is not allowed. Use toProvider(Providers.of(null))");
     }
   }
 
@@ -541,10 +540,6 @@ public class BinderTest extends TestCase {
           asModuleChain(OuterCoreModule.class, InnerCoreModule.class),
 
           "Binding to core guice framework type is not allowed: TypeLiteral.",
-          "at " + InnerCoreModule.class.getName() + getDeclaringSourcePart(getClass()),
-          asModuleChain(OuterCoreModule.class, InnerCoreModule.class),
-
-          "Binding to core guice framework type is not allowed: Key.",
           "at " + InnerCoreModule.class.getName() + getDeclaringSourcePart(getClass()),
           asModuleChain(OuterCoreModule.class, InnerCoreModule.class));
     }

--- a/core/test/com/google/inject/BindingTest.java
+++ b/core/test/com/google/inject/BindingTest.java
@@ -273,8 +273,6 @@ public class BindingTest extends TestCase {
     } catch (CreationException expected) {
       assertContains(expected.getMessage(),
           "1) T cannot be used as a key; It is not fully specified.",
-          "at " + C.class.getName() + ".<init>(BindingTest.java:",
-          "2) T cannot be used as a key; It is not fully specified.",
           "at " + C.class.getName() + ".anotherT(BindingTest.java:");
     }
   }

--- a/core/test/com/google/inject/CircularDependencyTest.java
+++ b/core/test/com/google/inject/CircularDependencyTest.java
@@ -366,8 +366,7 @@ public class CircularDependencyTest extends TestCase {
       fail("expected exception");
     } catch(ProvisionException expected) {
       assertContains(expected.getMessage(),
-          "Tried proxying " + A.class.getName() + " to support a circular dependency, but circular proxies are disabled", 
-          "Tried proxying " + B.class.getName() + " to support a circular dependency, but circular proxies are disabled");
+          "Tried proxying " + A.class.getName() + " to support a circular dependency, but circular proxies are disabled");
     }
   }
 

--- a/core/test/com/google/inject/SingletonConstructionFailureTest.java
+++ b/core/test/com/google/inject/SingletonConstructionFailureTest.java
@@ -1,0 +1,30 @@
+package com.google.inject;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SingletonConstructionFailureTest {
+    @Test
+    public void testGuiceCreatesSingletonTwice() throws Exception {
+        try {
+            Guice.createInjector(Stage.PRODUCTION, new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind (Boom.class).in(Scopes.SINGLETON);
+                    bind (Object.class).to(Boom.class);
+                }
+            }).getInstance(Boom.class);
+        } catch (CreationException expected) {
+            Assert.assertEquals(1, expected.getErrorMessages().size());
+        }
+        Assert.assertEquals(1, Boom.nCalls);
+    }
+
+    public static class Boom {
+        static int nCalls = 0;
+        public Boom() {
+            nCalls++;
+            throw new IllegalArgumentException("kaboom!");
+        }
+    }
+}


### PR DESCRIPTION
Current behavior:

If a Singleton cannot be created, it will re-attempt at every injection point.  In `Stage.PRODUCTION`, this is guaranteed wasted work -- the injector creates all Singletons eagerly, and any failure causes Injector creation failure.  In `Stage.DEVELOPMENT`, it's a bit more confusing as we may fail later at runtime, which conceivably allows us to 'recover' from this sort of error.  I would argue this is more a bug than a feature -- it allows multiple partially-created Singleton instances to leak (if you do so from the `Provider` or constructor) and is guaranteed to break later if you ever use `PRODUCTION` mode.

New behavior:

The exception thrown while creating the Singleton is saved and reused at every further try to inject it.  Duplicate exceptions are suppressed from `Errors` to ensure the end user only sees the true cause once.