### PR TITLE
Add way to set default scope

### DIFF
--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -623,6 +623,13 @@ final class InjectorImpl implements Injector, Lookups {
    */
   <T> BindingImpl<T> createUninitializedBinding(Key<T> key, Scoping scoping, Object source,
       Errors errors, boolean jitBinding) throws ErrorsException {
+    if (!scoping.isExplicitlyScoped()) {
+        BindingImpl<Scoping> scopingBinding = getExistingBinding(Key.get(Scoping.class));
+        if (scopingBinding instanceof com.google.inject.spi.InstanceBinding) {
+            scoping = (Scoping)((com.google.inject.spi.InstanceBinding<?>)scopingBinding).getInstance();
+        }
+    }
+
     Class<?> rawType = key.getTypeLiteral().getRawType();
 
     ImplementedBy implementedBy = rawType.getAnnotation(ImplementedBy.class);


### PR DESCRIPTION
If a binding exists for the Scoping class, use it whenever no
explicit scope is provided.

NB: Only instance bindings are supported at this time.
