### PR TITLE
Do not fail on circular constructor/setter dependency #690

### DIFF
--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -603,7 +603,7 @@ public final class Errors implements Serializable {
 
   public Errors cannotProxyClass(Class<?> expectedType) {
     return addMessage(
-        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces. 2",
+        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces.",
         expectedType);
   }
 

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -603,7 +603,7 @@ public final class Errors implements Serializable {
 
   public Errors cannotProxyClass(Class<?> expectedType) {
     return addMessage(
-        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces.",
+        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces. 32222",
         expectedType);
   }
 

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -603,7 +603,7 @@ public final class Errors implements Serializable {
 
   public Errors cannotProxyClass(Class<?> expectedType) {
     return addMessage(
-        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces. 32222",
+        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces.",
         expectedType);
   }
 

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -603,7 +603,7 @@ public final class Errors implements Serializable {
 
   public Errors cannotProxyClass(Class<?> expectedType) {
     return addMessage(
-        "Tried proxying %s to support a circular dependency, but it is not an interface.",
+        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces.",
         expectedType);
   }
 

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -603,7 +603,7 @@ public final class Errors implements Serializable {
 
   public Errors cannotProxyClass(Class<?> expectedType) {
     return addMessage(
-        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces.",
+        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces.r",
         expectedType);
   }
 

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -603,7 +603,7 @@ public final class Errors implements Serializable {
 
   public Errors cannotProxyClass(Class<?> expectedType) {
     return addMessage(
-        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces.r",
+        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces.",
         expectedType);
   }
 

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -603,7 +603,7 @@ public final class Errors implements Serializable {
 
   public Errors cannotProxyClass(Class<?> expectedType) {
     return addMessage(
-        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces.",
+        "Tried proxying %s to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces. 2",
         expectedType);
   }
 


### PR DESCRIPTION
I got this message for another link too: #139.
First of all I think that the @Inject doesn't refer to concrete classes and yes, interfaces only.
I guess that the message have to improve to:

> Tried proxying projectGuiceTest.A to support a circular dependency, but it is not an interface. You have to break the circular dependency, or make the circular dependency refers to interfaces.

In this way I think that we clarify more the user who will make the best decision.