### PR TITLE
Fix for issue 278

### DIFF
--- a/extensions/struts2/src/com/google/inject/struts2/Struts2Factory.java
+++ b/extensions/struts2/src/com/google/inject/struts2/Struts2Factory.java
@@ -164,6 +164,10 @@ public class Struts2Factory extends ObjectFactory {
     ProvidedInterceptor providedInterceptor =
         new ProvidedInterceptor(interceptorConfig, interceptorRefParams, interceptorClass);
     interceptors.add(providedInterceptor);
+    if (strutsInjector != null) {
+      // injector is already built so we need to inject the interceptor
+      providedInterceptor.inject();
+    }
     return providedInterceptor;
   }
 


### PR DESCRIPTION
Recently there was a major vulnerability discovered with Struts2 (CVE-2017-5638) - without this patch we were unable to get our Guice integrated version of Struts upgraded. Voytek Jarnot  had already provided a patch here: 
https://github.com/google/guice/issues/278

It was never integrated in.  Creating this PR to facilitate the rollout.  The exception is as follows:

java.lang.NullPointerException
com.google.inject.struts2.GuiceObjectFactory$ProvidedInterceptor.intercept(GuiceObjectFactory.java:224)