### PR TITLE
Make disableCircularProxies() disable all forms of circular dependencies.

### DIFF
--- a/core/src/com/google/inject/Binder.java
+++ b/core/src/com/google/inject/Binder.java
@@ -472,16 +472,15 @@ public interface Binder {
   void requireExplicitBindings();
   
   /**
-   * Prevents Guice from constructing a {@link Proxy} when a circular dependency
-   * is found.  By default, circular proxies are not disabled.
+   * Prevents Guice from injecting dependencies that form a cycle, unless broken by a
+   * {@link Provider}. By default, circular dependencies are not disabled.
    * <p>
-   * If a parent injector disables circular proxies, then all child injectors
-   * (and private modules within that injector) also disable circular proxies.
-   * If a parent does not disable circular proxies, a child injector or private
-   * module may optionally declare itself as disabling circular proxies. If it
-   * does, the behavior is limited only to that child or any grandchildren. No
-   * siblings of the child will disable circular proxies.
-   * 
+   * If a parent injector disables circular dependencies, then all child injectors (and private
+   * modules within that injector) also disable circular dependencies. If a parent does not disable
+   * circular dependencies, a child injector or private module may optionally declare itself as
+   * disabling circular dependencies. If it does, the behavior is limited only to that child or any
+   * grandchildren. No siblings of the child will disable circular dependencies.
+   *
    * @since 3.0
    */
   void disableCircularProxies();

--- a/core/src/com/google/inject/internal/ConstructionContext.java
+++ b/core/src/com/google/inject/internal/ConstructionContext.java
@@ -62,10 +62,10 @@ final class ConstructionContext<T> {
   public Object createProxy(Errors errors, InjectorOptions injectorOptions,
       Class<?> expectedType) throws ErrorsException {
     if (injectorOptions.disableCircularProxies) {
-      throw errors.circularProxiesDisabled(expectedType).toException();
+      throw errors.circularDependenciesDisabled(expectedType).toException();
     }
     if (!expectedType.isInterface()) {
-      throw errors.cannotSatisfyCircularDependency(expectedType).toException();
+      throw errors.cannotProxyClass(expectedType).toException();
     }
 
     if (invocationHandlers == null) {

--- a/core/src/com/google/inject/internal/ConstructorInjector.java
+++ b/core/src/com/google/inject/internal/ConstructorInjector.java
@@ -17,6 +17,7 @@
 package com.google.inject.internal;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.internal.InjectorImpl.InjectorOptions;
 import com.google.inject.internal.ProvisionListenerStackCallback.ProvisionCallback;
 import com.google.inject.spi.InjectionPoint;
 
@@ -63,19 +64,23 @@ final class ConstructorInjector<T> {
       ProvisionListenerStackCallback<T> provisionCallback)
       throws ErrorsException {
     final ConstructionContext<T> constructionContext = context.getConstructionContext(this);
+    InjectorOptions options = context.getInjectorOptions();
 
     // We have a circular reference between constructors. Return a proxy.
     if (constructionContext.isConstructing()) {
       // TODO (crazybob): if we can't proxy this object, can we proxy the other object?
-      return constructionContext.createProxy(
-          errors, context.getInjectorOptions(), expectedType);
+      return constructionContext.createProxy(errors, options, expectedType);
     }
 
     // If we're re-entering this factory while injecting fields or methods,
     // return the same instance. This prevents infinite loops.
     T t = constructionContext.getCurrentReference();
     if (t != null) {
-      return t;
+      if (options.disableCircularProxies) {
+        throw errors.circularDependenciesDisabled(expectedType).toException();
+      } else {
+        return t;
+      }
     }
 
     constructionContext.startConstruction();
@@ -85,6 +90,7 @@ final class ConstructorInjector<T> {
         return provision(errors, context, constructionContext);
       } else {
         return provisionCallback.provision(errors, context, new ProvisionCallback<T>() {
+          @Override
           public T call() throws ErrorsException {
             return provision(errors, context, constructionContext);
           }

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -450,15 +450,15 @@ public final class Errors implements Serializable {
     return addMessage("Cannot inject a TypeLiteral that has no type parameter");
   }
 
-  public Errors cannotSatisfyCircularDependency(Class<?> expectedType) {
+  public Errors cannotProxyClass(Class<?> expectedType) {
     return addMessage(
         "Tried proxying %s to support a circular dependency, but it is not an interface.",
         expectedType);
   }
 
-  public Errors circularProxiesDisabled(Class<?> expectedType) {
+  public Errors circularDependenciesDisabled(Class<?> expectedType) {
     return addMessage(
-        "Tried proxying %s to support a circular dependency, but circular proxies are disabled.",
+        "Found a circular dependency involving %s, and circular dependencies are disabled.",
         expectedType);
   }
 

--- a/core/test/com/google/inject/CircularDependencyTest.java
+++ b/core/test/com/google/inject/CircularDependencyTest.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * @author sameb@google.com (Sam Berlin)
  */
 public class CircularDependencyTest extends TestCase {
-  
+
   @Override
   protected void setUp() throws Exception {
     AImpl.nextId = 0;
@@ -46,6 +46,7 @@ public class CircularDependencyTest extends TestCase {
   public void testCircularlyDependentConstructors()
       throws CreationException {
     Injector injector = Guice.createInjector(new AbstractModule() {
+      @Override
       protected void configure() {
         bind(A.class).to(AImpl.class);
         bind(B.class).to(BImpl.class);
@@ -53,30 +54,34 @@ public class CircularDependencyTest extends TestCase {
     });
     assertCircularDependencies(injector);
   }
-  
+
   public void testCircularlyDependentConstructorsWithProviderMethods()
       throws CreationException {
     Injector injector = Guice.createInjector(new AbstractModule() {
+      @Override
       protected void configure() {}
-      
+
       @Provides @Singleton A a(B b) { return new AImpl(b); }
       @Provides B b(A a) { return new BImpl(a); }
     });
     assertCircularDependencies(injector);
   }
-  
+
   public void testCircularlyDependentConstructorsWithProviderInstances()
       throws CreationException {
     Injector injector = Guice.createInjector(new AbstractModule() {
+      @Override
       protected void configure() {
         bind(A.class).toProvider(new Provider<A>() {
           @Inject Provider<B> bp;
+          @Override
           public A get() {
             return new AImpl(bp.get());
           }
         }).in(Singleton.class);
         bind(B.class).toProvider(new Provider<B>() {
           @Inject Provider<A> ap;
+          @Override
           public B get() {
             return new BImpl(ap.get());
           }
@@ -85,10 +90,11 @@ public class CircularDependencyTest extends TestCase {
     });
     assertCircularDependencies(injector);
   }
-  
+
   public void testCircularlyDependentConstructorsWithProviderKeys()
       throws CreationException {
     Injector injector = Guice.createInjector(new AbstractModule() {
+      @Override
       protected void configure() {
         bind(A.class).toProvider(AP.class).in(Singleton.class);
         bind(B.class).toProvider(BP.class);
@@ -96,13 +102,13 @@ public class CircularDependencyTest extends TestCase {
     });
     assertCircularDependencies(injector);
   }
-  
+
   public void testCircularlyDependentConstructorsWithProvidedBy()
       throws CreationException {
     Injector injector = Guice.createInjector();
     assertCircularDependencies(injector);
   }
-  
+
   private void assertCircularDependencies(Injector injector) {
     A a = injector.getInstance(A.class);
     assertNotNull(a.getB().getA());
@@ -124,31 +130,35 @@ public class CircularDependencyTest extends TestCase {
   static class AImpl implements A {
     static int nextId;
     int id = nextId++;
-    
+
     final B b;
     @Inject public AImpl(B b) {
       this.b = b;
     }
+    @Override
     public int id() {
       return id;
     }
+    @Override
     public B getB() {
       return b;
     }
   }
-  
+
   static class AP implements Provider<A> {
     @Inject Provider<B> bp;
+    @Override
     public A get() {
       return new AImpl(bp.get());
     }
   }
-  
+
   @Singleton
   static class AutoAP implements Provider<A> {
     @Inject Provider<B> bp;
     A a;
-    
+
+    @Override
     public A get() {
       if (a == null) {
         a = new AImpl(bp.get());
@@ -166,24 +176,27 @@ public class CircularDependencyTest extends TestCase {
   static class BImpl implements B {
     static int nextId;
     int id = nextId++;
-    
+
     final A a;
     @Inject public BImpl(A a) {
       this.a = a;
     }
+    @Override
     public int id() {
       return id;
     }
+    @Override
     public A getA() {
       return a;
     }
   }
-  
+
   static class BP implements Provider<B> {
     Provider<A> ap;
     @Inject BP(Provider<A> ap) {
       this.ap = ap;
     }
+    @Override
     public B get() {
       return new BImpl(ap.get());
     }
@@ -199,11 +212,11 @@ public class CircularDependencyTest extends TestCase {
           "but it is not an interface.");
     }
   }
-  
+
   public void testUnresolvableCircularDependenciesWithProviderInstances() {
     try {
       Guice.createInjector(new AbstractModule() {
-        @Override protected void configure() {}        
+        @Override protected void configure() {}
         @Provides C c(D d) { return null; }
         @Provides D d(C c) { return null; }
       }).getInstance(C.class);
@@ -214,7 +227,7 @@ public class CircularDependencyTest extends TestCase {
           "but it is not an interface.");
     }
   }
-  
+
   public void testUnresolvableCircularDependenciesWithProviderKeys() {
     try {
       Guice.createInjector(new AbstractModule() {
@@ -230,7 +243,7 @@ public class CircularDependencyTest extends TestCase {
           "but it is not an interface.");
     }
   }
-  
+
   public void testUnresolvableCircularDependenciesWithProvidedBy() {
     try {
       Guice.createInjector().getInstance(C2.class);
@@ -248,9 +261,10 @@ public class CircularDependencyTest extends TestCase {
   static class D {
     @Inject D(C c) {}
   }
-  
+
   static class C2P implements Provider<C2> {
     @Inject Provider<D2> dp;
+    @Override
     public C2 get() {
       dp.get();
       return null;
@@ -258,6 +272,7 @@ public class CircularDependencyTest extends TestCase {
   }
   static class D2P implements Provider<D2> {
     @Inject Provider<C2> cp;
+    @Override
     public D2 get() {
       cp.get();
       return null;
@@ -271,7 +286,7 @@ public class CircularDependencyTest extends TestCase {
   static class D2 {
     @Inject D2(C2 c) {}
   }
-  
+
   public void testDisabledCircularDependency() {
     try {
       Guice.createInjector(new AbstractModule() {
@@ -283,28 +298,26 @@ public class CircularDependencyTest extends TestCase {
       fail();
     } catch (ProvisionException expected) {
       assertContains(expected.getMessage(),
-          "Tried proxying " + C.class.getName() + " to support a circular dependency, ",
-          "but circular proxies are disabled.");
+          "Found a circular dependency involving " + C.class.getName() + ", and circular dependencies are disabled.");
     }
   }
-  
+
   public void testDisabledCircularDependenciesWithProviderInstances() {
     try {
       Guice.createInjector(new AbstractModule() {
         @Override protected void configure() {
           binder().disableCircularProxies();
-        }        
+        }
         @Provides C c(D d) { return null; }
         @Provides D d(C c) { return null; }
       }).getInstance(C.class);
       fail();
     } catch (ProvisionException expected) {
       assertContains(expected.getMessage(),
-          "Tried proxying " + C.class.getName() + " to support a circular dependency, ",
-          "but circular proxies are disabled.");
+          "Found a circular dependency involving " + C.class.getName() + ", and circular dependencies are disabled.");
     }
   }
-  
+
   public void testDisabledCircularDependenciesWithProviderKeys() {
     try {
       Guice.createInjector(new AbstractModule() {
@@ -317,11 +330,10 @@ public class CircularDependencyTest extends TestCase {
       fail();
     } catch (ProvisionException expected) {
       assertContains(expected.getMessage(),
-          "Tried proxying " + C2.class.getName() + " to support a circular dependency, ",
-          "but circular proxies are disabled.");
+          "Found a circular dependency involving " + C2.class.getName() + ", and circular dependencies are disabled.");
     }
   }
-  
+
   public void testDisabledCircularDependenciesWithProvidedBy() {
     try {
       Guice.createInjector(new AbstractModule() {
@@ -333,8 +345,7 @@ public class CircularDependencyTest extends TestCase {
       fail();
     } catch (ProvisionException expected) {
       assertContains(expected.getMessage(),
-          "Tried proxying " + C2.class.getName() + " to support a circular dependency, ",
-          "but circular proxies are disabled.");
+          "Found a circular dependency involving " + C2.class.getName() + ", and circular dependencies are disabled.");
     }
   }
 
@@ -344,6 +355,7 @@ public class CircularDependencyTest extends TestCase {
    */
   public void testCircularlyDependentMultipleWays() {
     Injector injector = Guice.createInjector(new AbstractModule() {
+      @Override
       protected void configure() {
         binder.bind(A.class).to(E.class);
         binder.bind(B.class).to(E.class);
@@ -351,23 +363,24 @@ public class CircularDependencyTest extends TestCase {
     });
     injector.getInstance(A.class);
   }
-  
-  public void testDisablingCircularProxies() {
+
+  public void testDisablingCircularDependencies() {
     Injector injector = Guice.createInjector(new AbstractModule() {
+      @Override
       protected void configure() {
         binder().disableCircularProxies();
         binder.bind(A.class).to(E.class);
         binder.bind(B.class).to(E.class);
       }
     });
-    
+
     try {
       injector.getInstance(A.class);
       fail("expected exception");
     } catch(ProvisionException expected) {
       assertContains(expected.getMessage(),
-          "Tried proxying " + A.class.getName() + " to support a circular dependency, but circular proxies are disabled", 
-          "Tried proxying " + B.class.getName() + " to support a circular dependency, but circular proxies are disabled");
+          "Found a circular dependency involving " + A.class.getName() + ", and circular dependencies are disabled.",
+          "Found a circular dependency involving " + B.class.getName() + ", and circular dependencies are disabled.");
     }
   }
 
@@ -376,14 +389,17 @@ public class CircularDependencyTest extends TestCase {
     @Inject
     public E(A a, B b) {}
 
+    @Override
     public B getB() {
       return this;
     }
 
+    @Override
     public A getA() {
       return this;
     }
-    
+
+    @Override
     public int id() {
       return 0;
     }
@@ -392,6 +408,7 @@ public class CircularDependencyTest extends TestCase {
 
   public void testCircularDependencyProxyDelegateNeverInitialized() {
     Injector injector = Guice.createInjector(new AbstractModule() {
+      @Override
       protected void configure() {
         bind(F.class).to(RealF.class);
         bind(G.class).to(RealG.class);
@@ -414,6 +431,7 @@ public class CircularDependencyTest extends TestCase {
       this.g = g;
     }
 
+    @Override
     public G g() {
       return g;
     }
@@ -434,6 +452,7 @@ public class CircularDependencyTest extends TestCase {
       this.f = f;
     }
 
+    @Override
     public F f() {
       return f;
     }
@@ -442,7 +461,7 @@ public class CircularDependencyTest extends TestCase {
       return "G";
     }
   }
-  
+
   /**
    * Tests that ProviderInternalFactory can detect circular dependencies
    * before it gets to Scopes.SINGLETON.  This is especially important
@@ -455,11 +474,11 @@ public class CircularDependencyTest extends TestCase {
       protected void configure() {
         bind(Number.class).to(Integer.class);
       }
-      
-      @Provides @Singleton Integer provideInteger(List list) { 
+
+      @Provides @Singleton Integer provideInteger(List list) {
         return new Integer(2);
       }
-      
+
       @Provides List provideList(Integer integer) {
         return new ArrayList();
       }
@@ -470,10 +489,10 @@ public class CircularDependencyTest extends TestCase {
     } catch(ProvisionException expected) {
       assertContains(expected.getMessage(),
           "Tried proxying " + Integer.class.getName() + " to support a circular dependency, ",
-          "but it is not an interface.");      
+          "but it is not an interface.");
     }
   }
-  
+
   public void testPrivateModulesDontTriggerCircularErrorsInProviders() {
     Injector injector = Guice.createInjector(new AbstractModule() {
       @Override
@@ -509,7 +528,7 @@ public class CircularDependencyTest extends TestCase {
   static class Bar {
     @Inject String string;
   }
-  
+
   /**
    * When Scope Providers call their unscoped Provider's get() methods are
    * called, it's possible that the result is a circular proxy designed for one
@@ -517,7 +536,7 @@ public class CircularDependencyTest extends TestCase {
    * typically cache the results without checking to see if the result is a
    * proxy. This leads to caching a result that is unsuitable for reuse for
    * other parameters.
-   * 
+   *
    * This means that custom proxies have to do an
    *   {@code if(Scopes.isCircularProxy(..))}
    * in order to avoid exceptions.
@@ -532,7 +551,7 @@ public class CircularDependencyTest extends TestCase {
         bind(J.class).to(JImpl.class);
       }
     });
-    
+
     // The reason this happens is because the Scope gets these requests, in order:
     // entry: Key<IImpl> (1 - from getInstance call)
     // entry: Key<HImpl>
@@ -540,13 +559,13 @@ public class CircularDependencyTest extends TestCase {
     // result of 2nd Key<IImpl> - a com.google.inject.$Proxy, because it's a circular proxy
     // result of Key<HImpl> - an HImpl
     // entry: Key<JImpl>
-    // entry: Key<IImpl> (3 - another circular dependency, this time from JImpl)    
+    // entry: Key<IImpl> (3 - another circular dependency, this time from JImpl)
     // At this point, if the first Key<Impl> result was cached, our cache would have
     //  Key<IImpl> caching to an instanceof of I, but not an an instanceof of IImpl.
     // If returned this, it would result in cglib giving a ClassCastException or
     // java reflection giving an IllegalArgumentException when filling in parameters
     // for the constructor, because JImpl wants an IImpl, not an I.
-    
+
     try {
       injector.getInstance(IImpl.class);
       fail();
@@ -556,13 +575,13 @@ public class CircularDependencyTest extends TestCase {
           + " to support a circular dependency, but it is not an interface.");
     }
   }
-  
+
   interface H {}
   interface I {}
   interface J {}
   @SimpleSingleton
   static class HImpl implements H {
-     @Inject HImpl(I i) {}     
+     @Inject HImpl(I i) {}
   }
   @SimpleSingleton
   static class IImpl implements I {
@@ -572,15 +591,17 @@ public class CircularDependencyTest extends TestCase {
   static class JImpl implements J {
      @Inject JImpl(IImpl i) {}
   }
-  
+
   @Target({ ElementType.TYPE, ElementType.METHOD })
   @Retention(RUNTIME)
   @ScopeAnnotation
   public @interface SimpleSingleton {}
   public static class BasicSingleton implements Scope {
-    private static Map<Key, Object> cache = Maps.newHashMap();
+    private static Map<Key<?>, Object> cache = Maps.newHashMap();
+    @Override
     public <T> Provider<T> scope(final Key<T> key, final Provider<T> unscoped) {
       return new Provider<T>() {
+        @Override
         @SuppressWarnings("unchecked")
         public T get() {
           if (!cache.containsKey(key)) {
@@ -593,6 +614,39 @@ public class CircularDependencyTest extends TestCase {
           return (T)cache.get(key);
         }
       };
+    }
+  }
+
+  public void testDisabledNonConstructorCircularDependencies() {
+    Injector injector = Guice.createInjector(new AbstractModule() {
+      @Override
+      protected void configure() {
+        binder().disableCircularProxies();
+      }
+    });
+
+    try {
+      injector.getInstance(K.class);
+      fail("expected exception");
+    } catch(ProvisionException expected) {
+      assertContains(expected.getMessage(),
+          "Found a circular dependency involving " + K.class.getName() + ", and circular dependencies are disabled.");
+    }
+
+    try {
+      injector.getInstance(L.class);
+      fail("expected exception");
+    } catch(ProvisionException expected) {
+      assertContains(expected.getMessage(),
+          "Found a circular dependency involving " + L.class.getName() + ", and circular dependencies are disabled.");
+    }
+  }
+
+  static class K {
+    @Inject L l;
+  }
+  static class L {
+    @Inject void inject(K k) {
     }
   }
 }


### PR DESCRIPTION
This addresses https://github.com/google/guice/issues/970.  It's an incomplete fix: there's no pre-validation of the graph to check for cycles -- all the checking happens during previsioning.  But I wanted to post it early to get feedback on the approach (and to get Travis to run it).  I'll add the early validation in a later ~~commit~~ pull request.