### PR TITLE
Moe Sync

### DIFF
--- a/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryModuleBuilder.java
+++ b/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryModuleBuilder.java
@@ -314,7 +314,7 @@ public final class FactoryModuleBuilder {
       @Override
       protected void configure() {
         Provider<F> provider = new FactoryProvider2<>(factoryInterface, bindings);
-        bind(factoryInterface).toProvider(provider);
+        binder().skipSources(this.getClass()).bind(factoryInterface).toProvider(provider);
       }
     };
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add support for extensions into the proto SPI & convert them.

This converts the BindingProto to use oneofs instead of a type enum in order to let it grow more easily for extensions.

dfa2f128cd1c7bfd359e32e35cbb3f3410b1267e