### PR TITLE
Moe Sync

### DIFF
--- a/core/src/com/google/inject/Injector.java
+++ b/core/src/com/google/inject/Injector.java
@@ -16,6 +16,7 @@
 
 package com.google.inject;
 
+import com.google.inject.spi.Element;
 import com.google.inject.spi.TypeConverterBinding;
 import java.lang.annotation.Annotation;
 import java.util.List;
@@ -31,10 +32,10 @@ import java.util.Set;
  * <p>Contains several default bindings:
  *
  * <ul>
- * <li>This {@link Injector} instance itself
- * <li>A {@code Provider<T>} for each binding of type {@code T}
- * <li>The {@link java.util.logging.Logger} for the class being injected
- * <li>The {@link Stage} in which the Injector was created
+ *   <li>This {@link Injector} instance itself
+ *   <li>A {@code Provider<T>} for each binding of type {@code T}
+ *   <li>The {@link java.util.logging.Logger} for the class being injected
+ *   <li>The {@link Stage} in which the Injector was created
  * </ul>
  *
  * Injectors are created using the facade class {@link Guice}.
@@ -260,4 +261,15 @@ public interface Injector {
    * @since 3.0
    */
   Set<TypeConverterBinding> getTypeConverterBindings();
+
+  /**
+   * Returns the elements that make up this injector. Note that not all kinds of elements are
+   * returned.
+   *
+   * <p>The returned list does not include elements inherited from a {@link #getParent() parent
+   * injector}, should one exist.
+   *
+   * @since 5.0
+   */
+  List<Element> getElements();
 }

