### PR TITLE
Merge internal changes

### DIFF
--- a/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java
+++ b/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java
@@ -1480,11 +1480,11 @@ public class CheckedProviderTest extends TestCase {
               .providing(ProvisionExceptionFoo.class);
           bindScope(BadScope.class, new Scope() {
             @Override
-            public <T> Provider<T> scope(Key<T> key, Provider<T> unscoped) {
+            public <T> Provider<T> scope(final Key<T> key, Provider<T> unscoped) {
               return new Provider<T>() {
                 @Override
                 public T get() {
-                  throw new OutOfScopeException("failure");
+                  throw new OutOfScopeException("failure: " + key.toString());
                 }
               };
             }
@@ -1498,10 +1498,10 @@ public class CheckedProviderTest extends TestCase {
     } catch(ProvisionException pe) {
       assertEquals(2, pe.getErrorMessages().size());
       List<Message> messages = Lists.newArrayList(pe.getErrorMessages());
-      assertEquals("Error in custom provider, com.google.inject.OutOfScopeException: failure",
-          messages.get(0).getMessage());
-      assertEquals("Error in custom provider, com.google.inject.OutOfScopeException: failure",
-          messages.get(1).getMessage());
+      assertEquals("Error in custom provider, com.google.inject.OutOfScopeException: failure: "
+          + Key.get(Unscoped1.class), messages.get(0).getMessage());
+      assertEquals("Error in custom provider, com.google.inject.OutOfScopeException: failure: "
+          + Key.get(Unscoped2.class), messages.get(1).getMessage());
     }
   }
   


### PR DESCRIPTION
Reduce the amount of stack trace spam in error message.  If all the errors have
the same cause, don't list them individually and instead use as the Throwable's
cause.  If some (but not all) errors are duplicates, elide the duplicate stack
traces and point to the error # it's the same as.

"same" here is defined as the same exception class, same stack trace, and same causes (with causes using the same 'same' definition).
-------------
Created by MOE: http://code.google.com/p/moe-java
MOE_MIGRATED_REVID=92389485