### PR TITLE
Fix https://github.com/google/guice/issues/888.

### DIFF
--- a/core/src/com/google/inject/Binder.java
+++ b/core/src/com/google/inject/Binder.java
@@ -429,8 +429,8 @@ public interface Binder {
   /**
    * Instructs the Injector that bindings must be listed in a Module in order to
    * be injected. Classes that are not explicitly bound in a module cannot be
-   * injected. Bindings created through a linked binding (
-   * <code>bind(Foo.class).to(FooImpl.class)</code>) are allowed, but the
+   * injected. Bindings created through a linked binding
+   * (<code>bind(Foo.class).to(FooImpl.class)</code>) are allowed, but the
    * implicit binding (<code>FooImpl</code>) cannot be directly injected unless
    * it is also explicitly bound (<code>bind(FooImpl.class)</code>).
    * <p>
@@ -447,10 +447,11 @@ public interface Binder {
    * does, the behavior is limited only to that child or any grandchildren. No
    * siblings of the child will require explicit bindings.
    * <p>
-   * If the parent did not require explicit bindings but the child does, it is
-   * possible that a linked binding in the child may add a JIT binding to the
-   * parent. The child will not be allowed to reference the target binding
-   * directly, but the parent and other children of the parent may be able to.
+   * In the absence of an explicit binding for the target, linked bindings in
+   * child injectors create a binding for the target in the parent. Since this
+   * behavior can be surprising, it causes an error instead if explicit bindings
+   * are required. To avoid this error, add an explicit binding for the target,
+   * either in the child or the parent.
    * 
    * @since 3.0
    */

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -141,7 +141,10 @@ public final class Errors implements Serializable {
   }
 
   public Errors jitDisabledInParent(Key<?> key) {
-    return addMessage("Explicit bindings are required and %s would be bound in a parent injector.", key);
+    return addMessage(
+        "Explicit bindings are required and %s would be bound in a parent injector.%n"
+        + "Please add an explicit binding for it, either in the child or the parent.",
+        key);
   }
 
   public Errors atInjectRequired(Class clazz) {

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -140,6 +140,10 @@ public final class Errors implements Serializable {
     return addMessage("Explicit bindings are required and %s is not explicitly bound.", key);
   }
 
+  public Errors jitDisabledInParent(Key<?> key) {
+    return addMessage("Explicit bindings are required and %s would be bound in a parent injector.", key);
+  }
+
   public Errors atInjectRequired(Class clazz) {
     return addMessage(
         "Explicit @Inject annotations are required on constructors,"

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -101,7 +101,7 @@ final class InjectorImpl implements Injector, Lookups {
     NO_JIT,
     /** allows existing just in time bindings, but does not allow new ones */
     EXISTING_JIT,
-    /** allows existing just in time bindings & allows new ones to be created in the current injector */
+    /** allows existing just in time bindings & allows new ones to be created */
     NEW_OR_EXISTING_JIT,
   }
 

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -101,7 +101,7 @@ final class InjectorImpl implements Injector, Lookups {
     NO_JIT,
     /** allows existing just in time bindings, but does not allow new ones */
     EXISTING_JIT,
-    /** allows existing just in time bindings & allows new ones to be created */
+    /** allows existing just in time bindings & allows new ones to be created in the current injector */
     NEW_OR_EXISTING_JIT,
   }
 
@@ -779,10 +779,14 @@ final class InjectorImpl implements Injector, Lookups {
       boolean jitDisabled, JitLimitation jitType) throws ErrorsException {
     // ask the parent to create the JIT binding
     if (parent != null) {
-      try {
-        return parent.createJustInTimeBindingRecursive(key, new Errors(), jitDisabled,
-            parent.options.jitDisabled ? JitLimitation.NO_JIT : jitType);
-      } catch (ErrorsException ignored) {
+      if (jitDisabled && jitType == JitLimitation.NEW_OR_EXISTING_JIT) {
+        throw errors.jitDisabledInParent(key).toException();
+      } else {
+        try {
+          return parent.createJustInTimeBindingRecursive(key, new Errors(), jitDisabled,
+              parent.options.jitDisabled ? JitLimitation.NO_JIT : jitType);
+        } catch (ErrorsException ignored) {
+        }
       }
     }
 

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -779,14 +779,16 @@ final class InjectorImpl implements Injector, Lookups {
       boolean jitDisabled, JitLimitation jitType) throws ErrorsException {
     // ask the parent to create the JIT binding
     if (parent != null) {
-      if (jitDisabled && jitType == JitLimitation.NEW_OR_EXISTING_JIT) {
+      if (jitType == JitLimitation.NEW_OR_EXISTING_JIT
+          && jitDisabled && !parent.options.jitDisabled) {
+        // If the binding would be forbidden here but allowed in a parent, report an error instead
         throw errors.jitDisabledInParent(key).toException();
-      } else {
-        try {
-          return parent.createJustInTimeBindingRecursive(key, new Errors(), jitDisabled,
-              parent.options.jitDisabled ? JitLimitation.NO_JIT : jitType);
-        } catch (ErrorsException ignored) {
-        }
+      }
+
+      try {
+        return parent.createJustInTimeBindingRecursive(key, new Errors(), jitDisabled,
+            parent.options.jitDisabled ? JitLimitation.NO_JIT : jitType);
+      } catch (ErrorsException ignored) {
       }
     }
 

--- a/core/test/com/google/inject/JitBindingsTest.java
+++ b/core/test/com/google/inject/JitBindingsTest.java
@@ -326,10 +326,10 @@ public class JitBindingsTest extends TestCase {
       @Override
       protected void configure() {
         bind(Foo.class).to(FooImpl.class);
-        bind(FooImpl.class);
       }
     });
     ensureWorks(child, Foo.class, Bar.class);
+    ensureFails(child, ALLOW_BINDING, FooImpl.class);
     ensureInChild(parent, FooImpl.class, Foo.class);
     // TODO(sameb): FooBar may or may not be in a child injector, depending on if GC has run.
     // We should fix failed child injectors to remove their contents from the parent blacklist
@@ -344,6 +344,8 @@ public class JitBindingsTest extends TestCase {
       }
     });
     ensureWorks(grandchild, FooBar.class, Foo.class, Bar.class);
+    ensureFails(grandchild, ALLOW_BINDING, FooImpl.class);
+    ensureFails(child, ALLOW_BINDING, FooImpl.class);
     ensureInChild(parent, FooImpl.class, FooBar.class, Foo.class);
   }
   
@@ -426,7 +428,6 @@ public class JitBindingsTest extends TestCase {
           public void configure() {
             bind(Foo.class).to(FooImpl.class);
             expose(Foo.class);
-            bind(FooImpl.class);
           }
         });
       }
@@ -596,7 +597,7 @@ public class JitBindingsTest extends TestCase {
       assertEquals(1, expected.getErrorMessages().size());
     }
   }
-  
+
   private void ensureWorks(Injector injector, Class<?>... classes) {
     for(int i = 0; i < classes.length; i++) {
       injector.getInstance(classes[i]);

--- a/core/test/com/google/inject/JitBindingsTest.java
+++ b/core/test/com/google/inject/JitBindingsTest.java
@@ -168,8 +168,8 @@ public class JitBindingsTest extends TestCase {
       });
       fail();
     } catch(CreationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitFailed(ScopedFooImpl.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitFailed(ScopedFooImpl.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
   }
   
@@ -198,8 +198,8 @@ public class JitBindingsTest extends TestCase {
       }).getInstance(Bar.class);
       fail("should have failed");
     } catch(ConfigurationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitFailed(Bar.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitFailed(Bar.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
   }
   
@@ -215,8 +215,8 @@ public class JitBindingsTest extends TestCase {
       });
       fail("should have failed");
     } catch (CreationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitFailed(Bar.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitFailed(Bar.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
   }
 
@@ -230,8 +230,8 @@ public class JitBindingsTest extends TestCase {
       }).getProvider(Bar.class);
       fail("should have failed");
     } catch (ConfigurationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitFailed(Bar.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitFailed(Bar.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
   }
 
@@ -247,8 +247,8 @@ public class JitBindingsTest extends TestCase {
       });
       fail("should have failed");
     } catch (CreationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitFailed(Bar.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitFailed(Bar.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
   }
   
@@ -318,8 +318,8 @@ public class JitBindingsTest extends TestCase {
       });
       fail("should have failed");
     } catch(CreationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitFailed(Foo.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitFailed(Foo.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
     
     Injector child = parent.createChildInjector(new AbstractModule() {
@@ -366,8 +366,8 @@ public class JitBindingsTest extends TestCase {
       });
       fail("should have failed");
     } catch(CreationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitFailed(Foo.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitFailed(Foo.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
     assertEquals(totalParentBindings, parent.getAllBindings().size());
     
@@ -414,8 +414,8 @@ public class JitBindingsTest extends TestCase {
       });
       fail("should have failed");
     } catch(CreationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitFailed(Bar.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitFailed(Bar.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
     
     Injector injector = Guice.createInjector(new AbstractModule() {
@@ -453,8 +453,8 @@ public class JitBindingsTest extends TestCase {
       });
       fail("should have failed");
     } catch(CreationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitFailed(Bar.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitFailed(Bar.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
   }
 
@@ -529,8 +529,8 @@ public class JitBindingsTest extends TestCase {
       });
       fail("should have failed");
     } catch (CreationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitInParentFailed(FooImpl.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitInParentFailed(FooImpl.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
   }
 
@@ -550,8 +550,8 @@ public class JitBindingsTest extends TestCase {
       });
       fail("should have failed");
     } catch (CreationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitInParentFailed(FooProvider.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitInParentFailed(FooProvider.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
   }
 
@@ -571,8 +571,8 @@ public class JitBindingsTest extends TestCase {
       });
       fail("should have failed");
     } catch (CreationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitInParentFailed(ImplByImpl.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitInParentFailed(ImplByImpl.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
   }
 
@@ -592,8 +592,8 @@ public class JitBindingsTest extends TestCase {
       });
       fail("should have failed");
     } catch (CreationException expected) {
-      assertContains(expected.getMessage(), "\n1) " + jitInParentFailed(ProvByProvider.class));
-      assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+      assertContains(expected.getMessage(), jitInParentFailed(ProvByProvider.class));
+      assertEquals(1, expected.getErrorMessages().size());
     }
   }
   
@@ -612,16 +612,16 @@ public class JitBindingsTest extends TestCase {
         injector.getInstance(classes[i]);
         fail("should have failed tring to retrieve class: " + classes[i]);
       } catch(ConfigurationException expected) {
-        assertContains(expected.getMessage(), "\n1) " + jitFailed(classes[i]));
-        assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+        assertContains(expected.getMessage(), jitFailed(classes[i]));
+        assertEquals(1, expected.getErrorMessages().size());
       }
       
       try { 
         injector.getProvider(classes[i]);
         fail("should have failed tring to retrieve class: " + classes[i]);
       } catch(ConfigurationException expected) {
-        assertContains(expected.getMessage(), "\n1) " + jitFailed(classes[i]));
-        assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+        assertContains(expected.getMessage(), jitFailed(classes[i]));
+        assertEquals(1, expected.getErrorMessages().size());
       }
       
       if (getBinding == GetBindingCheck.ALLOW_BINDING
@@ -636,16 +636,16 @@ public class JitBindingsTest extends TestCase {
           if (getBinding == GetBindingCheck.ALLOW_BINDING_PROVIDER) {
             throw expected;
           }
-          assertContains(expected.getMessage(), "\n1) " + jitFailed(classes[i]));
-          assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+          assertContains(expected.getMessage(), jitFailed(classes[i]));
+          assertEquals(1, expected.getErrorMessages().size());
         }
       } else {
         try {
           injector.getBinding(classes[i]);
           fail("should have failed tring to retrieve class: " + classes[i]);          
         } catch(ConfigurationException expected) {
-          assertContains(expected.getMessage(), "\n1) " + jitFailed(classes[i]));
-          assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+          assertContains(expected.getMessage(), jitFailed(classes[i]));
+          assertEquals(1, expected.getErrorMessages().size());
         }
       }
     }
@@ -657,24 +657,24 @@ public class JitBindingsTest extends TestCase {
         injector.getInstance(classes[i]);
         fail("should have failed tring to retrieve class: " + classes[i]);
       } catch(ConfigurationException expected) {
-        assertContains(expected.getMessage(), "\n1) " + inChildMessage(classes[i]));
-        assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+        assertContains(expected.getMessage(), inChildMessage(classes[i]));
+        assertEquals(1, expected.getErrorMessages().size());
       }
       
       try { 
         injector.getProvider(classes[i]);
         fail("should have failed tring to retrieve class: " + classes[i]);
       } catch(ConfigurationException expected) {
-        assertContains(expected.getMessage(), "\n1) " + inChildMessage(classes[i]));
-        assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+        assertContains(expected.getMessage(), inChildMessage(classes[i]));
+        assertEquals(1, expected.getErrorMessages().size());
       }
       
       try {
         injector.getBinding(classes[i]);
         fail("should have failed tring to retrieve class: " + classes[i]);          
       } catch(ConfigurationException expected) {
-        assertContains(expected.getMessage(), "\n1) " + inChildMessage(classes[i]));
-        assertTrue(expected.getMessage(), !expected.getMessage().contains("\n2) "));
+        assertContains(expected.getMessage(), inChildMessage(classes[i]));
+        assertEquals(1, expected.getErrorMessages().size());
       }
     }
   }


### PR DESCRIPTION
When Binder.requireExplicitBindings() is in effect, don't allow any
JIT bindings to be created in parent injectors, even JIT bindings that
are normally exempt such as the targets of linked key bindings.