### PR TITLE
Fix error propagation in SingleMethodInjector

### DIFF
--- a/core/src/com/google/inject/internal/SingleMethodInjector.java
+++ b/core/src/com/google/inject/internal/SingleMethodInjector.java
@@ -93,7 +93,7 @@ final class SingleMethodInjector implements SingleMemberInjector {
       throw new AssertionError(e); // a security manager is blocking us, we're hosed
     } catch (InvocationTargetException userException) {
       Throwable cause = userException.getCause() != null ? userException.getCause() : userException;
-      errors.withSource(injectionPoint).errorInjectingMethod(cause);
+      errors.merge(errors.withSource(injectionPoint).errorInjectingMethod(cause));
     }
   }
 }


### PR DESCRIPTION
Under certain circumstances (when errors.withSource() returns a new Errors
instance), the caught user exception can be lost and not propagated. This is
because the message from the cause gets added into the new Errors instance,
which gets subsequently discarded without being merged into the Errors instance
that is being processed by the SingleMethodInjector.inject() method.