### PR TITLE
Fix minor OSGi metadata issues caused by upgrade to bundleplugin 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,8 +339,9 @@ See the Apache License Version 2.0 for the specific language governing permissio
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>5.1.2</version>
           <configuration>
+            <excludeDependencies>jsr305</excludeDependencies>
             <instructions>
               <module>com.google.inject</module>
               <_include>-${project.basedir}/build.properties</_include>
@@ -351,7 +352,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
               <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
               <Import-Package>!com.google.inject.*,*</Import-Package>
               <_exportcontents>!*.internal.*,$(module).*;version=${guice.api.version}</_exportcontents>
-              <_versionpolicy>$(version;==;$(@))</_versionpolicy>
+              <_consumer-policy>$(version;==;$(@))</_consumer-policy>
               <_nouses>true</_nouses>
               <_removeheaders>
                 Embed-Dependency,Embed-Transitive,


### PR DESCRIPTION
 * `_versionpolicy` instruction (deprecated) should now be `_consumer-policy`
 * forked builds (like the 'no_aop' munged build) will now attempt to merge
   in headers from the main jar. This overwrites the custom 'no_aop' headers
   so we need to exclude `Bundle-Name` and `Import-Package` from this merging
   in the core build to keep those 'no_aop' differences.

Note: neither of these issues stop someone from deploying Guice 4.2 on OSGi.

It's just the first issue means they'd have to deploy a specific version of Guava.
Versions after 23.x wouldn't be accepted due to an unnecessarily strict range,
because our relaxed version policy wasn't picked up. Whereas the second issue
is more cosmetic and is about preserving the custom 'no_aop' bundle name and
its simpler imports.