### PR TITLE
Provide a way to create a copy of a Key with an annotation

### DIFF
--- a/core/src/com/google/inject/Key.java
+++ b/core/src/com/google/inject/Key.java
@@ -300,6 +300,24 @@ public class Key<T> {
     return new Key<T>(typeLiteral, annotationStrategy.withoutAttributes());
   }
 
+  /**
+   * Returns a new key of the same type with the specified annotation.
+   *
+   * @since 4.1
+   */
+  public Key<T> withAnnotation(Class<? extends Annotation> annotationType) {
+    return new Key<T>(typeLiteral, strategyFor(annotationType));
+  }
+
+  /**
+   * Returns a new key of the same type with the specified annotation.
+   *
+   * @since 4.1
+   */
+  public Key<T> withAnnotation(Annotation annotation) {
+    return new Key<T>(typeLiteral, strategyFor(annotation));
+  }
+
   interface AnnotationStrategy {
     Annotation getAnnotation();
 

--- a/core/test/com/google/inject/KeyTest.java
+++ b/core/test/com/google/inject/KeyTest.java
@@ -352,4 +352,11 @@ public class KeyTest extends TestCase {
   }
 
   static class Typed<T> {}
+
+  public void testWithAnnotation() {
+    Key<Object> k = Key.get(Object.class);
+    Key<Object> kf = k.withAnnotation(Foo.class);
+    assertNull(k.getAnnotationType());
+    assertEquals(Foo.class, kf.getAnnotationType());
+  }
 }


### PR DESCRIPTION
This allows you to easily specify an annotation/annotation type to an existing key.