### PR TITLE
Exclude transitive ant dependency from cglib because we don't need it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
         <groupId>cglib</groupId>
         <artifactId>cglib</artifactId>
         <version>3.2.6</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
There are a couple of issues against cglib to fix this upstream (such as https://github.com/cglib/cglib/pull/87) until then this is a quick local fix.