### PR TITLE
Added option to configure PersistFilter to assume persistence service is initialized

### DIFF
--- a/extensions/persist/src/com/google/inject/persist/PersistFilter.java
+++ b/extensions/persist/src/com/google/inject/persist/PersistFilter.java
@@ -76,7 +76,10 @@ public final class PersistFilter implements Filter {
   }
 
   public void init(FilterConfig filterConfig) throws ServletException {
-    persistService.start();
+    if (filterConfig.getInitParameter("startPersistanceServiceManually") == null
+        || Boolean.parseBoolean(filterConfig.getInitParameter("startPersistanceServiceManually")) == false) {
+      persistService.start();
+    }
   }
 
   public void destroy() {

--- a/extensions/persist/test/com/google/inject/persist/AllTests.java
+++ b/extensions/persist/test/com/google/inject/persist/AllTests.java
@@ -27,6 +27,7 @@ import com.google.inject.persist.jpa.ManagedLocalTransactionsAcrossRequestTest;
 import com.google.inject.persist.jpa.ManagedLocalTransactionsTest;
 import com.google.inject.persist.jpa.ManualLocalTransactionsTest;
 import com.google.inject.persist.jpa.ManualLocalTransactionsWithCustomMatcherTest;
+import com.google.inject.persist.jpa.PersistFilterManualServiceStartTest;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -51,6 +52,7 @@ public class AllTests {
     suite.addTestSuite(ManagedLocalTransactionsTest.class);
     suite.addTestSuite(ManualLocalTransactionsTest.class);
     suite.addTestSuite(ManualLocalTransactionsWithCustomMatcherTest.class);
+    suite.addTestSuite(PersistFilterManualServiceStartTest.class);
 
     return suite;
   }

--- a/extensions/persist/test/com/google/inject/persist/jpa/PersistFilterManualServiceStartTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/PersistFilterManualServiceStartTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2010 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.inject.persist.jpa;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+
+import junit.framework.TestCase;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.persist.PersistFilter;
+import com.google.inject.persist.UnitOfWork;
+
+
+public class PersistFilterManualServiceStartTest extends TestCase {
+    private Injector injector;
+
+    
+    private FilterConfig filterConfig;
+    private PersistFilter persistFilter;
+    private JpaPersistService sut;
+
+    @Override
+    public void setUp() {
+        
+        injector = Guice.createInjector(new JpaPersistModule("testUnit"));
+        sut = injector.getInstance(JpaPersistService.class);
+        persistFilter = new PersistFilter(injector.getInstance(UnitOfWork.class), sut);
+        filterConfig = mock(FilterConfig.class);
+        //persistFilter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+    }
+
+    @Override
+    public final void tearDown() {
+    }
+
+    public void testFilterConfigurationWithManualServiceStartPositive() throws ServletException, IOException {
+        when(filterConfig.getInitParameter("startPersistanceServiceManually")).thenReturn("true");
+        sut.start();
+        persistFilter.init(filterConfig);
+        assertPersistServiceStateAndStartIt(true);
+        persistFilter.doFilter(null, null, mock(FilterChain.class));
+        persistFilter.destroy();
+    }
+    
+    public void testFilterConfigurationWithManualServiceStartNegative() throws ServletException, IOException {
+        when(filterConfig.getInitParameter("startPersistanceServiceManually")).thenReturn("true");
+        persistFilter.init(filterConfig);
+        assertPersistServiceStateAndStartIt(false);
+        persistFilter.doFilter(null, null, mock(FilterChain.class));
+        // Not calling persist filter destroy method, because persistence service is not supposed to be initialized
+    }
+
+    public void testFilterConfigurationWithAutomaticServiceStartPositive() throws ServletException, IOException {
+        persistFilter.init(filterConfig);
+        assertPersistServiceStateAndStartIt(true);
+        persistFilter.doFilter(null, null, mock(FilterChain.class));
+        persistFilter.destroy();
+    }
+    
+    private void assertPersistServiceStateAndStartIt(boolean isStarted) {
+        try {
+            sut.start();
+            assertTrue(!isStarted);
+        } catch (IllegalStateException e) {
+            assertTrue(isStarted);
+        }
+    }
+        
+}


### PR DESCRIPTION
Added option to configure PersistFilter not to start persistence service on initialization. Such option is needed because filter is initialized at certain stage of servlet container lifecycle, and connection to the database might be needed before this stage, so it is logical to have an option to start the persistence service manually.