### PR TITLE
Fix the outdated link to google's java style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ again.
   1. Finally, push the commits to your fork and submit a [pull request][].
 
 [forking]: https://help.github.com/articles/fork-a-repo
-[java style guide]: http://google-styleguide.googlecode.com/svn/trunk/javaguide.html
+[java style guide]: https://google.github.io/styleguide/javaguide.html
 [well-formed commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [pull request]: https://help.github.com/articles/creating-a-pull-request
 


### PR DESCRIPTION
Hi,

In `CONTRIBUTING.md`, the link of Google Java style guide is outdated (given a `404` error code).
The current Java style guide is at
https://google.github.io/styleguide/javaguide.html

(used by the `google/guava` project
https://github.com/google/guava/blob/master/CONTRIBUTING.md)

This PR is a simple update for the link.