### PR TITLE
Moe Sync

### DIFF
--- a/extensions/testlib/src/com/google/inject/testing/throwingproviders/CheckedProviderSubject.java
+++ b/extensions/testlib/src/com/google/inject/testing/throwingproviders/CheckedProviderSubject.java
@@ -53,8 +53,7 @@ public final class CheckedProviderSubject<T, P extends CheckedProvider<T>>
     try {
       got = provider.get();
     } catch (Exception e) {
-      failWithRawMessageAndCause(
-          String.format("checked provider <%s> threw an exception", provider), e);
+      failWithCauseAndMessage(e, "checked provider <%s> threw an exception", provider);
       return ignoreCheck().that(new Object());
     }
     return check().withMessage("value provided by <%s>", provider).that(got);
@@ -79,5 +78,35 @@ public final class CheckedProviderSubject<T, P extends CheckedProvider<T>>
     }
     failWithBadResults("threw", "an exception", "provided", got);
     return ignoreCheck().that(new Throwable());
+  }
+
+  /*
+   * Hack to get Truth to include a given exception as the cause of the failure. It works by letting
+   * us delegate to a new Subject whose value under test is the exception. Because that makes the
+   * assertion "about" the exception, Truth includes it as a cause.
+   */
+
+  private void failWithCauseAndMessage(Throwable cause, String format, Object... args) {
+    check().about(unexpectedFailures()).that(cause).doFail(format, args);
+  }
+
+  private static Factory<UnexpectedFailureSubject, Throwable> unexpectedFailures() {
+    return new Factory<UnexpectedFailureSubject, Throwable>() {
+      @Override
+      public UnexpectedFailureSubject createSubject(FailureMetadata metadata, Throwable actual) {
+        return new UnexpectedFailureSubject(metadata, actual);
+      }
+    };
+  }
+
+  private static final class UnexpectedFailureSubject
+      extends Subject<UnexpectedFailureSubject, Throwable> {
+    UnexpectedFailureSubject(FailureMetadata metadata, @Nullable Throwable actual) {
+      super(metadata, actual);
+    }
+
+    void doFail(String format, Object... args) {
+      failWithRawMessage(format, args);
+    }
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate off failWithRawMessageAndCause, which is being deprecated.

I'm sorry that the replacement is so ugly. Our reason for not supporting this directly is partially that it's needed by only ~1% of subjects. But mostly, we've over time taken the position that Truth is intended for only the "assert" phases of the "arrange, act, assert" testing process. Exceptions, on the other hand, usually come from the earlier phases.

Unfortunately, I still owe everyone a long explanation of *why* we have come to this position. If it's bugging you now, let me know, and I can make it happen.

(And yes, in this particular case, we're basically arguing that Your Subject Is Wrong. Sorry: I'm not trying to get you to delete it or recant or anything; I'm just trying to explain where we're coming from.)

cca8d01ea0223bb23a410d2c29aa9e07b0eb3931