### PR TITLE
assistedinject: Skip static methods on interfaces.

### DIFF
--- a/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
+++ b/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
@@ -226,6 +226,11 @@ final class FactoryProvider2 <F> implements InvocationHandler,
       ImmutableMap.Builder<Method, AssistData> assistDataBuilder = ImmutableMap.builder();
       // TODO: also grab methods from superinterfaces
       for (Method method : factoryRawType.getMethods()) {
+        // Skip static methods
+        if (Modifier.isStatic(method.getModifiers())) {
+          continue;
+        }
+
         // Skip default methods that java8 may have created.
         if (isDefault(method) && (method.isBridge() || method.isSynthetic())) {
           // Even synthetic default methods need the return type validation...

--- a/jdk8-tests/pom.xml
+++ b/jdk8-tests/pom.xml
@@ -35,6 +35,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-assistedinject</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
       <scope>test</scope>

--- a/jdk8-tests/test/com/google/inject/jdk8/StaticInterfaceMethodsTest.java
+++ b/jdk8-tests/test/com/google/inject/jdk8/StaticInterfaceMethodsTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.inject.jdk8;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+
+import junit.framework.TestCase;
+
+/**
+ * Test static methods in interfaces.
+ *
+ * @author tavianator@tavianator.com (Tavian Barnes)
+ */
+public class StaticInterfaceMethodsTest extends TestCase {
+
+  private static class Thing {
+    final int i;
+
+    @Inject
+    Thing(@Assisted int i) {
+      this.i = i;
+    }
+  }
+
+  private interface Factory {
+    Thing create(int i);
+
+    static Factory getDefault() {
+      return Thing::new;
+    }
+  }
+
+  public void testAssistedInjection() {
+    Injector injector = Guice.createInjector(new AbstractModule() {
+      @Override
+      protected void configure() {
+        install(new FactoryModuleBuilder().build(Factory.class));
+      }
+    });
+    Factory factory = injector.getInstance(Factory.class);
+    assertEquals(1, factory.create(1).i);
+  }
+
+}


### PR DESCRIPTION
This fixes https://github.com/google/guice/issues/937.