### PR TITLE
Enable Travis container infra & cache maven deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: java
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.m2
 
 jdk:
   - oraclejdk8
@@ -21,11 +26,6 @@ install:
 
 script:
   - ${CMD}
-
-notifications:
-  email:
-    recipients:
-      - google-guice-dev+ci@googlegroups.com
 
 after_success:
   - util/generate-latest-docs.sh


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/1441 for caching maven deps, https://docs.travis-ci.com/user/workers/container-based-infrastructure for container infra.

Also delete the notifications stanza since google-guice-dev@ doesn't exist anymore.