### PR TITLE
accomodate manually initiated rollbacks

### DIFF
--- a/extensions/persist/src/com/google/inject/persist/jpa/JpaLocalTxnInterceptor.java
+++ b/extensions/persist/src/com/google/inject/persist/jpa/JpaLocalTxnInterceptor.java
@@ -82,7 +82,13 @@ class JpaLocalTxnInterceptor implements MethodInterceptor {
     //everything was normal so commit the txn (do not move into try block above as it
     //  interferes with the advised method's throwing semantics)
     try {
-      txn.commit();
+      if (txn.isActive()) {
+        if (txn.getRollbackOnly()) {
+          txn.rollback();
+        } else {
+          txn.commit();
+        }
+      }
     } finally {
       //close the em if necessary
       if (null != didWeStartWork.get()) {


### PR DESCRIPTION
When methods marked @Transactional initiated a rollback without
throwing an exception, the Interceptor threw an exception with
either "Transaction not active" or "Transaction marked for rollback only"..

Fixes #1136