### PR TITLE
Make Message.hashCode Consistent with Message.equals

### DIFF
--- a/core/src/com/google/inject/spi/Message.java
+++ b/core/src/com/google/inject/spi/Message.java
@@ -16,6 +16,8 @@
 
 package com.google.inject.spi;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
@@ -25,8 +27,6 @@ import com.google.inject.internal.util.SourceProvider;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * An error message and the context in which it occured. Messages are usually created internally by

--- a/core/src/com/google/inject/spi/Message.java
+++ b/core/src/com/google/inject/spi/Message.java
@@ -16,8 +16,6 @@
 
 package com.google.inject.spi;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
@@ -27,6 +25,8 @@ import com.google.inject.internal.util.SourceProvider;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * An error message and the context in which it occured. Messages are usually created internally by
@@ -108,7 +108,7 @@ public final class Message implements Serializable, Element {
   }
 
   @Override public int hashCode() {
-    return message.hashCode();
+    return Objects.hashCode(message, cause, sources);
   }
 
   @Override public boolean equals(Object o) {

--- a/core/test/com/google/inject/AllTests.java
+++ b/core/test/com/google/inject/AllTests.java
@@ -31,6 +31,7 @@ import com.google.inject.spi.ElementsTest;
 import com.google.inject.spi.HasDependenciesTest;
 import com.google.inject.spi.InjectionPointTest;
 import com.google.inject.spi.InjectorSpiTest;
+import com.google.inject.spi.MessageTest;
 import com.google.inject.spi.ModuleAnnotatedMethodScannerTest;
 import com.google.inject.spi.ModuleRewriterTest;
 import com.google.inject.spi.ModuleSourceTest;
@@ -134,6 +135,7 @@ public class AllTests {
     suite.addTestSuite(ToolStageInjectorTest.class);
     suite.addTestSuite(ModuleSourceTest.class);
     suite.addTestSuite(ElementSourceTest.class);
+    suite.addTestSuite(MessageTest.class);
 
     // tools
     // suite.addTestSuite(JmxTest.class); not a testcase

--- a/core/test/com/google/inject/spi/MessageTest.java
+++ b/core/test/com/google/inject/spi/MessageTest.java
@@ -1,0 +1,29 @@
+package com.google.inject.spi;
+
+import com.google.common.collect.Lists;
+import junit.framework.TestCase;
+
+import java.util.List;
+
+/**
+ * Tests for {@link Message}.
+ */
+public class MessageTest extends TestCase {
+
+  public void testMessageHashCodeVariesWithSource() {
+    String innerMessage = "This is the message.";
+    Message firstMessage = new Message(1, innerMessage);
+    Message secondMessage = new Message(2, innerMessage);
+    assertFalse(firstMessage.hashCode() == secondMessage.hashCode());
+  }
+
+  public void testMessageHashCodeVariesWithCause() {
+    String innerMessage = "This is the message.";
+    List<Object> sourceList = Lists.newArrayList(new Object());
+    // the throwable argument of each Message below do not have value equality
+    Message firstMessage = new Message(sourceList, innerMessage, new Exception(innerMessage));
+    Message secondMessage = new Message(sourceList, innerMessage, new Exception(innerMessage));
+    assertFalse(firstMessage.hashCode() == secondMessage.hashCode());
+  }
+}
+


### PR DESCRIPTION
Fixes https://github.com/google/guice/issues/940

This commit makes `Message.hashCode` and `Message.equals` computed off of the same fields.