### PR TITLE
Closing ObjectOutputStream before calling toByteArray on the underlying ByteArrayOutputStream

### DIFF
--- a/core/test/com/google/inject/Asserts.java
+++ b/core/test/com/google/inject/Asserts.java
@@ -146,7 +146,9 @@ public class Asserts {
   public static <E> E reserialize(E original) throws IOException {
     try {
       ByteArrayOutputStream out = new ByteArrayOutputStream();
-      new ObjectOutputStream(out).writeObject(original);
+      ObjectOutputStream objectoutputstream = new ObjectOutputStream(out);
+      objectoutputstream.writeObject(original);
+      objectoutputstream.flush();
       ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
       @SuppressWarnings("unchecked") // the reserialized type is assignable
       E reserialized = (E) new ObjectInputStream(in).readObject();


### PR DESCRIPTION
When an ObjectOutputStream instance wraps an underlying ByteArrayOutputStream instance,
it is recommended to flush or close the ObjectOutputStream before invoking the underlying instances's toByteArray(). Although in this case, this is not strictly necessary because the writeObject method is invoked right before toByteArray, and writeObject internally calls flush/drain.  However, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a flush method before calling toByteArray().