### PR TITLE
Added option to configure PersistFilter to assume on initialization that persistence service is already started

### DIFF
--- a/extensions/persist/src/com/google/inject/persist/PersistFilter.java
+++ b/extensions/persist/src/com/google/inject/persist/PersistFilter.java
@@ -76,7 +76,10 @@ public final class PersistFilter implements Filter {
   }
 
   public void init(FilterConfig filterConfig) throws ServletException {
-    persistService.start();
+    if (filterConfig.getInitParameter("startPersistanceServiceManually") == null
+        || Boolean.parseBoolean(filterConfig.getInitParameter("startPersistanceServiceManually")) == false) {
+      persistService.start();
+    }
   }
 
   public void destroy() {


### PR DESCRIPTION
Added option to configure PersistFilter not to start persistence service on initialization. Such option is needed because filter is initialized at certain stage of servlet container lifecycle, and connection to the database might be needed before this stage, so it is logical to have an option to start the persistence service manually.