### PR TITLE
Improve performance of internal DependencyStack collection

### DIFF
--- a/core/src/com/google/inject/internal/InternalContext.java
+++ b/core/src/com/google/inject/internal/InternalContext.java
@@ -23,7 +23,7 @@ import com.google.inject.Key;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.DependencyAndSource;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -68,8 +68,7 @@ final class InternalContext {
   public Dependency<?> pushDependency(Dependency<?> dependency, Object source) {
     Dependency<?> previous = this.dependency;
     this.dependency = dependency;
-    state.add(dependency);
-    state.add(source);
+    state.add(dependency, source);
     return previous;
   }
   
@@ -81,8 +80,7 @@ final class InternalContext {
   
   /** Adds to the state without setting the dependency. */
   public void pushState(Key<?> key, Object source) {
-    state.add(key);
-    state.add(source);
+    state.add(key, source);
   }
   
   /** Pops from the state without setting a dependency. */
@@ -106,10 +104,29 @@ final class InternalContext {
     return builder.build();
   }
 
-  private static final class DependencyStack extends ArrayList<Object> {
-    void pop() {
-      int sz = size();
-      removeRange(sz - 2, sz);
+  private static final class DependencyStack {
+    private Object[] elements = new Object[10];
+    private int size = 0;
+
+    public void add(Object dependencyOrKey, Object source) {
+      if (elements.length < size + 2) {
+        elements = Arrays.copyOf(elements, (elements.length*3)/2 + 2);
+      }
+      elements[size++] = dependencyOrKey;
+      elements[size++] = source;
+    }
+
+    public void pop() {
+      elements[--size] = null;
+      elements[--size] = null;
+    }
+
+    public Object get(int i) {
+      return elements[i];
+    }
+
+    public int size() {
+      return size;
     }
   }
 }

--- a/core/src/com/google/inject/internal/InternalContext.java
+++ b/core/src/com/google/inject/internal/InternalContext.java
@@ -40,13 +40,7 @@ final class InternalContext {
   /** Keeps track of the type that is currently being requested for injection. */
   private Dependency<?> dependency;
 
-  /**
-   * Keeps track of the hierarchy of types needed during injection.
-   *
-   * <p>This is a pairwise combination of dependencies and sources, with dependencies or keys on
-   * even indices, and sources on odd indices. This structure is to avoid the memory overhead of
-   * DependencyAndSource objects, which can add to several tens of megabytes in large applications.
-   */
+  /** Keeps track of the hierarchy of types needed during injection. */
   private final DependencyStack state = new DependencyStack();
 
   @SuppressWarnings("unchecked")
@@ -104,6 +98,13 @@ final class InternalContext {
     return builder.build();
   }
 
+  /**
+   * Keeps track of the hierarchy of types needed during injection.
+   *
+   * <p>This is a pairwise combination of dependencies and sources, with dependencies or keys on
+   * even indices, and sources on odd indices. This structure is to avoid the memory overhead of
+   * DependencyAndSource objects, which can add to several tens of megabytes in large applications.
+   */
   private static final class DependencyStack {
     private Object[] elements = new Object[10];
     private int size = 0;

--- a/core/src/com/google/inject/internal/InternalContext.java
+++ b/core/src/com/google/inject/internal/InternalContext.java
@@ -106,7 +106,7 @@ final class InternalContext {
    * DependencyAndSource objects, which can add to several tens of megabytes in large applications.
    */
   private static final class DependencyStack {
-    private Object[] elements = new Object[10];
+    private Object[] elements = new Object[16];
     private int size = 0;
 
     public void add(Object dependencyOrKey, Object source) {


### PR DESCRIPTION
Recent changes to the internal dependency stack in InternalContext reduced memory consumption at the cost of overall performance (see cadabc1aa1cbe30c48a7b730c2907c82abff6336). The changes in 9be698db4a8fa560cfae23795d629b018ad009cf helped, but it's still not as good as the original implementation. One reason might be that `ArrayList.removeRange` will always trigger a call to `System.arrayCopy`, even when you're only removing a range at the end of the list.

Since the internal API needed from `DependencyStack` is minimal, I tried re-implementing it as a thin wrapper around an array. The following implementation is faster than the original (at least on my local machine) while still retaining the memory improvements.

WDYT?  Note this is a bare-bones implementation, extra checks can be added as necessary.
