### PR TITLE
Make Gerrit work on IBM's WLP

### DIFF
--- a/extensions/servlet/src/com/google/inject/servlet/ServletDefinition.java
+++ b/extensions/servlet/src/com/google/inject/servlet/ServletDefinition.java
@@ -265,14 +265,16 @@ class ServletDefinition implements ProviderWithExtensionVisitor<ServletDefinitio
           private String computePath() {
             if (!isPathComputed()) {
               String servletPath = super.getServletPath();
+              if(servletPath.isEmpty()) {
+                servletPath = super.getRequestURI().substring(getContextPath().length());
+              }
               path = patternMatcher.extractPath(servletPath);
               pathComputed = true;
 
               if (null == path) {
-                path = servletPath;
+                  path = servletPath;
               }
             }
-
             return path;
           }
         };

--- a/extensions/servlet/test/com/google/inject/servlet/ServletDefinitionPathsTest.java
+++ b/extensions/servlet/test/com/google/inject/servlet/ServletDefinitionPathsTest.java
@@ -91,6 +91,12 @@ public class ServletDefinitionPathsTest extends TestCase {
 
     expect(request.getServletPath()).andReturn(requestPath);
 
+    // computePath()
+    if(requestPath.isEmpty()) {
+        expect(request.getRequestURI()).andReturn(requestPath);
+        expect(request.getContextPath()).andReturn("");
+    }
+
     replay(injector, binding, request);
 
     ServletDefinition servletDefinition =
@@ -194,6 +200,13 @@ public class ServletDefinitionPathsTest extends TestCase {
 
     expect(request.getServletPath()).andReturn(servletPath).anyTimes();
 
+    // computePath()
+    if(servletPath.isEmpty()) {
+        expect(request.getRequestURI()).andReturn(requestUri);
+        expect(request.getContextPath())
+        .andReturn(contextPath);
+    }
+
     expect(request.getContextPath()).andReturn(contextPath);
 
     expect(request.getAttribute(REQUEST_DISPATCHER_REQUEST)).andReturn(null);
@@ -217,41 +230,39 @@ public class ServletDefinitionPathsTest extends TestCase {
 
   // Data-driven test.
   public final void testPathInfoWithRegexMatching() throws IOException, ServletException {
+
     // first a mapping of /*
-    pathInfoWithRegexMatching("/path/index.html", "/path", "/(.)*", "/index.html", "");
-    pathInfoWithRegexMatching(
-        "/path//hulaboo///index.html", "/path", "/(.)*", "/hulaboo/index.html", "");
-    pathInfoWithRegexMatching("/path/", "/path", "/(.)*", "/", "");
-    pathInfoWithRegexMatching("/path////////", "/path", "/(.)*", "/", "");
+    pathInfoWithRegexMatching("/path/index.html", "/path", "(/).*", "/index.html", "");
+    pathInfoWithRegexMatching("/path//hulaboo///index.html", "/path", "(/).*",
+        "/hulaboo/index.html", "");
+    pathInfoWithRegexMatching("/path/", "/path", "(/).*", "/", "");
+    pathInfoWithRegexMatching("/path////////", "/path", "(/).*", "/", "");
 
     // a servlet mapping of /thing/*
     pathInfoWithRegexMatching("/path/thing////////", "/path", "/thing/(.)*", "/", "/thing");
-    pathInfoWithRegexMatching("/path/thing/stuff", "/path", "/thing/(.)*", "/stuff", "/thing");
-    pathInfoWithRegexMatching(
-        "/path/thing/stuff.html", "/path", "/thing/(.)*", "/stuff.html", "/thing");
-    pathInfoWithRegexMatching("/path/thing", "/path", "/thing/(.)*", null, "/thing");
+    pathInfoWithRegexMatching("/path/thing/stuff", "/path", "/thing(/).*", "/stuff", "/thing");
+    pathInfoWithRegexMatching("/path/thing/stuff.html", "/path", "/thing(/).*", "/stuff.html",
+        "/thing");
+    pathInfoWithRegexMatching("/path/thing", "/path", "/thing(/).*", null, "/thing");
 
     // *.xx style mapping
-    pathInfoWithRegexMatching("/path/thing.thing", "/path", ".*\\.thing", null, "/thing.thing");
-    pathInfoWithRegexMatching("/path///h.thing", "/path", ".*\\.thing", null, "/h.thing");
-    pathInfoWithRegexMatching("/path///...//h.thing", "/path", ".*\\.thing", null, "/.../h.thing");
-    pathInfoWithRegexMatching("/path/my/h.thing", "/path", ".*\\.thing", null, "/my/h.thing");
+    //FIXME: what sense make the regex here anyway?
+    pathInfoWithRegexMatching("/path/thing.thing", "/path", "", null, "/thing.thing");
+    pathInfoWithRegexMatching("/path///h.thing", "/path", "", null, "/h.thing");
+    pathInfoWithRegexMatching("/path///...//h.thing", "/path", "", null,
+        "/.../h.thing");
+    pathInfoWithRegexMatching("/path/my/h.thing", "/path", "", null, "/my/h.thing");
 
     // path
-    pathInfoWithRegexMatching(
-        "/path/test.com/com.test.MyServletModule",
-        "",
-        "/path/[^/]+/(.*)",
-        "com.test.MyServletModule",
-        "/path/test.com/com.test.MyServletModule");
+    pathInfoWithRegexMatching("/path/test.com/com.test.MyServletModule", "", "/path/[^/]+/(.*)",
+        "com.test.MyServletModule", "/path/test.com/com.test.MyServletModule");
+    pathInfoWithRegexMatching("/path/test.com/com.test.MyServletModule", "/path", "/[^/]+/(.*)",
+            "com.test.MyServletModule", "/test.com/com.test.MyServletModule");
 
     // Encoded URLs
-    pathInfoWithRegexMatching("/path/index%2B.html", "/path", "/(.)*", "/index+.html", "");
-    pathInfoWithRegexMatching(
-        "/path/a%20file%20with%20spaces%20in%20name.html",
-        "/path", "/(.)*", "/a file with spaces in name.html", "");
-    pathInfoWithRegexMatching(
-        "/path/Tam%C3%A1s%20nem%20m%C3%A1s.html", "/path", "/(.)*", "/Tamás nem más.html", "");
+    pathInfoWithRegexMatching("/path/index%2B.html", "/path", "(/).*", "/index+.html", "");
+    pathInfoWithRegexMatching("/path/a%20file%20with%20spaces%20in%20name.html", "/path", "(/).*", "/a file with spaces in name.html", "");
+    pathInfoWithRegexMatching("/path/Tam%C3%A1s%20nem%20m%C3%A1s.html", "/path", "(/).*", "/Tamás nem más.html", "");
   }
 
   public final void pathInfoWithRegexMatching(
@@ -305,7 +316,15 @@ public class ServletDefinitionPathsTest extends TestCase {
 
     expect(request.getServletPath()).andReturn(servletPath).anyTimes();
 
-    expect(request.getContextPath()).andReturn(contextPath);
+    // computePath()
+    if(servletPath.isEmpty()) {
+        expect(request.getRequestURI()).andReturn(requestUri);
+        expect(request.getContextPath())
+        .andReturn(contextPath);
+    }
+
+    expect(request.getContextPath())
+        .andReturn(contextPath);
 
     expect(request.getAttribute(REQUEST_DISPATCHER_REQUEST)).andReturn(null);
 


### PR DESCRIPTION
I think there is a bug in the method getPathInfo() which calls
getServletPath().
The problem is as we don't have any real JSR-340-Servlets in gerrit;
instead only one "real" filter is installed in the Servlet container.
So getServletPath() will always return an empty string according to the
documentation (
https://docs.oracle.com/javaee/7/api/javax/servlet/http/HttpServletRequest.html#getServletPath--
)
because everything will be matched against /*

But guice-servlet users like gerrit expect the getServletPath() to
return something different as this call is made in computePath():
path = patternMatcher.extractPath(servletPath);

This call makes only sense when not an empty string is returned.

This broken behavior makes it currently impossible to run gerrit on any
other Servlet container than Jetty 9.2. For the URI
"http://localhost:9080/gerrit/projects/?n=26&type=ALL&d" Jetty does
return
"/projects" when getServletPath() is called. Which actually violates the
Servlet spec, I think.

For the reference: The Gerrit guice-servlet bindings are created in
gerrit-httpd/src/main/java/com/google/gerrit/httpd/UrlModule.java
