### PR TITLE
#788 jpa: Object-methods like finalize become transactional, if the Type is annotated Transactional

### DIFF
--- a/extensions/persist/src/com/google/inject/persist/jpa/JpaPersistModule.java
+++ b/extensions/persist/src/com/google/inject/persist/jpa/JpaPersistModule.java
@@ -70,7 +70,7 @@ public final class JpaPersistModule extends PersistModule {
     bind(EntityManagerFactory.class)
         .toProvider(JpaPersistService.EntityManagerFactoryProvider.class);
 
-    transactionInterceptor = new JpaLocalTxnInterceptor();
+    transactionInterceptor = new JpaLocalTxnInterceptor(false);
     requestInjection(transactionInterceptor);
 
     // Bind dynamic finders.

--- a/extensions/persist/test/com/google/inject/persist/jpa/util/TrackedEntityManagerFactory.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/util/TrackedEntityManagerFactory.java
@@ -1,0 +1,79 @@
+package com.google.inject.persist.jpa.util;
+
+import java.util.Map;
+
+import javax.persistence.Cache;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnitUtil;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.metamodel.Metamodel;
+
+/**
+ * Proxy EntityManager that adds tracking capabilities, keeping a count of
+ * created objects.
+ */
+public class TrackedEntityManagerFactory implements EntityManagerFactory {
+  
+  private EntityManagerFactory originalEMF;
+  private int entityManagerCreatedCount = 0;
+
+  public TrackedEntityManagerFactory(EntityManagerFactory originalEMF) {
+    this.originalEMF = originalEMF;
+  }
+  
+  public boolean hasCreatedSomeEntityManager() {
+    return (entityManagerCreatedCount > 0);
+  }
+  
+  public int getEntityManagerCreatedCount() {
+    return entityManagerCreatedCount;
+  }
+
+  @Override
+  public boolean isOpen() {
+    return originalEMF.isOpen();
+  }
+  
+  @Override
+  public Map<String, Object> getProperties() {
+    return originalEMF.getProperties();
+  }
+  
+  @Override
+  public PersistenceUnitUtil getPersistenceUnitUtil() {
+    return originalEMF.getPersistenceUnitUtil();
+  }
+  
+  @Override
+  public Metamodel getMetamodel() {
+    return originalEMF.getMetamodel();
+  }
+  
+  @Override
+  public CriteriaBuilder getCriteriaBuilder() {
+    return originalEMF.getCriteriaBuilder();
+  }
+  
+  @Override
+  public Cache getCache() {
+    return originalEMF.getCache();
+  }
+  
+  @Override
+  public EntityManager createEntityManager(Map arg0) {
+    entityManagerCreatedCount++;
+    return originalEMF.createEntityManager(arg0);
+  }
+  
+  @Override
+  public EntityManager createEntityManager() {
+    entityManagerCreatedCount++;
+    return originalEMF.createEntityManager();
+  }
+  
+  @Override
+  public void close() {
+    originalEMF.close();
+  }
+}


### PR DESCRIPTION
I had the problem described in the issue too. The thing is that when a class is annotated as Transactional, the methods of its superclasses shouldn't be considered transactional. The most serious problem comes with Object methods, and especially finalize. I've fixed that, checking that the method class has the annotation, instead of the class of the called object.

I've also created a "lenient" mode, so that if anyone was using the interceptor in some strange way with no real Transactional annotational attached, it keeps working. But the normal behaviour configured in the module is to be not lenient (strict).