--- a/core/src/com/google/inject/internal/InheritingState.java
+++ b/core/src/com/google/inject/internal/InheritingState.java
@@ -27,11 +27,13 @@ import com.google.inject.Key;
 import com.google.inject.Scope;
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.ModuleAnnotatedMethodScannerBinding;
+import com.google.inject.spi.ProviderLookup;
 import com.google.inject.spi.ProvisionListenerBinding;
 import com.google.inject.spi.ScopeBinding;
 import com.google.inject.spi.TypeConverterBinding;
 import com.google.inject.spi.TypeListenerBinding;
 import java.lang.annotation.Annotation;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +49,7 @@ final class InheritingState implements State {
   private final Map<Key<?>, Binding<?>> explicitBindings =
       Collections.unmodifiableMap(explicitBindingsMutable);
   private final Map<Class<? extends Annotation>, ScopeBinding> scopes = Maps.newHashMap();
+  private final List<ProviderLookup<?>> lookups = Lists.newArrayList();
   private final List<TypeConverterBinding> converters = Lists.newArrayList();
   /*if[AOP]*/
   private final List<MethodAspect> methodAspects = Lists.newArrayList();
@@ -86,6 +89,16 @@ final class InheritingState implements State {
   }
 
   @Override
+  public void putProviderLookup(ProviderLookup<?> lookup) {
+    lookups.add(lookup);
+  }
+
+  @Override
+  public List<ProviderLookup<?>> getProviderLookupsThisLevel() {
+    return lookups;
+  }
+
+  @Override
   public ScopeBinding getScopeBinding(Class<? extends Annotation> annotationType) {
     ScopeBinding scopeBinding = scopes.get(annotationType);
     return scopeBinding != null ? scopeBinding : parent.getScopeBinding(annotationType);
@@ -94,6 +107,11 @@ final class InheritingState implements State {
   @Override
   public void putScopeBinding(Class<? extends Annotation> annotationType, ScopeBinding scope) {
     scopes.put(annotationType, scope);
+  }
+
+  @Override
+  public Collection<ScopeBinding> getScopeBindingsThisLevel() {
+    return scopes.values();
   }
 
   @Override
@@ -154,6 +172,11 @@ final class InheritingState implements State {
   }
 
   @Override
+  public List<TypeListenerBinding> getTypeListenerBindingsThisLevel() {
+    return typeListenerBindings;
+  }
+
+  @Override
   public void addProvisionListener(ProvisionListenerBinding listenerBinding) {
     provisionListenerBindings.add(listenerBinding);
   }
@@ -169,6 +192,11 @@ final class InheritingState implements State {
   }
 
   @Override
+  public List<ProvisionListenerBinding> getProvisionListenerBindingsThisLevel() {
+    return provisionListenerBindings;
+  }
+
+  @Override
   public void addScanner(ModuleAnnotatedMethodScannerBinding scanner) {
     scannerBindings.add(scanner);
   }
@@ -181,6 +209,11 @@ final class InheritingState implements State {
     result.addAll(parentBindings);
     result.addAll(scannerBindings);
     return result;
+  }
+
+  @Override
+  public List<ModuleAnnotatedMethodScannerBinding> getScannerBindingsThisLevel() {
+    return scannerBindings;
   }
 
   @Override

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -42,6 +42,7 @@ import com.google.inject.internal.util.SourceProvider;
 import com.google.inject.spi.BindingTargetVisitor;
 import com.google.inject.spi.ConvertedConstantBinding;
 import com.google.inject.spi.Dependency;
+import com.google.inject.spi.Element;
 import com.google.inject.spi.HasDependencies;
 import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.InstanceBinding;
@@ -860,11 +861,11 @@ final class InjectorImpl implements Injector, Lookups {
    * create just-in-time bindings are:
    *
    * <ol>
-   * <li>Internalizing Providers. If the requested binding is for {@code Provider<T>}, we delegate
-   *     to the binding for {@code T}.
-   * <li>Converting constants.
-   * <li>ImplementedBy and ProvidedBy annotations. Only for unannotated keys.
-   * <li>The constructor of the raw type. Only for unannotated keys.
+   *   <li>Internalizing Providers. If the requested binding is for {@code Provider<T>}, we delegate
+   *       to the binding for {@code T}.
+   *   <li>Converting constants.
+   *   <li>ImplementedBy and ProvidedBy annotations. Only for unannotated keys.
+   *   <li>The constructor of the raw type. Only for unannotated keys.
    * </ol>
    *
    * @throws com.google.inject.internal.ErrorsException if the binding cannot be created.
@@ -961,6 +962,20 @@ final class InjectorImpl implements Injector, Lookups {
   @Override
   public Set<TypeConverterBinding> getTypeConverterBindings() {
     return ImmutableSet.copyOf(state.getConvertersThisLevel());
+  }
+
+  @Override
+  public List<Element> getElements() {
+    ImmutableList.Builder<Element> elements = ImmutableList.builder();
+    elements.addAll(getAllBindings().values());
+    elements.addAll(state.getProviderLookupsThisLevel());
+    elements.addAll(state.getConvertersThisLevel());
+    elements.addAll(state.getScopeBindingsThisLevel());
+    elements.addAll(state.getTypeListenerBindingsThisLevel());
+    elements.addAll(state.getProvisionListenerBindingsThisLevel());
+    elements.addAll(state.getScannerBindingsThisLevel());
+
+    return elements.build();
   }
 
   /** Returns parameter injectors, or {@code null} if there are no parameters. */

--- a/core/src/com/google/inject/internal/InternalInjectorCreator.java
+++ b/core/src/com/google/inject/internal/InternalInjectorCreator.java
@@ -27,6 +27,7 @@ import com.google.inject.Stage;
 import com.google.inject.TypeLiteral;
 import com.google.inject.internal.util.Stopwatch;
 import com.google.inject.spi.Dependency;
+import com.google.inject.spi.Element;
 import com.google.inject.spi.TypeConverterBinding;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -43,13 +44,13 @@ import java.util.Set;
  * <p>Injector construction happens in two phases.
  *
  * <ol>
- * <li>Static building. In this phase, we interpret commands, create bindings, and inspect
- *     dependencies. During this phase, we hold a lock to ensure consistency with parent injectors.
- *     No user code is executed in this phase.
- * <li>Dynamic injection. In this phase, we call user code. We inject members that requested
- *     injection. This may require user's objects be created and their providers be called. And we
- *     create eager singletons. In this phase, user code may have started other threads. This phase
- *     is not executed for injectors created using {@link Stage#TOOL the tool stage}
+ *   <li>Static building. In this phase, we interpret commands, create bindings, and inspect
+ *       dependencies. During this phase, we hold a lock to ensure consistency with parent
+ *       injectors. No user code is executed in this phase.
+ *   <li>Dynamic injection. In this phase, we call user code. We inject members that requested
+ *       injection. This may require user's objects be created and their providers be called. And we
+ *       create eager singletons. In this phase, user code may have started other threads. This
+ *       phase is not executed for injectors created using {@link Stage#TOOL the tool stage}
  * </ol>
  *
  * @author crazybob@google.com (Bob Lee)
@@ -304,6 +305,11 @@ public final class InternalInjectorCreator {
     @Override
     public Set<TypeConverterBinding> getTypeConverterBindings() {
       return delegateInjector.getTypeConverterBindings();
+    }
+
+    @Override
+    public List<Element> getElements() {
+      return delegateInjector.getElements();
     }
 
     @Override

--- a/core/src/com/google/inject/internal/LookupProcessor.java
+++ b/core/src/com/google/inject/internal/LookupProcessor.java
@@ -52,6 +52,11 @@ final class LookupProcessor extends AbstractProcessor {
     try {
       Provider<T> provider = injector.getProviderOrThrow(lookup.getDependency(), errors);
       lookup.initializeDelegate(provider);
+      // only remember ProviderLookups that are based on injection points,
+      // since those are the only worthwhile ones that can be examined later.
+      if (lookup.getDependency().getInjectionPoint() != null) {
+        injector.state.putProviderLookup(lookup);
+      }
     } catch (ErrorsException e) {
       errors.merge(e.getErrors()); // TODO: source
     }

--- a/core/src/com/google/inject/internal/State.java
+++ b/core/src/com/google/inject/internal/State.java
@@ -24,11 +24,13 @@ import com.google.inject.Key;
 import com.google.inject.Scope;
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.ModuleAnnotatedMethodScannerBinding;
+import com.google.inject.spi.ProviderLookup;
 import com.google.inject.spi.ProvisionListenerBinding;
 import com.google.inject.spi.ScopeBinding;
 import com.google.inject.spi.TypeConverterBinding;
 import com.google.inject.spi.TypeListenerBinding;
 import java.lang.annotation.Annotation;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,6 +62,16 @@ interface State {
 
         @Override
         public void putBinding(Key<?> key, BindingImpl<?> binding) {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void putProviderLookup(ProviderLookup<?> lookup) {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<ProviderLookup<?>> getProviderLookupsThisLevel() {
           throw new UnsupportedOperationException();
         }
 
@@ -150,13 +162,29 @@ interface State {
           throw new UnsupportedOperationException();
         }
 
-        public Object singletonCreationLock() {
+        @Override
+        public Map<Class<? extends Annotation>, Scope> getScopes() {
+          return ImmutableMap.of();
+        }
+
+        @Override
+        public List<ScopeBinding> getScopeBindingsThisLevel() {
           throw new UnsupportedOperationException();
         }
 
         @Override
-        public Map<Class<? extends Annotation>, Scope> getScopes() {
-          return ImmutableMap.of();
+        public List<TypeListenerBinding> getTypeListenerBindingsThisLevel() {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<ProvisionListenerBinding> getProvisionListenerBindingsThisLevel() {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<ModuleAnnotatedMethodScannerBinding> getScannerBindingsThisLevel() {
+          throw new UnsupportedOperationException();
         }
       };
 
@@ -170,9 +198,15 @@ interface State {
 
   void putBinding(Key<?> key, BindingImpl<?> binding);
 
+  void putProviderLookup(ProviderLookup<?> lookup);
+
+  List<ProviderLookup<?>> getProviderLookupsThisLevel();
+
   ScopeBinding getScopeBinding(Class<? extends Annotation> scopingAnnotation);
 
   void putScopeBinding(Class<? extends Annotation> annotationType, ScopeBinding scope);
+
+  Collection<ScopeBinding> getScopeBindingsThisLevel();
 
   void addConverter(TypeConverterBinding typeConverterBinding);
 
@@ -193,13 +227,19 @@ interface State {
 
   List<TypeListenerBinding> getTypeListenerBindings();
 
+  List<TypeListenerBinding> getTypeListenerBindingsThisLevel();
+
   void addProvisionListener(ProvisionListenerBinding provisionListenerBinding);
 
   List<ProvisionListenerBinding> getProvisionListenerBindings();
 
+  List<ProvisionListenerBinding> getProvisionListenerBindingsThisLevel();
+
   void addScanner(ModuleAnnotatedMethodScannerBinding scanner);
 
   List<ModuleAnnotatedMethodScannerBinding> getScannerBindings();
+
+  List<ModuleAnnotatedMethodScannerBinding> getScannerBindingsThisLevel();
 
   /**
    * Forbids the corresponding injector from creating a binding to {@code key}. Child injectors

--- a/core/src/com/google/inject/spi/ProviderLookup.java
+++ b/core/src/com/google/inject/spi/ProviderLookup.java
@@ -19,10 +19,12 @@ package com.google.inject.spi;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Provider;
+import com.google.inject.internal.Errors;
 import com.google.inject.util.Types;
 import java.util.Set;
 
@@ -124,5 +126,13 @@ public final class ProviderLookup<T> implements Element {
         return "Provider<" + getKey().getTypeLiteral() + ">";
       }
     };
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(ProviderLookup.class)
+        .add("dependency", dependency)
+        .add("source", Errors.convert(source))
+        .toString();
   }
 }

--- a/core/src/com/google/inject/spi/ScopeBinding.java
+++ b/core/src/com/google/inject/spi/ScopeBinding.java
@@ -18,8 +18,10 @@ package com.google.inject.spi;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import com.google.inject.Binder;
 import com.google.inject.Scope;
+import com.google.inject.internal.Errors;
 import java.lang.annotation.Annotation;
 
 /**
@@ -66,5 +68,14 @@ public final class ScopeBinding implements Element {
   @Override
   public void applyTo(Binder binder) {
     binder.withSource(getSource()).bindScope(annotationType, scope);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(ScopeBinding.class)
+        .add("annotationType", annotationType)
+        .add("scope", scope)
+        .add("source", Errors.convert(source))
+        .toString();
   }
 }

--- a/core/test/com/google/inject/internal/WeakKeySetTest.java
+++ b/core/test/com/google/inject/internal/WeakKeySetTest.java
@@ -35,6 +35,7 @@ import com.google.inject.Key;
 import com.google.inject.Scope;
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.ModuleAnnotatedMethodScannerBinding;
+import com.google.inject.spi.ProviderLookup;
 import com.google.inject.spi.ProvisionListenerBinding;
 import com.google.inject.spi.ScopeBinding;
 import com.google.inject.spi.TypeConverterBinding;
@@ -474,6 +475,16 @@ public class WeakKeySetTest extends TestCase {
     }
 
     @Override
+    public void putProviderLookup(ProviderLookup<?> lookup) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ProviderLookup<?>> getProviderLookupsThisLevel() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public ScopeBinding getScopeBinding(Class<? extends Annotation> scopingAnnotation) {
       return null;
     }
@@ -559,13 +570,29 @@ public class WeakKeySetTest extends TestCase {
       throw new UnsupportedOperationException();
     }
 
-    public Object singletonCreationLock() {
+    @Override
+    public Map<Class<? extends Annotation>, Scope> getScopes() {
+      return ImmutableMap.of();
+    }
+
+    @Override
+    public List<ScopeBinding> getScopeBindingsThisLevel() {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public Map<Class<? extends Annotation>, Scope> getScopes() {
-      return ImmutableMap.of();
+    public List<TypeListenerBinding> getTypeListenerBindingsThisLevel() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ProvisionListenerBinding> getProvisionListenerBindingsThisLevel() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ModuleAnnotatedMethodScannerBinding> getScannerBindingsThisLevel() {
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/core/test/com/google/inject/spi/InjectorSpiTest.java
+++ b/core/test/com/google/inject/spi/InjectorSpiTest.java
@@ -1,5 +1,7 @@
 package com.google.inject.spi;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.inject.AbstractModule;
 import com.google.inject.Binding;
 import com.google.inject.Guice;
@@ -7,8 +9,15 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Provider;
+import com.google.inject.Stage;
 import com.google.inject.TypeLiteral;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
 import junit.framework.TestCase;
 
 /** @author sberlin@gmail.com (Sam Berlin) */
@@ -38,7 +47,8 @@ public class InjectorSpiTest extends TestCase {
     assertEquals(Foo.class, binding.getKey().getTypeLiteral().getRawType());
 
     // 2) Provider<Foo> class (should already exist, because Baz @Injects it).
-    // the assertTrue is a bit stricter than necessary, but makes sure this works for pre-existing Provider bindings
+    // the assertTrue is a bit stricter than necessary, but makes sure this works for pre-existing
+    // Provider bindings
     assertTrue(injector.getAllBindings().containsKey(Key.get(new TypeLiteral<Provider<Foo>>() {})));
     binding = injector.getExistingBinding(Key.get(new TypeLiteral<Provider<Foo>>() {}));
     assertNotNull(binding);
@@ -51,7 +61,8 @@ public class InjectorSpiTest extends TestCase {
     assertEquals(Baz.class, binding.getKey().getTypeLiteral().getRawType());
 
     // 4) Provider<Baz> class (should not already exist, because nothing used it yet).
-    // the assertFalse is a bit stricter than necessary, but makes sure this works for non-pre-existing Provider bindings
+    // the assertFalse is a bit stricter than necessary, but makes sure this works for
+    // non-pre-existing Provider bindings
     assertFalse(
         injector.getAllBindings().containsKey(Key.get(new TypeLiteral<Provider<Baz>>() {})));
     binding = injector.getExistingBinding(Key.get(new TypeLiteral<Provider<Baz>>() {}));
@@ -64,6 +75,106 @@ public class InjectorSpiTest extends TestCase {
 
     // 6) Provider Bar, doesn't exist.
     assertNull(injector.getExistingBinding(Key.get(new TypeLiteral<Provider<Bar>>() {})));
+  }
+
+  @SuppressWarnings("unused")
+  private static void customMethod(Foo foo, Bar bar) {}
+
+  public void testGetElements() {
+    Method customMethod;
+    try {
+      customMethod = getClass().getDeclaredMethod("customMethod", Foo.class, Bar.class);
+    } catch (NoSuchMethodException | SecurityException e) {
+      throw new RuntimeException(e);
+    }
+    InjectionPoint ip = InjectionPoint.forMethod(customMethod, TypeLiteral.get(getClass()));
+    final Dependency<?> fooDep =
+        ip.getDependencies().get(0).getParameterIndex() == 0
+            ? ip.getDependencies().get(0)
+            : ip.getDependencies().get(1);
+    final Dependency<?> barDep =
+        ip.getDependencies().get(1).getParameterIndex() == 1
+            ? ip.getDependencies().get(1)
+            : ip.getDependencies().get(0);
+    Injector injector =
+        Guice.createInjector(
+            new AbstractModule() {
+              @Override
+              protected void configure() {
+                bind(Foo.class);
+                bind(Baz.class);
+                binder().getProvider(fooDep);
+                binder().getProvider(barDep);
+              }
+            });
+
+    final List<Binding<?>> bindings = new ArrayList<>();
+    final List<ProviderLookup<?>> lookups = new ArrayList<>();
+    final List<TypeConverterBinding> typeConverters = new ArrayList<>();
+    final List<ScopeBinding> scopes = new ArrayList<>();
+    for (Element element : injector.getElements()) {
+      element.acceptVisitor(
+          new DefaultElementVisitor<Void>() {
+            @Override
+            public <T> Void visit(Binding<T> binding) {
+              bindings.add(binding);
+              return null;
+            }
+
+            @Override
+            public <T> Void visit(ProviderLookup<T> providerLookup) {
+              lookups.add(providerLookup);
+              return null;
+            }
+
+            @Override
+            public Void visit(ScopeBinding scopeBinding) {
+              scopes.add(scopeBinding);
+              return null;
+            }
+
+            @Override
+            public Void visit(TypeConverterBinding typeConverterBinding) {
+              typeConverters.add(typeConverterBinding);
+              return null;
+            }
+
+            @Override
+            protected Void visitOther(Element element) {
+              throw new IllegalStateException("Unexpected element: " + element);
+            }
+          });
+    }
+
+    Set<Key<?>> actualKeys = new HashSet<>();
+    for (Binding<?> binding : bindings) {
+      actualKeys.add(binding.getKey());
+    }
+    assertThat(actualKeys)
+        .containsExactly(
+            Key.get(Stage.class),
+            Key.get(Injector.class),
+            Key.get(Logger.class),
+            Key.get(Foo.class),
+            Key.get(Bar.class),
+            Key.get(Baz.class),
+            new Key<Provider<Foo>>() {});
+
+    boolean foundFooLookup = false;
+    boolean foundBarLookup = false;
+    for (ProviderLookup<?> lookup : lookups) {
+      if (lookup.getKey().getTypeLiteral().getRawType().equals(Foo.class)) {
+        foundFooLookup = true;
+        assertThat(lookup.getDependency()).isEqualTo(fooDep);
+      } else if (lookup.getKey().getTypeLiteral().getRawType().equals(Bar.class)) {
+        foundBarLookup = true;
+        assertThat(lookup.getDependency()).isEqualTo(barDep);
+      } else {
+        fail("Unexpected lookup: " + lookup);
+      }
+    }
+    assertTrue(foundFooLookup);
+    assertTrue(foundBarLookup);
   }
 
   private static class Foo {}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add Injector.getElements method that returns all supported SPI types from the Injector.

Update Injectors to keep track of ProviderLookups attached to InjectionPoints, since these are meaningful for SPI usages.

(See the linked bug for the rationale of why we're adding this.)

4efdeb9e4fd12988d241f213e73196255877fe06