### PR TITLE
Mark JSR305 dependency as optional for throwingproviders

### DIFF
--- a/extensions/throwingproviders/pom.xml
+++ b/extensions/throwingproviders/pom.xml
@@ -44,6 +44,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
… as it's not required at runtime (you only need it if you want to perform `null` analysis on the code)