### PR TITLE
Make requestInjection with an explicit type actually use the type

### DIFF
--- a/core/src/com/google/inject/AbstractModule.java
+++ b/core/src/com/google/inject/AbstractModule.java
@@ -122,6 +122,14 @@ public abstract class AbstractModule implements Module {
   }
 
   /**
+   * @see Binder#requestInjection(TypeLiteral, Object)
+   * @since 4.1
+   */
+  protected <T> void requestInjection(TypeLiteral<T> type, T instance) {
+    binder().requestInjection(type, instance);
+  }
+
+  /**
    * @see Binder#requestInjection(Object)
    * @since 2.0
    */

--- a/core/src/com/google/inject/internal/BindingProcessor.java
+++ b/core/src/com/google/inject/internal/BindingProcessor.java
@@ -101,7 +101,7 @@ final class BindingProcessor extends AbstractBindingProcessor {
             // the processor was constructed w/ it
             Initializable<T> ref =
                 initializer.requestInjection(
-                    injector, instance, (Binding<T>) binding, source, injectionPoints);
+                    injector, null, instance, (Binding<T>) binding, source, injectionPoints);
             ConstantFactory<? extends T> factory = new ConstantFactory<T>(ref);
             InternalFactory<? extends T> scopedFactory =
                 Scoping.scope(key, injector, factory, source, scoping);
@@ -124,7 +124,7 @@ final class BindingProcessor extends AbstractBindingProcessor {
             Set<InjectionPoint> injectionPoints = binding.getInjectionPoints();
             Initializable<? extends javax.inject.Provider<? extends T>> initializable =
                 initializer.<javax.inject.Provider<? extends T>>requestInjection(
-                    injector, provider, null, source, injectionPoints);
+                    injector, null, provider, null, source, injectionPoints);
             // always visited with Binding<T>
             @SuppressWarnings("unchecked")
             InternalFactory<T> factory =

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -443,6 +443,10 @@ public final class Errors implements Serializable {
     return addMessage("%s is an interface, but interfaces have no static injection points.", clazz);
   }
 
+  public Errors requestInjectionWithDifferentTypes(TypeLiteral<?> type1, TypeLiteral<?> type2) {
+    return addMessage("Requested injection for the same object with different types: %s and %s", type1, type2);
+  }
+
   public Errors cannotInjectFinalField(Field field) {
     return addMessage("Injected field %s cannot be final.", field);
   }

--- a/core/src/com/google/inject/internal/InjectionRequestProcessor.java
+++ b/core/src/com/google/inject/internal/InjectionRequestProcessor.java
@@ -59,9 +59,13 @@ final class InjectionRequestProcessor extends AbstractProcessor {
       injectionPoints = e.getPartialValue();
     }
 
-    initializer.requestInjection(
-        injector, request.getInstance(), null, request.getSource(), injectionPoints);
+    requestInjection(request, injectionPoints);
     return true;
+  }
+
+  private <T> void requestInjection(InjectionRequest<T> request, Set<InjectionPoint> injectionPoints) {
+    initializer.requestInjection(
+        injector, request.getType(), request.getInstance(), null, request.getSource(), injectionPoints);
   }
 
   void validate() {

--- a/core/src/com/google/inject/spi/InjectionRequest.java
+++ b/core/src/com/google/inject/spi/InjectionRequest.java
@@ -72,7 +72,7 @@ public final class InjectionRequest<T> implements Element {
    *     the valid injection points.
    */
   public Set<InjectionPoint> getInjectionPoints() throws ConfigurationException {
-    return InjectionPoint.forInstanceMethodsAndFields(instance.getClass());
+    return InjectionPoint.forInstanceMethodsAndFields(type);
   }
 
   @Override


### PR DESCRIPTION
Make `Binder#requestInjection(TypeLiteral, Object)` scan the given `TypeLiteral` for dependencies, instead of always scanning the instance. This is important if the type is generic, and has generic dependencies.