### PR TITLE
Update plugin versions because of @threadSafe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
         -->
         <plugin>
           <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>1.1</version>
+          <version>1.5</version>
           <executions>
             <execution>
               <goals>
@@ -298,7 +298,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.5</version>
+          <version>2.19.1</version>
           <configuration>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <!--<argLine>-Dguice_include_stack_traces=OFF</argLine>-->
@@ -336,7 +336,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.1.0</version>
+          <version>2.5.4</version>
           <configuration>
             <instructions>
               <module>com.google.inject</module>
@@ -392,7 +392,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.7</version>
+          <version>2.10.4</version>
           <executions>
             <execution>
               <phase>package</phase>


### PR DESCRIPTION
The newer plugin versions support a @threadSafe build, e.g.:
mvn -T 1C package

The only non-threadsafe plugins left are:

[WARNING] The following goals are not marked @threadSafe in Google Guice - Core Library:
[WARNING] org.sonatype.plugins:jarjar-maven-plugin:1.9:jarjar
[WARNING] org.sonatype.plugins:munge-maven-plugin:1.0:munge-fork

But those seem to work correctly, maybe they are already threadsafe but
not explicilty marked as so...
