### PR TITLE
Set correct bundle version of fragment host.

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -103,7 +103,7 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Fragment-Host>com.google.inject</Fragment-Host>
+            <Fragment-Host>com.google.inject;bundle-version=${project.version}</Fragment-Host>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
- Fixes #1049
- Ensures that extensions are only applied to a specific version of com.google.inject
