### PR TITLE
Graph private houcheng

### DIFF
--- a/extensions/grapher/src/com/google/inject/grapher/AbstractInjectorGrapher.java
+++ b/extensions/grapher/src/com/google/inject/grapher/AbstractInjectorGrapher.java
@@ -192,6 +192,13 @@ public abstract class AbstractInjectorGrapher implements InjectorGrapher {
     return aliases.containsKey(nodeId) ? aliases.get(nodeId) : nodeId;
   }
 
+  /**
+   * Use a BFS alike approach to discovery all sub-graphs exposed by the
+   * ExposedBinding instances. For each sub-graph, create its nodes and edges
+   * by calling graphModule().
+   *
+   * @see graphModule
+   */
   private void createSubs() throws IOException {
     Set<Key<?>> visitedKeys = Sets.newHashSet();
     while (!foundSubgraphs.isEmpty()) {

--- a/extensions/grapher/src/com/google/inject/grapher/DefaultNodeCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/DefaultNodeCreator.java
@@ -51,7 +51,7 @@ final class DefaultNodeCreator implements NodeCreator {
    */
   private static final class NodeVisitor
       extends DefaultBindingTargetVisitor<Object, Collection<Node>> {
-    String subname;
+    final String subname;
     NodeVisitor(String subname) {
       this.subname = subname;
     }

--- a/extensions/grapher/src/com/google/inject/grapher/DefaultSubgraphCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/DefaultSubgraphCreator.java
@@ -1,0 +1,42 @@
+package com.google.inject.grapher;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.inject.Binding;
+import com.google.inject.spi.DefaultBindingTargetVisitor;
+import com.google.inject.spi.ExposedBinding;
+
+/**
+ * Default subgraph creator.
+ *
+ * @author houcheng@gmail.com (Houcheng Lin)
+ */
+public class DefaultSubgraphCreator implements SubgraphCreator {
+  @Override
+  public Iterable<Subgraph> getSubs(Iterable<Binding<?>> bindings) {
+    List<Subgraph> subs = Lists.newArrayList();
+    SubgraphVisitor visitor = new SubgraphVisitor();
+    for (Binding<?> binding : bindings) {
+      subs.addAll(binding.acceptTargetVisitor(visitor));
+    }
+    return subs;
+  }
+}
+
+class SubgraphVisitor extends 
+  DefaultBindingTargetVisitor<Object, Collection<Subgraph>> {
+  @Override
+  public Collection<Subgraph> visit(ExposedBinding<?> exposedBinding) {
+    return ImmutableList.<Subgraph>of(getSubgraph(exposedBinding));
+  }
+  @Override public Collection<Subgraph> visitOther(Binding<?> binding) {
+    return ImmutableList.of();
+  }  
+  private Subgraph getSubgraph(ExposedBinding<?> exposedBinding) {
+    return new Subgraph(exposedBinding);
+  }
+}
+

--- a/extensions/grapher/src/com/google/inject/grapher/DefaultSubgraphCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/DefaultSubgraphCreator.java
@@ -1,7 +1,20 @@
-package com.google.inject.grapher;
+/**
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import java.util.Collection;
-import java.util.List;
+package com.google.inject.grapher;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -9,14 +22,18 @@ import com.google.inject.Binding;
 import com.google.inject.spi.DefaultBindingTargetVisitor;
 import com.google.inject.spi.ExposedBinding;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
- * Default subgraph creator.
- *
+ * Default subgraph creator. This creator use a visitor to visit 
+ * every binding; for exposed binding, create a subgraph instance.
+ * 
  * @author houcheng@gmail.com (Houcheng Lin)
  */
-public class DefaultSubgraphCreator implements SubgraphCreator {
+final class DefaultSubgraphCreator implements SubgraphCreator {
   @Override
-  public Iterable<Subgraph> getSubs(Iterable<Binding<?>> bindings) {
+  public Iterable<Subgraph> getSubgraphs(Iterable<Binding<?>> bindings) {
     List<Subgraph> subs = Lists.newArrayList();
     SubgraphVisitor visitor = new SubgraphVisitor();
     for (Binding<?> binding : bindings) {
@@ -24,19 +41,23 @@ public class DefaultSubgraphCreator implements SubgraphCreator {
     }
     return subs;
   }
+
+  private static final class SubgraphVisitor extends 
+      DefaultBindingTargetVisitor<Object, Collection<Subgraph>> {
+
+    @Override
+    public Collection<Subgraph> visit(ExposedBinding<?> exposedBinding) {
+      return ImmutableList.<Subgraph>of(getSubgraph(exposedBinding));
+    }
+
+    @Override public Collection<Subgraph> visitOther(Binding<?> binding) {
+      return ImmutableList.of();
+    }  
+
+    private Subgraph getSubgraph(ExposedBinding<?> exposedBinding) {
+      return new Subgraph(exposedBinding);
+    }
+  }
 }
 
-class SubgraphVisitor extends 
-  DefaultBindingTargetVisitor<Object, Collection<Subgraph>> {
-  @Override
-  public Collection<Subgraph> visit(ExposedBinding<?> exposedBinding) {
-    return ImmutableList.<Subgraph>of(getSubgraph(exposedBinding));
-  }
-  @Override public Collection<Subgraph> visitOther(Binding<?> binding) {
-    return ImmutableList.of();
-  }  
-  private Subgraph getSubgraph(ExposedBinding<?> exposedBinding) {
-    return new Subgraph(exposedBinding);
-  }
-}
 

--- a/extensions/grapher/src/com/google/inject/grapher/DefaultSubgraphCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/DefaultSubgraphCreator.java
@@ -48,7 +48,7 @@ final class DefaultSubgraphCreator implements SubgraphCreator {
   /**
    * {@link BindingTargetVisitor} that adds subgraphs to the graph based on the visited {@link Binding}.
    */
-  private static final class SubgraphVisitor extends 
+  private static final class SubgraphVisitor extends
       DefaultBindingTargetVisitor<Object, Collection<Subgraph>> {
 
     /**
@@ -62,7 +62,7 @@ final class DefaultSubgraphCreator implements SubgraphCreator {
 
     @Override public Collection<Subgraph> visitOther(Binding<?> binding) {
       return ImmutableList.of();
-    }  
+    }
 
     /**
      * Returns a new sub-graph for the exposed binding.

--- a/extensions/grapher/src/com/google/inject/grapher/DefaultSubgraphCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/DefaultSubgraphCreator.java
@@ -19,6 +19,7 @@ package com.google.inject.grapher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.Binding;
+import com.google.inject.spi.ConstructorBinding;
 import com.google.inject.spi.DefaultBindingTargetVisitor;
 import com.google.inject.spi.ExposedBinding;
 
@@ -26,9 +27,11 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Default subgraph creator. This creator use a visitor to visit 
- * every binding; for exposed binding, create a subgraph instance.
- * 
+ * Default subgraph creator. This creator use a visitor to visit every
+ * binding, and for the exposed binding, create one subgraph instance.
+ * Later, the graph injector creates nodes and edges for each subgraph.
+ *
+ * @see AbstractInjectorGrapher
  * @author houcheng@gmail.com (Houcheng Lin)
  */
 final class DefaultSubgraphCreator implements SubgraphCreator {
@@ -42,9 +45,16 @@ final class DefaultSubgraphCreator implements SubgraphCreator {
     return subs;
   }
 
+  /**
+   * {@link BindingTargetVisitor} that adds subgraphs to the graph based on the visited {@link Binding}.
+   */
   private static final class SubgraphVisitor extends 
       DefaultBindingTargetVisitor<Object, Collection<Subgraph>> {
 
+    /**
+     * Visitor for {@link ExposedBinding}s. These are for classes that Guice will instantiate to
+     * satisfy injection requests.
+     */
     @Override
     public Collection<Subgraph> visit(ExposedBinding<?> exposedBinding) {
       return ImmutableList.<Subgraph>of(getSubgraph(exposedBinding));
@@ -54,10 +64,14 @@ final class DefaultSubgraphCreator implements SubgraphCreator {
       return ImmutableList.of();
     }  
 
+    /**
+     * Returns a new sub-graph for the exposed binding.
+     *
+     * @param exposed binding for the sub-graph to create
+     * @return sub-graph for the given binding
+     */
     private Subgraph getSubgraph(ExposedBinding<?> exposedBinding) {
       return new Subgraph(exposedBinding);
     }
   }
 }
-
-

--- a/extensions/grapher/src/com/google/inject/grapher/EdgeCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/EdgeCreator.java
@@ -27,5 +27,5 @@ import com.google.inject.Binding;
 public interface EdgeCreator {
 
   /** Returns edges for the given dependency graph. */
-  Iterable<Edge> getEdges(Iterable<Binding<?>> bindings);
+  Iterable<Edge> getEdges(String subname, Iterable<Binding<?>> bindings);
 }

--- a/extensions/grapher/src/com/google/inject/grapher/InjectorGrapher.java
+++ b/extensions/grapher/src/com/google/inject/grapher/InjectorGrapher.java
@@ -16,10 +16,12 @@
 
 package com.google.inject.grapher;
 
+import com.google.inject.Binding;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -38,4 +40,5 @@ public interface InjectorGrapher {
    * their transitive dependencies.
    */
   void graph(Injector injector, Set<Key<?>> root) throws IOException;
+  // List <Binding> getPrivates();
 }

--- a/extensions/grapher/src/com/google/inject/grapher/InjectorGrapher.java
+++ b/extensions/grapher/src/com/google/inject/grapher/InjectorGrapher.java
@@ -16,12 +16,9 @@
 
 package com.google.inject.grapher;
 
-import com.google.inject.Binding;
 import com.google.inject.Injector;
 import com.google.inject.Key;
-
 import java.io.IOException;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -40,5 +37,5 @@ public interface InjectorGrapher {
    * their transitive dependencies.
    */
   void graph(Injector injector, Set<Key<?>> root) throws IOException;
-  // List <Binding> getPrivates();
+
 }

--- a/extensions/grapher/src/com/google/inject/grapher/NodeCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/NodeCreator.java
@@ -26,5 +26,5 @@ import com.google.inject.Binding;
 public interface NodeCreator {
 
   /** Returns nodes for the given dependency graph. */
-  Iterable<Node> getNodes(Iterable<Binding<?>> bindings);
+  Iterable<Node> getNodes(String subname, Iterable<Binding<?>> bindings);
 }

--- a/extensions/grapher/src/com/google/inject/grapher/NodeId.java
+++ b/extensions/grapher/src/com/google/inject/grapher/NodeId.java
@@ -41,18 +41,20 @@ public final class NodeId {
 
   private final Key<?> key;
   private final NodeType nodeType;
+  private final String subname;
 
-  private NodeId(Key<?> key, NodeType nodeType) {
+  private NodeId(String subname, Key<?> key, NodeType nodeType) {
     this.key = key;
     this.nodeType = nodeType;
+    this.subname = subname;
   }
 
-  public static NodeId newTypeId(Key<?> key) {
-    return new NodeId(key, NodeType.TYPE);
+  public static NodeId newTypeId(String subname, Key<?> key) {
+    return new NodeId(subname, key, NodeType.TYPE);
   }
 
-  public static NodeId newInstanceId(Key<?> key) {
-    return new NodeId(key, NodeType.INSTANCE);
+  public static NodeId newInstanceId(String subname, Key<?> key) {
+    return new NodeId(subname, key, NodeType.INSTANCE);
   }
 
   public Key<?> getKey() {
@@ -68,10 +70,11 @@ public final class NodeId {
       return false;
     }
     NodeId other = (NodeId) obj;
-    return Objects.equal(key, other.key) && Objects.equal(nodeType, other.nodeType);
+    return Objects.equal(key, other.key) && Objects.equal(nodeType, other.nodeType)
+        && Objects.equal(subname, other.subname);
   }
 
   @Override public String toString() {
-    return "NodeId{nodeType=" + nodeType + " key=" + key + "}";
+    return "NodeId{nodeType=" + nodeType + " key=" + " subname=" + subname + key + "}";
   }
 }

--- a/extensions/grapher/src/com/google/inject/grapher/NodeId.java
+++ b/extensions/grapher/src/com/google/inject/grapher/NodeId.java
@@ -75,6 +75,6 @@ public final class NodeId {
   }
 
   @Override public String toString() {
-    return "NodeId{nodeType=" + nodeType + " key=" + " subname=" + subname + key + "}";
+    return "NodeId{nodeType=" + nodeType + " key=" + key + " subname=" + subname + "}";
   }
 }

--- a/extensions/grapher/src/com/google/inject/grapher/NodeId.java
+++ b/extensions/grapher/src/com/google/inject/grapher/NodeId.java
@@ -61,6 +61,10 @@ public final class NodeId {
     return key;
   }
 
+  public String getSubname() {
+    return subname;
+  }
+
   @Override public int hashCode() {
     return Objects.hashCode(key, nodeType);
   }

--- a/extensions/grapher/src/com/google/inject/grapher/ProviderAliasCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/ProviderAliasCreator.java
@@ -34,8 +34,8 @@ final class ProviderAliasCreator implements AliasCreator {
     List<Alias> aliases = Lists.newArrayList();
     for (Binding<?> binding : bindings) {
       if (binding instanceof ProviderBinding) {
-        aliases.add(new Alias(NodeId.newTypeId(binding.getKey()),
-            NodeId.newTypeId(((ProviderBinding<?>) binding).getProvidedKey())));
+        aliases.add(new Alias(NodeId.newTypeId("", binding.getKey()),
+            NodeId.newTypeId("", ((ProviderBinding<?>) binding).getProvidedKey())));
       }
     }
     return aliases;

--- a/extensions/grapher/src/com/google/inject/grapher/Subgraph.java
+++ b/extensions/grapher/src/com/google/inject/grapher/Subgraph.java
@@ -1,0 +1,26 @@
+package com.google.inject.grapher;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.spi.ExposedBinding;
+
+/**
+ * Subgraph to represents a private module.
+ *
+ * @author houcheng@gmail.com (Houcheng Lin)
+ */
+public class Subgraph {
+  Injector   injector;
+  Key <?>    key;
+  String     name;
+  Set <Node> nodes = new HashSet <Node>();
+  Set <Edge> edges = new HashSet <Edge>();
+  Subgraph(ExposedBinding binding) {
+    injector = binding.getPrivateElements().getInjector();
+    key = binding.getKey();
+    name = binding.getKey().getTypeLiteral().toString();
+  }
+}

--- a/extensions/grapher/src/com/google/inject/grapher/Subgraph.java
+++ b/extensions/grapher/src/com/google/inject/grapher/Subgraph.java
@@ -1,26 +1,63 @@
-package com.google.inject.grapher;
+/**
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import java.util.HashSet;
-import java.util.Set;
+package com.google.inject.grapher;
 
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.spi.ExposedBinding;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Subgraph to represents a private module.
  *
  * @author houcheng@gmail.com (Houcheng Lin)
  */
-public class Subgraph {
-  Injector   injector;
-  Key <?>    key;
-  String     name;
-  Set <Node> nodes = new HashSet <Node>();
-  Set <Edge> edges = new HashSet <Edge>();
-  Subgraph(ExposedBinding binding) {
+final class Subgraph {
+  private final Injector   injector;
+  private final Key<?>    key;
+  private final String     name;
+  private final Set<Node> nodes = new HashSet<Node>();
+  private final Set<Edge> edges = new HashSet<Edge>();
+
+  Subgraph(ExposedBinding<?> binding) {
     injector = binding.getPrivateElements().getInjector();
     key = binding.getKey();
     name = binding.getKey().getTypeLiteral().toString();
+  }
+
+  Injector getInjector() {
+    return injector;
+  }
+
+  Key<?> getKey() {
+    return key;
+  }
+
+  String getName() {
+    return name;
+  }
+
+  Set<Node> getNodes() {
+    return nodes;
+  }
+
+  Set<Edge> getEdges() {
+    return edges;
   }
 }

--- a/extensions/grapher/src/com/google/inject/grapher/SubgraphCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/SubgraphCreator.java
@@ -1,0 +1,13 @@
+package com.google.inject.grapher;
+
+import com.google.inject.Binding;
+
+/**
+ * Creator of subgraph.
+ *
+ * @author houcheng@gmail.com (Houcheng Lin)
+ */
+public interface SubgraphCreator {
+  /** Find subgraphs recursively for the given dependency graph. */
+  Iterable<Subgraph> getSubs(Iterable<Binding<?>> bindings);
+}

--- a/extensions/grapher/src/com/google/inject/grapher/SubgraphCreator.java
+++ b/extensions/grapher/src/com/google/inject/grapher/SubgraphCreator.java
@@ -9,5 +9,5 @@ import com.google.inject.Binding;
  */
 public interface SubgraphCreator {
   /** Find subgraphs recursively for the given dependency graph. */
-  Iterable<Subgraph> getSubs(Iterable<Binding<?>> bindings);
+  Iterable<Subgraph> getSubgraphs(Iterable<Binding<?>> bindings);
 }

--- a/extensions/grapher/test/com/google/inject/grapher/AbstractInjectorGrapherTest.java
+++ b/extensions/grapher/test/com/google/inject/grapher/AbstractInjectorGrapherTest.java
@@ -109,7 +109,7 @@ public class AbstractInjectorGrapherTest extends TestCase {
   private Node a3Node;
   private Node bNode;
   private Node ibNode;
-  private Node ibNode2;  
+  private Node ibNode2;
   private Node iaNode;
   private Node iaAnnNode;
   private Node stringNode;
@@ -189,7 +189,7 @@ public class AbstractInjectorGrapherTest extends TestCase {
   }
 
   /**
-   * Test ExposedBinding and the constructed two IBs in both subgraph:"" 
+   * Test ExposedBinding and the constructed two IBs in both subgraph:""
    * and subgraph:"com.google.inject.grapher.AbstractInjectorGrapherTest$IB".
    */
   public void testExposeBindings() throws Exception {
@@ -207,7 +207,7 @@ public class AbstractInjectorGrapherTest extends TestCase {
         }
     }));
 
-    Set<Node> expectedNodes = ImmutableSet.<Node>of(iaNode, a3Node, 
+    Set<Node> expectedNodes = ImmutableSet.<Node>of(iaNode, a3Node,
         bNode, ibNode, ibNode2);
     Set<Edge> expectedEdges = ImmutableSet.<Edge>of(
         new BindingEdge(iaNode.getId(), a3Node.getId(), BindingEdge.Type.NORMAL),

--- a/extensions/grapher/test/com/google/inject/grapher/AbstractInjectorGrapherTest.java
+++ b/extensions/grapher/test/com/google/inject/grapher/AbstractInjectorGrapherTest.java
@@ -102,21 +102,23 @@ public class AbstractInjectorGrapherTest extends TestCase {
   private Node iaAnnNode;
   private Node stringNode;
   private Node stringInstanceNode;
+  private String subname;
 
   private FakeGrapher grapher;
 
   @Override protected void setUp() throws Exception {
     super.setUp();
+    subname = "";
     grapher = new FakeGrapher();
     Node.ignoreSourceInComparisons = true;
-    aNode = new ImplementationNode(NodeId.newTypeId(Key.get(A.class)), null,
+    aNode = new ImplementationNode(NodeId.newTypeId(subname, Key.get(A.class)), null,
         ImmutableList.<Member>of(A.class.getConstructor(String.class)));
-    a2Node = new ImplementationNode(NodeId.newTypeId(Key.get(A2.class)), null,
+    a2Node = new ImplementationNode(NodeId.newTypeId(subname, Key.get(A2.class)), null,
         ImmutableList.<Member>of(A2.class.getConstructor(Provider.class)));
-    iaNode = new InterfaceNode(NodeId.newTypeId(Key.get(IA.class)), null);
-    iaAnnNode = new InterfaceNode(NodeId.newTypeId(Key.get(IA.class, Ann.class)), null);
-    stringNode = new InterfaceNode(NodeId.newTypeId(Key.get(String.class)), null);
-    stringInstanceNode = new InstanceNode(NodeId.newInstanceId(Key.get(String.class)), null,
+    iaNode = new InterfaceNode(NodeId.newTypeId(subname, Key.get(IA.class)), null);
+    iaAnnNode = new InterfaceNode(NodeId.newTypeId(subname, Key.get(IA.class, Ann.class)), null);
+    stringNode = new InterfaceNode(NodeId.newTypeId(subname, Key.get(String.class)), null);
+    stringInstanceNode = new InstanceNode(NodeId.newInstanceId(subname, Key.get(String.class)), null,
         TEST_STRING, ImmutableList.<Member>of());
   }
 
@@ -152,7 +154,7 @@ public class AbstractInjectorGrapherTest extends TestCase {
         }
     }));
 
-    Node a2ProviderNode = new InstanceNode(NodeId.newInstanceId(Key.get(IA.class)), null,
+    Node a2ProviderNode = new InstanceNode(NodeId.newInstanceId(subname, Key.get(IA.class)), null,
         wrapper.value, ImmutableList.<Member>of());
     Set<Node> expectedNodes =
         ImmutableSet.<Node>of(iaNode, stringNode, a2Node, stringInstanceNode, a2ProviderNode);


### PR DESCRIPTION
Add support to private module in graph extension.
- All elements in private module will be draw onto the result DOT file.
- Fix error in test.
- Note, the interface that used in higher level and defined in lower level
  will be shown twice in the generated graph.
