### PR TITLE
Moe Sync

### DIFF
--- a/extensions/testlib/src/com/google/inject/testing/fieldbinder/BoundFieldModule.java
+++ b/extensions/testlib/src/com/google/inject/testing/fieldbinder/BoundFieldModule.java
@@ -18,14 +18,19 @@ package com.google.inject.testing.fieldbinder;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.BindingAnnotation;
+import com.google.inject.ConfigurationException;
+import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.TypeLiteral;
 import com.google.inject.binder.AnnotatedBindingBuilder;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.internal.Annotations;
+import com.google.inject.internal.MoreTypes;
 import com.google.inject.internal.Nullability;
 import com.google.inject.spi.Message;
 import com.google.inject.util.Providers;
@@ -95,12 +100,15 @@ import java.lang.reflect.Type;
  */
 public final class BoundFieldModule implements Module {
   private final Object instance;
-
-  // Note that binder is not initialized until configure() is called.
-  private Binder binder;
+  private final ImmutableList<Message> deferredBindingErrors;
+  private final ImmutableSet<BoundFieldInfo> boundFields;
 
   private BoundFieldModule(Object instance) {
     this.instance = instance;
+
+    ImmutableList.Builder<Message> deferredErrors = ImmutableList.builder();
+    boundFields = findBindableFields(deferredErrors);
+    deferredBindingErrors = deferredErrors.build();
   }
 
   /**
@@ -113,7 +121,7 @@ public final class BoundFieldModule implements Module {
     return new BoundFieldModule(instance);
   }
 
-  private static class BoundFieldException extends RuntimeException {
+  private static class BoundFieldException extends Exception {
     private final Message message;
 
     BoundFieldException(Message message) {
@@ -122,64 +130,149 @@ public final class BoundFieldModule implements Module {
     }
   }
 
-  private class BoundFieldInfo {
+  private static class NullBoundFieldValueException extends RuntimeException {
+    private final Message message;
+
+    NullBoundFieldValueException(Message message) {
+      super(message.toString());
+      this.message = message;
+    }
+  }
+
+  /** Information about a field bound by {@link BoundFieldModule}. */
+  public static final class BoundFieldInfo {
+    private final Object instance;
+    private final Field field;
+    private final TypeLiteral<?> fieldType;
+    private final Bind bindAnnotation;
+
+    /** @see #getBoundKey */
+    private final Key<?> boundKey;
+
+    private BoundFieldInfo(
+        Object instance, Field field, Bind bindAnnotation, TypeLiteral<?> fieldType)
+        throws BoundFieldException {
+      this.instance = instance;
+      this.field = field;
+      this.fieldType = fieldType;
+      this.bindAnnotation = bindAnnotation;
+
+      field.setAccessible(true);
+      Annotation bindingAnnotation = computeBindingAnnotation();
+      Optional<TypeLiteral<?>> naturalType = computeNaturalFieldType();
+      this.boundKey = computeKey(naturalType, bindingAnnotation);
+      checkBindingIsAssignable(field, naturalType);
+    }
+
+    private void checkBindingIsAssignable(Field field, Optional<TypeLiteral<?>> naturalType)
+        throws BoundFieldException {
+      if (naturalType.isPresent()) {
+        Class<?> boundRawType = boundKey.getTypeLiteral().getRawType();
+        Class<?> naturalRawType = MoreTypes.canonicalizeForKey(naturalType.get()).getRawType();
+        if (!boundRawType.isAssignableFrom(naturalRawType)) {
+          throw new BoundFieldException(
+              new Message(
+                  field,
+                  String.format(
+                      "Requested binding type \"%s\" is not assignable "
+                          + "from field binding type \"%s\"",
+                      boundRawType.getName(), naturalRawType.getName())));
+        }
+      }
+    }
+
     /** The field itself. */
-    final Field field;
+    public Field getField() {
+      return field;
+    }
 
     /**
      * The actual type of the field.
      *
-     * <p>For example, {@code @Bind(to = Object.class) Number one = new Integer(1);} will be {@link
-     * Number}.
+     * <p>For example, {@code @Bind(to = Object.class) Number one = new Integer(1);} will be {@code
+     * Number}. {@code @Bind Provider<Number>} will be {@code Provider<Number>}.
      */
-    final TypeLiteral<?> type;
-
-    /** The {@link Bind} annotation which is present on the field. */
-    final Bind bindAnnotation;
-
-    /**
-     * The type this field will bind to.
-     *
-     * <p>For example, {@code @Bind(to = Object.class) Number one = new Integer(1);} will be {@link
-     * Object} and {@code @Bind Number one = new Integer(1);} will be {@link Number}.
-     */
-    final TypeLiteral<?> boundType;
-
-    /**
-     * The "natural" type of this field.
-     *
-     * <p>For example, {@code @Bind(to = Object.class) Number one = new Integer(1);} will be {@link
-     * Number}, and {@code @Bind(to = Object.class) Provider<Number> one = new Integer(1);} will be
-     * {@link Number}.
-     *
-     * @see #getNaturalFieldType
-     */
-    final Optional<TypeLiteral<?>> naturalType;
-
-    BoundFieldInfo(Field field, Bind bindAnnotation, TypeLiteral<?> fieldType) {
-      this.field = field;
-      this.type = fieldType;
-      this.bindAnnotation = bindAnnotation;
-
-      field.setAccessible(true);
-
-      this.naturalType = getNaturalFieldType();
-      this.boundType = getBoundType();
+    public TypeLiteral<?> getFieldType() {
+      return fieldType;
     }
 
-    private TypeLiteral<?> getBoundType() {
+    /**
+     * The {@literal @}{@link Bind} annotation which is present on the field.
+     *
+     * <p>Note this is not the same as the binding annotation (or qualifier) for {@link
+     * #getBoundKey()}
+     */
+    public Bind getBindAnnotation() {
+      return bindAnnotation;
+    }
+
+    /**
+     * The key this field will bind to.
+     *
+     * <ul>
+     *   <li>{@code @Bind(to = Object.class) @MyQualifier Number one = new Integer(1);} will be
+     *       {@code @MyQualifier Object}.
+     *   <li>{@code @Bind @MyQualifier(2) Number one = new Integer(1);} will be
+     *       {@code @MyQualifier(2) Number}.
+     *   <li>{@code @Bind @MyQualifier Provider<String> three = "default"} will be
+     *       {@code @MyQualfier String}
+     * </ul>
+     */
+    public Key<?> getBoundKey() {
+      return boundKey;
+    }
+
+    /** Returns the current value of this field. */
+    public Object getValue() {
+      try {
+        return field.get(instance);
+      } catch (IllegalAccessException e) {
+        // Since we called setAccessible(true) on this field in the constructor, this is a
+        // programming error if it occurs.
+        throw new AssertionError(e);
+      }
+    }
+
+    private Annotation computeBindingAnnotation() throws BoundFieldException {
+      Annotation found = null;
+      for (Annotation annotation : field.getAnnotations()) {
+        Class<? extends Annotation> annotationType = annotation.annotationType();
+        if (Annotations.isBindingAnnotation(annotationType)) {
+          if (found != null) {
+            throw new BoundFieldException(
+                new Message(field, "More than one annotation is specified for this binding."));
+          }
+          found = annotation;
+        }
+      }
+      return found;
+    }
+
+    private Key<?> computeKey(Optional<TypeLiteral<?>> naturalType, Annotation bindingAnnotation)
+        throws BoundFieldException {
+      TypeLiteral<?> boundType = computeBoundType(naturalType);
+      if (bindingAnnotation == null) {
+        return Key.get(boundType);
+      } else {
+        return Key.get(boundType, bindingAnnotation);
+      }
+    }
+
+    private TypeLiteral<?> computeBoundType(Optional<TypeLiteral<?>> naturalType)
+        throws BoundFieldException {
       Class<?> bindClass = bindAnnotation.to();
       // Bind#to's default value is Bind.class which is used to represent that no explicit binding
       // type is requested.
       if (bindClass == Bind.class) {
         Preconditions.checkState(naturalType != null);
-        if (!this.naturalType.isPresent()) {
-          throwBoundFieldException(
-              field,
-              "Non parameterized Provider fields must have an explicit "
-                  + "binding class via @Bind(to = Foo.class)");
+        if (!naturalType.isPresent()) {
+          throw new BoundFieldException(
+              new Message(
+                  field,
+                  "Non parameterized Provider fields must have an explicit "
+                      + "binding class via @Bind(to = Foo.class)"));
         }
-        return this.naturalType.get();
+        return naturalType.get();
       } else {
         return TypeLiteral.get(bindClass);
       }
@@ -196,9 +289,9 @@ public final class BoundFieldModule implements Module {
      * @return the type this field binds to naturally, or {@link Optional#absent()} if this field is
      *     a non-parameterized {@link Provider}.
      */
-    private Optional<TypeLiteral<?>> getNaturalFieldType() {
-      if (isTransparentProvider(type.getRawType())) {
-        Type providerType = type.getType();
+    private Optional<TypeLiteral<?>> computeNaturalFieldType() {
+      if (isTransparentProvider(fieldType.getRawType())) {
+        Type providerType = fieldType.getType();
         if (providerType instanceof Class) {
           return Optional.absent();
         }
@@ -207,30 +300,51 @@ public final class BoundFieldModule implements Module {
         Preconditions.checkState(providerTypeArguments.length == 1);
         return Optional.<TypeLiteral<?>>of(TypeLiteral.get(providerTypeArguments[0]));
       } else {
-        return Optional.<TypeLiteral<?>>of(type);
-      }
-    }
-
-    Object getValue() {
-      try {
-        return field.get(instance);
-      } catch (IllegalAccessException e) {
-        // Since we called setAccessible(true) on this field in the constructor, this is a
-        // programming error if it occurs.
-        throw new AssertionError(e);
+        return Optional.<TypeLiteral<?>>of(fieldType);
       }
     }
 
     /** Returns whether a binding supports null values. */
-    boolean allowsNull() {
-      return !isTransparentProvider(type.getRawType())
+    private boolean allowsNull() {
+      return !isTransparentProvider(fieldType.getRawType())
           && Nullability.allowsNull(field.getAnnotations());
     }
   }
 
-  private static boolean hasInject(Field field) {
-    return field.isAnnotationPresent(javax.inject.Inject.class)
-        || field.isAnnotationPresent(com.google.inject.Inject.class);
+  /** Returns the the object originally passed to {@link BoundFieldModule#of}). */
+  public Object getInstance() {
+    return instance;
+  }
+
+  /**
+   * Returns information about the fields bound by this module.
+   *
+   * <p>Note this is available immediately after construction, fields with errors won't be included
+   * but their error messages will be deferred to configuration time.
+   *
+   * <p>Fields with invalid null values <em>are</em> included but still cause errors at
+   * configuration time.
+   */
+  public ImmutableSet<BoundFieldInfo> getBoundFields() {
+    return boundFields;
+  }
+
+  private ImmutableSet<BoundFieldInfo> findBindableFields(
+      ImmutableList.Builder<Message> deferredErrors) {
+    ImmutableSet.Builder<BoundFieldInfo> fieldInfos = ImmutableSet.builder();
+    TypeLiteral<?> currentClassType = TypeLiteral.get(instance.getClass());
+    while (currentClassType.getRawType() != Object.class) {
+      for (Field field : currentClassType.getRawType().getDeclaredFields()) {
+        Optional<BoundFieldInfo> fieldInfoOpt =
+            getBoundFieldInfo(currentClassType, field, deferredErrors);
+        if (fieldInfoOpt.isPresent()) {
+          fieldInfos.add(fieldInfoOpt.get());
+        }
+      }
+      currentClassType =
+          currentClassType.getSupertype(currentClassType.getRawType().getSuperclass());
+    }
+    return fieldInfos.build();
   }
 
   /**
@@ -240,30 +354,34 @@ public final class BoundFieldModule implements Module {
    * it returns {@link Optional#absent()}.
    */
   private Optional<BoundFieldInfo> getBoundFieldInfo(
-      TypeLiteral<?> containingClassType, Field field) {
+      TypeLiteral<?> containingClassType,
+      Field field,
+      ImmutableList.Builder<Message> deferredErrors) {
     Bind bindAnnotation = field.getAnnotation(Bind.class);
     if (bindAnnotation == null) {
       return Optional.absent();
     }
     if (hasInject(field)) {
-      throwBoundFieldException(field, "Fields annotated with both @Bind and @Inject are illegal.");
+      deferredErrors.add(
+          new Message(field, "Fields annotated with both @Bind and @Inject are illegal."));
+      return Optional.absent();
     }
-    return Optional.of(
-        new BoundFieldInfo(field, bindAnnotation, containingClassType.getFieldType(field)));
+    try {
+      return Optional.of(
+          new BoundFieldInfo(
+              instance, field, bindAnnotation, containingClassType.getFieldType(field)));
+    } catch (ConfigurationException e) { // thrown from Key.get, MoreTypes.canonicalizeForKey
+      deferredErrors.addAll(e.getErrorMessages());
+      return Optional.absent();
+    } catch (BoundFieldException e) {
+      deferredErrors.add(e.message);
+      return Optional.absent();
+    }
   }
 
-  private LinkedBindingBuilder<?> verifyBindingAnnotations(
-      Field field, AnnotatedBindingBuilder<?> annotatedBinder) {
-    LinkedBindingBuilder<?> binderRet = annotatedBinder;
-    for (Annotation annotation : field.getAnnotations()) {
-      Class<? extends Annotation> annotationType = annotation.annotationType();
-      if (Annotations.isBindingAnnotation(annotationType)) {
-        // not returning here ensures that annotatedWith will be called multiple times if this field
-        // has multiple BindingAnnotations, relying on the binder to throw an error in this case.
-        binderRet = annotatedBinder.annotatedWith(annotation);
-      }
-    }
-    return binderRet;
+  private static boolean hasInject(Field field) {
+    return field.isAnnotationPresent(javax.inject.Inject.class)
+        || field.isAnnotationPresent(com.google.inject.Inject.class);
   }
 
   /**
@@ -285,21 +403,8 @@ public final class BoundFieldModule implements Module {
     return com.google.inject.Provider.class == clazz || javax.inject.Provider.class == clazz;
   }
 
-  private void bindField(final BoundFieldInfo fieldInfo) {
-    if (fieldInfo.naturalType.isPresent()) {
-      Class<?> naturalRawType = fieldInfo.naturalType.get().getRawType();
-      Class<?> boundRawType = fieldInfo.boundType.getRawType();
-      if (!boundRawType.isAssignableFrom(naturalRawType)) {
-        throwBoundFieldException(
-            fieldInfo.field,
-            "Requested binding type \"%s\" is not assignable from field binding type \"%s\"",
-            boundRawType.getName(),
-            naturalRawType.getName());
-      }
-    }
-
-    AnnotatedBindingBuilder<?> annotatedBinder = binder.bind(fieldInfo.boundType);
-    LinkedBindingBuilder<?> binder = verifyBindingAnnotations(fieldInfo.field, annotatedBinder);
+  private static void bindField(Binder binder, final BoundFieldInfo fieldInfo) {
+    LinkedBindingBuilder<?> linkedBinder = binder.bind(fieldInfo.boundKey);
 
     // It's unfortunate that Field.get() just returns Object rather than the actual type (although
     // that would be impossible) because as a result calling binder.toInstance or binder.toProvider
@@ -308,9 +413,9 @@ public final class BoundFieldModule implements Module {
     // fieldInfo.naturalType is absent which occurrs when a non-parameterized Provider is used with
     // @Bind(to = ...)
     @SuppressWarnings("unchecked")
-    AnnotatedBindingBuilder<Object> binderUnsafe = (AnnotatedBindingBuilder<Object>) binder;
+    AnnotatedBindingBuilder<Object> binderUnsafe = (AnnotatedBindingBuilder<Object>) linkedBinder;
 
-    if (isTransparentProvider(fieldInfo.type.getRawType())) {
+    if (isTransparentProvider(fieldInfo.fieldType.getRawType())) {
       if (fieldInfo.bindAnnotation.lazy()) {
         binderUnsafe.toProvider(
             new Provider<Object>() {
@@ -355,52 +460,40 @@ public final class BoundFieldModule implements Module {
    * Returns the field value to bind, throwing for non-{@code @Nullable} fields with null values,
    * and for null "transparent providers".
    */
-  private Object getFieldValue(final BoundFieldInfo fieldInfo) {
+  private static Object getFieldValue(final BoundFieldInfo fieldInfo) {
     Object fieldValue = fieldInfo.getValue();
     if (fieldValue == null && !fieldInfo.allowsNull()) {
-      if (isTransparentProvider(fieldInfo.type.getRawType())) {
-        throwBoundFieldException(
-            fieldInfo.field,
-            "Binding to null is not allowed. Use Providers.of(null) if this is your intended "
-                + "behavior.",
-            fieldInfo.field.getName());
+      if (isTransparentProvider(fieldInfo.fieldType.getRawType())) {
+        throw new NullBoundFieldValueException(
+            new Message(
+                fieldInfo.field,
+                "Binding to null is not allowed. Use Providers.of(null) if this is your intended "
+                    + "behavior."));
       } else {
-        throwBoundFieldException(
-            fieldInfo.field,
-            "Binding to null values is only allowed for fields that are annotated @Nullable.",
-            fieldInfo.field.getName());
+        throw new NullBoundFieldValueException(
+            new Message(
+                fieldInfo.field,
+                "Binding to null values is only allowed for fields that are annotated @Nullable."));
       }
     }
     return fieldValue;
   }
 
-  private void throwBoundFieldException(Field field, String format, Object... args) {
-    Preconditions.checkNotNull(binder);
-    String source =
-        String.format("%s field %s", field.getDeclaringClass().getName(), field.getName());
-    throw new BoundFieldException(new Message(source, String.format(format, args)));
-  }
-
   @Override
   public void configure(Binder binder) {
     binder = binder.skipSources(BoundFieldModule.class);
-    this.binder = binder;
 
-    TypeLiteral<?> currentClassType = TypeLiteral.get(instance.getClass());
-    while (currentClassType.getRawType() != Object.class) {
-      for (Field field : currentClassType.getRawType().getDeclaredFields()) {
-        try {
-          Optional<BoundFieldInfo> fieldInfoOpt = getBoundFieldInfo(currentClassType, field);
-          if (fieldInfoOpt.isPresent()) {
-            bindField(fieldInfoOpt.get());
-          }
-        } catch (BoundFieldException e) {
-          // keep going to try to collect as many errors as possible
-          binder.addError(e.message);
-        }
+    for (Message message : deferredBindingErrors) {
+      binder.addError(message);
+    }
+
+    for (BoundFieldInfo fieldInfo : boundFields) {
+      try {
+        bindField(binder, fieldInfo);
+      } catch (NullBoundFieldValueException e) {
+        // Defer errors for all eagerly bound null values
+        binder.addError(e.message);
       }
-      currentClassType =
-          currentClassType.getSupertype(currentClassType.getRawType().getSuperclass());
     }
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make BoundFieldInfo public

And discover the bound fields when constructing the module, but deferring the errors to configure() time.

This enables using BoundFieldModule with custom scoping in GuiceBerry/Acai using TestScopeListener/TestingService to reflectively reset the instance before tests.

dc11d3d4c2af533c545314dbef5bf07c69aa2f2c