### PR TITLE
Use LinkedList to store Elements in InjectorShell

### DIFF
--- a/core/src/com/google/inject/internal/InjectorShell.java
+++ b/core/src/com/google/inject/internal/InjectorShell.java
@@ -68,7 +68,7 @@ final class InjectorShell {
   }
 
   static class Builder {
-    private final List<Element> elements = Lists.newArrayList();
+    private final List<Element> elements = Lists.newLinkedList();
     private final List<Module> modules = Lists.newArrayList();
 
     /** lazily constructed */


### PR DESCRIPTION
Elements in the list are processed by various AbstractProcessor objects, and get removed when processing is all done.
Removing elements from an array list takes O(n) time, while it is O(1) for linked list. This can become bottleneck
for injector creation.
