### PR TITLE
Fix type mismatch in ProvisionListenerCallbackStore.remove

### DIFF
--- a/core/src/com/google/inject/internal/ProvisionListenerCallbackStore.java
+++ b/core/src/com/google/inject/internal/ProvisionListenerCallbackStore.java
@@ -86,7 +86,7 @@ final class ProvisionListenerCallbackStore {
    * <p>Returns true if the type was stored in the cache, false otherwise.
    */
   boolean remove(Binding<?> type) {
-    return cache.asMap().remove(type) != null;
+    return cache.asMap().remove(new KeyBinding(type.getKey(), type)) != null;
   }
 
   /**

--- a/core/test/com/google/inject/internal/ProvisionListenerCallbackStoreTest.java
+++ b/core/test/com/google/inject/internal/ProvisionListenerCallbackStoreTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.inject.internal;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.spi.ProvisionListenerBinding;
+import junit.framework.TestCase;
+
+import java.util.Collections;
+
+/** Tests for {@link com.google.inject.internal.ProvisionListenerCallbackStore}. */
+public class ProvisionListenerCallbackStoreTest extends TestCase {
+  private ProvisionListenerCallbackStore store;
+  private Injector injector;
+
+  @Override
+  protected void setUp() throws Exception {
+    store = new ProvisionListenerCallbackStore(Collections.<ProvisionListenerBinding>emptyList());
+    injector = Guice.createInjector(
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(TestObject1.class);
+          }
+        });
+  }
+
+  public void testRemoveFromEmpty() {
+    assertFalse(store.remove(injector.getBinding(TestObject1.class)));
+  }
+
+  public void testRemoveNonExisting() {
+    store.get(injector.getBinding(TestObject1.class));
+    assertFalse(store.remove(injector.getBinding(TestObject2.class)));
+  }
+
+  public void testRemoveExisting() {
+    store.get(injector.getBinding(TestObject1.class));
+    assertTrue(store.remove(injector.getBinding(TestObject1.class)));
+  }
+
+  private static class TestObject1 {};
+  private static class TestObject2 {};
+}


### PR DESCRIPTION
The type of the value returned from `cache.asMap()` is `Map<KeyBinding, ProvisionListenerStackCallback<?>`, however we were trying to remove a `Binding`. This would never work as the hashcode/equals for a `Binding` are different from a `KeyBinding`. I have no experience with this code but it seems all that is necessary is wrapping it as `new KeyBinding(type.getKey(), type)` so this is a very simple fix.

I added a test for this though maybe you consider this too trivial to test for in which case I can easily remove it from the PR, but the test does indeed fail before the change and pass afterwards so it seems useful.

This bug was found using [lgtm.com](https://lgtm.com/projects/g/google/guice/) where Guice is one of the many thousands of open source projects analysed. It turns out Guice has no other alerts which is very impressive, but there are many other projects that do.