### PR TITLE
Fix Checkstyle violation: forbidding making public Logger

### DIFF
--- a/core/src/com/google/inject/internal/BytecodeGen.java
+++ b/core/src/com/google/inject/internal/BytecodeGen.java
@@ -63,7 +63,7 @@ import java.util.logging.Logger;
  */
 public final class BytecodeGen {
 
-  static final Logger logger = Logger.getLogger(BytecodeGen.class.getName());
+  private static final Logger logger = Logger.getLogger(BytecodeGen.class.getName());
 
   static final ClassLoader GUICE_CLASS_LOADER = canonicalize(BytecodeGen.class.getClassLoader());
 

--- a/core/test/com/google/inject/LoggerInjectionTest.java
+++ b/core/test/com/google/inject/LoggerInjectionTest.java
@@ -15,7 +15,7 @@ import java.util.logging.Logger;
  */
 public class LoggerInjectionTest extends TestCase {
 
-  @Inject Logger logger;
+  @Inject private Logger logger;
 
   public void testLoggerWithMember() {
     Injector injector = Guice.createInjector();
@@ -30,7 +30,7 @@ public class LoggerInjectionTest extends TestCase {
   }
   
   private static class Foo {
-    Logger logger;
+    private Logger logger;
     @SuppressWarnings("unused")
     @Inject Foo(Logger logger) {
       this.logger = logger;

--- a/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
+++ b/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
@@ -90,7 +90,7 @@ final class FactoryProvider2 <F> implements InvocationHandler,
   static final Annotation RETURN_ANNOTATION = UniqueAnnotations.create();
 
   // use the logger under a well-known name, not FactoryProvider2
-  static final Logger logger = Logger.getLogger(AssistedInject.class.getName());
+  private static final Logger logger = Logger.getLogger(AssistedInject.class.getName());
 
   /** if a factory method parameter isn't annotated, it gets this annotation. */
   static final Assisted DEFAULT_ANNOTATION = new Assisted() {


### PR DESCRIPTION
Return Logger out of the class is a very bad practice as it produce logs that are hard to investigate as logging class does not contains that code and search should be done in other classes or in hierarchy (if filed is public or accessible by other protected or package)
