### PR TITLE
Update JpaPersistService to ignore subsequent calls to start() and stop()

### DIFF
--- a/extensions/persist/src/com/google/inject/persist/jpa/JpaPersistService.java
+++ b/extensions/persist/src/com/google/inject/persist/jpa/JpaPersistService.java
@@ -103,7 +103,9 @@ class JpaPersistService implements Provider<EntityManager>, UnitOfWork, PersistS
 
   @Override
   public synchronized void start() {
-    Preconditions.checkState(null == emFactory, "Persistence service was already initialized.");
+    if (null != emFactory) {
+      return;
+    }
 
     if (null != persistenceProperties) {
       this.emFactory =
@@ -115,8 +117,9 @@ class JpaPersistService implements Provider<EntityManager>, UnitOfWork, PersistS
 
   @Override
   public synchronized void stop() {
-    Preconditions.checkState(emFactory.isOpen(), "Persistence service was already shut down.");
-    emFactory.close();
+    if (emFactory.isOpen()) {
+      emFactory.close();
+    }
   }
 
   @Singleton

--- a/extensions/persist/test/com/google/inject/persist/jpa/JpaWorkManagerTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/JpaWorkManagerTest.java
@@ -89,15 +89,16 @@ public class JpaWorkManagerTest extends TestCase {
     }
   }
 
+  public void testStartMoreThanOnce() {
+    injector.getInstance(PersistService.class).start();
+    // No exception is thrown on subsequent start.
+    injector.getInstance(PersistService.class).start();
+  }
+
   public void testCloseMoreThanOnce() {
     injector.getInstance(PersistService.class).stop();
-
-    try {
-      injector.getInstance(PersistService.class).stop();
-      fail();
-    } catch (IllegalStateException e) {
-      // Ignored.
-    }
+    // No exception is thrown on subsequent stop.
+    injector.getInstance(PersistService.class).stop();
   }
 
   public static class TransactionalObject {


### PR DESCRIPTION
This resolves #947 and supersedes #972 and #598. It possibly also supersedes #1132, although I'm not sure what that user's use case is.

The current behaviour is to throw an `IllegalStateException` when `JpaPersistService.start()` or `JpaPersistService.stop()` are called multiple times. However, this clashes with the javadoc in `PersistService` and `UnitOfWork`, both of which state that subsequent calls to these methods are no-ops.

`JpaPersistService.end()` already handles multiple calls, and has the following comment:
```// Let's not penalize users for calling end() multiple times.```

This PR brings `JpaPersistService` and related tests into line with the documentation and resolves a pain point that multiple people (including myself) have experienced, e.g. https://stackoverflow.com/questions/17402081/how-to-start-jpa-in-a-guice-quartz-web-application.

Thank you for taking the time to look at my PR.