### PR TITLE
ignore everything in extensions' build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin/
 .idea/
 *.iml
 *.ipr
+extensions/**/build/


### PR DESCRIPTION
When running the 'ant' build a bunch of files get created within the extensions' build directories.

These are now being ignored.