### PR TITLE
Add support to private module in graph extension

### DIFF
--- a/extensions/grapher/src/com/google/inject/grapher/DefaultSubgraphCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/DefaultSubgraphCreator.java
@@ -1,0 +1,42 @@
+package com.google.inject.grapher;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.inject.Binding;
+import com.google.inject.spi.DefaultBindingTargetVisitor;
+import com.google.inject.spi.ExposedBinding;
+
+/**
+ * Default subgraph creator.
+ *
+ * @author houcheng@gmail.com (Houcheng Lin)
+ */
+public class DefaultSubgraphCreator implements SubgraphCreator {
+  @Override
+  public Iterable<Subgraph> getSubs(Iterable<Binding<?>> bindings) {
+    List<Subgraph> subs = Lists.newArrayList();
+    SubgraphVisitor visitor = new SubgraphVisitor();
+    for (Binding<?> binding : bindings) {
+      subs.addAll(binding.acceptTargetVisitor(visitor));
+    }
+    return subs;
+  }
+}
+
+class SubgraphVisitor extends 
+  DefaultBindingTargetVisitor<Object, Collection<Subgraph>> {
+  @Override
+  public Collection<Subgraph> visit(ExposedBinding<?> exposedBinding) {
+    return ImmutableList.<Subgraph>of(getSubgraph(exposedBinding));
+  }
+  @Override public Collection<Subgraph> visitOther(Binding<?> binding) {
+    return ImmutableList.of();
+  }  
+  private Subgraph getSubgraph(ExposedBinding<?> exposedBinding) {
+    return new Subgraph(exposedBinding);
+  }
+}
+

--- a/extensions/grapher/src/com/google/inject/grapher/EdgeCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/EdgeCreator.java
@@ -27,5 +27,5 @@ import com.google.inject.Binding;
 public interface EdgeCreator {
 
   /** Returns edges for the given dependency graph. */
-  Iterable<Edge> getEdges(Iterable<Binding<?>> bindings);
+  Iterable<Edge> getEdges(String subname, Iterable<Binding<?>> bindings);
 }

--- a/extensions/grapher/src/com/google/inject/grapher/InjectorGrapher.java
+++ b/extensions/grapher/src/com/google/inject/grapher/InjectorGrapher.java
@@ -16,10 +16,12 @@
 
 package com.google.inject.grapher;
 
+import com.google.inject.Binding;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -38,4 +40,5 @@ public interface InjectorGrapher {
    * their transitive dependencies.
    */
   void graph(Injector injector, Set<Key<?>> root) throws IOException;
+  // List <Binding> getPrivates();
 }

--- a/extensions/grapher/src/com/google/inject/grapher/NodeCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/NodeCreator.java
@@ -26,5 +26,5 @@ import com.google.inject.Binding;
 public interface NodeCreator {
 
   /** Returns nodes for the given dependency graph. */
-  Iterable<Node> getNodes(Iterable<Binding<?>> bindings);
+  Iterable<Node> getNodes(String subname, Iterable<Binding<?>> bindings);
 }

--- a/extensions/grapher/src/com/google/inject/grapher/NodeId.java
+++ b/extensions/grapher/src/com/google/inject/grapher/NodeId.java
@@ -41,18 +41,20 @@ public final class NodeId {
 
   private final Key<?> key;
   private final NodeType nodeType;
+  private final String subname;
 
-  private NodeId(Key<?> key, NodeType nodeType) {
+  private NodeId(String subname, Key<?> key, NodeType nodeType) {
     this.key = key;
     this.nodeType = nodeType;
+    this.subname = subname;
   }
 
-  public static NodeId newTypeId(Key<?> key) {
-    return new NodeId(key, NodeType.TYPE);
+  public static NodeId newTypeId(String subname, Key<?> key) {
+    return new NodeId(subname, key, NodeType.TYPE);
   }
 
-  public static NodeId newInstanceId(Key<?> key) {
-    return new NodeId(key, NodeType.INSTANCE);
+  public static NodeId newInstanceId(String subname, Key<?> key) {
+    return new NodeId(subname, key, NodeType.INSTANCE);
   }
 
   public Key<?> getKey() {
@@ -68,10 +70,11 @@ public final class NodeId {
       return false;
     }
     NodeId other = (NodeId) obj;
-    return Objects.equal(key, other.key) && Objects.equal(nodeType, other.nodeType);
+    return Objects.equal(key, other.key) && Objects.equal(nodeType, other.nodeType)
+        && Objects.equal(subname, other.subname);
   }
 
   @Override public String toString() {
-    return "NodeId{nodeType=" + nodeType + " key=" + key + "}";
+    return "NodeId{nodeType=" + nodeType + " key=" + " subname=" + subname + key + "}";
   }
 }

--- a/extensions/grapher/src/com/google/inject/grapher/ProviderAliasCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/ProviderAliasCreator.java
@@ -34,8 +34,8 @@ final class ProviderAliasCreator implements AliasCreator {
     List<Alias> aliases = Lists.newArrayList();
     for (Binding<?> binding : bindings) {
       if (binding instanceof ProviderBinding) {
-        aliases.add(new Alias(NodeId.newTypeId(binding.getKey()),
-            NodeId.newTypeId(((ProviderBinding<?>) binding).getProvidedKey())));
+        aliases.add(new Alias(NodeId.newTypeId("", binding.getKey()),
+            NodeId.newTypeId("", ((ProviderBinding<?>) binding).getProvidedKey())));
       }
     }
     return aliases;

--- a/extensions/grapher/src/com/google/inject/grapher/Subgraph.java
+++ b/extensions/grapher/src/com/google/inject/grapher/Subgraph.java
@@ -1,0 +1,26 @@
+package com.google.inject.grapher;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.spi.ExposedBinding;
+
+/**
+ * Subgraph to represents a private module.
+ *
+ * @author houcheng@gmail.com (Houcheng Lin)
+ */
+public class Subgraph {
+  Injector   injector;
+  Key <?>    key;
+  String     name;
+  Set <Node> nodes = new HashSet <Node>();
+  Set <Edge> edges = new HashSet <Edge>();
+  Subgraph(ExposedBinding binding) {
+    injector = binding.getPrivateElements().getInjector();
+    key = binding.getKey();
+    name = binding.getKey().getTypeLiteral().toString();
+  }
+}

--- a/extensions/grapher/src/com/google/inject/grapher/SubgraphCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/SubgraphCreator.java
@@ -1,0 +1,13 @@
+package com.google.inject.grapher;
+
+import com.google.inject.Binding;
+
+/**
+ * Creator of subgraph.
+ *
+ * @author houcheng@gmail.com (Houcheng Lin)
+ */
+public interface SubgraphCreator {
+  /** Find subgraphs recursively for the given dependency graph. */
+  Iterable<Subgraph> getSubs(Iterable<Binding<?>> bindings);
+}

--- a/extensions/grapher/test/com/google/inject/grapher/AbstractInjectorGrapherTest.java
+++ b/extensions/grapher/test/com/google/inject/grapher/AbstractInjectorGrapherTest.java
@@ -102,21 +102,23 @@ public class AbstractInjectorGrapherTest extends TestCase {
   private Node iaAnnNode;
   private Node stringNode;
   private Node stringInstanceNode;
+  private String subname;
 
   private FakeGrapher grapher;
 
   @Override protected void setUp() throws Exception {
     super.setUp();
+    subname = "";
     grapher = new FakeGrapher();
     Node.ignoreSourceInComparisons = true;
-    aNode = new ImplementationNode(NodeId.newTypeId(Key.get(A.class)), null,
+    aNode = new ImplementationNode(NodeId.newTypeId(subname, Key.get(A.class)), null,
         ImmutableList.<Member>of(A.class.getConstructor(String.class)));
-    a2Node = new ImplementationNode(NodeId.newTypeId(Key.get(A2.class)), null,
+    a2Node = new ImplementationNode(NodeId.newTypeId(subname, Key.get(A2.class)), null,
         ImmutableList.<Member>of(A2.class.getConstructor(Provider.class)));
-    iaNode = new InterfaceNode(NodeId.newTypeId(Key.get(IA.class)), null);
-    iaAnnNode = new InterfaceNode(NodeId.newTypeId(Key.get(IA.class, Ann.class)), null);
-    stringNode = new InterfaceNode(NodeId.newTypeId(Key.get(String.class)), null);
-    stringInstanceNode = new InstanceNode(NodeId.newInstanceId(Key.get(String.class)), null,
+    iaNode = new InterfaceNode(NodeId.newTypeId(subname, Key.get(IA.class)), null);
+    iaAnnNode = new InterfaceNode(NodeId.newTypeId(subname, Key.get(IA.class, Ann.class)), null);
+    stringNode = new InterfaceNode(NodeId.newTypeId(subname, Key.get(String.class)), null);
+    stringInstanceNode = new InstanceNode(NodeId.newInstanceId(subname, Key.get(String.class)), null,
         TEST_STRING, ImmutableList.<Member>of());
   }
 
@@ -152,7 +154,7 @@ public class AbstractInjectorGrapherTest extends TestCase {
         }
     }));
 
-    Node a2ProviderNode = new InstanceNode(NodeId.newInstanceId(Key.get(IA.class)), null,
+    Node a2ProviderNode = new InstanceNode(NodeId.newInstanceId(subname, Key.get(IA.class)), null,
         wrapper.value, ImmutableList.<Member>of());
     Set<Node> expectedNodes =
         ImmutableSet.<Node>of(iaNode, stringNode, a2Node, stringInstanceNode, a2ProviderNode);


### PR DESCRIPTION
All elements in private module will be draw onto
the result DOT file. Note: the interface that used
in higher level and defined in lower level will be
shown twice in the generated graph.