### PR TITLE
Moe Sync

### DIFF
--- a/core/src/com/google/inject/internal/DeclaredMembers.java
+++ b/core/src/com/google/inject/internal/DeclaredMembers.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.inject.internal;
+
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+/**
+ * Utility class for retrieving declared fields or methods in a particular order, because the JVM
+ * doesn't guarantee ordering for listing declared methods. We don't externally guarantee an
+ * ordering, but having a consistent ordering allows deterministic behavior and simpler tests.
+ */
+public final class DeclaredMembers {
+
+  private DeclaredMembers() {}
+
+  public static Field[] getDeclaredFields(Class<?> type) {
+    Field[] fields = type.getDeclaredFields();
+    Arrays.sort(fields, FIELD_ORDERING);
+    return fields;
+  }
+
+  public static Method[] getDeclaredMethods(Class<?> type) {
+    Method[] methods = type.getDeclaredMethods();
+    Arrays.sort(methods, METHOD_ORDERING);
+    return methods;
+  }
+
+  /**
+   * An ordering suitable for comparing two classes if they are loaded by the same classloader
+   *
+   * <p>Within a single classloader there can only be one class with a given name, so we just
+   * compare the names.
+   */
+  private static final Ordering<Class<?>> CLASS_ORDERING =
+      new Ordering<Class<?>>() {
+        @Override
+        public int compare(Class<?> o1, Class<?> o2) {
+          return o1.getName().compareTo(o2.getName());
+        }
+      };
+
+  /**
+   * An ordering suitable for comparing two fields if they are owned by the same class.
+   *
+   * <p>Within a single class it is sufficent to compare the non-generic field signature which
+   * consists of the field name and type.
+   */
+  private static final Ordering<Field> FIELD_ORDERING =
+      new Ordering<Field>() {
+        @Override
+        public int compare(Field left, Field right) {
+          return ComparisonChain.start()
+              .compare(left.getName(), right.getName())
+              .compare(left.getType(), right.getType(), CLASS_ORDERING)
+              .result();
+        }
+      };
+
+  /**
+   * An ordering suitable for comparing two methods if they are owned by the same class.
+   *
+   * <p>Within a single class it is sufficient to compare the non-generic method signature which
+   * consists of the name, return type and parameter types.
+   */
+  private static final Ordering<Method> METHOD_ORDERING =
+      new Ordering<Method>() {
+        @Override
+        public int compare(Method left, Method right) {
+          return ComparisonChain.start()
+              .compare(left.getName(), right.getName())
+              .compare(left.getReturnType(), right.getReturnType(), CLASS_ORDERING)
+              .compare(
+                  Arrays.asList(left.getParameterTypes()),
+                  Arrays.asList(right.getParameterTypes()),
+                  CLASS_ORDERING.lexicographical())
+              .result();
+        }
+      };
+}

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -16,6 +16,8 @@
 
 package com.google.inject.internal;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ArrayListMultimap;
@@ -151,14 +153,15 @@ final class InjectorImpl implements Injector, Lookups {
   @Override
   public <T> List<Binding<T>> findBindingsByType(TypeLiteral<T> type) {
     @SuppressWarnings("unchecked") // safe because we only put matching entries into the map
-    List<Binding<T>> list = (List<Binding<T>>) (List) bindingsMultimap.get(type);
+    List<Binding<T>> list =
+        (List<Binding<T>>) (List) bindingsMultimap.get(checkNotNull(type, "type"));
     return Collections.unmodifiableList(list);
   }
 
   /** Returns the binding for {@code key} */
   @Override
   public <T> BindingImpl<T> getBinding(Key<T> key) {
-    Errors errors = new Errors(key);
+    Errors errors = new Errors(checkNotNull(key, "key"));
     try {
       BindingImpl<T> result = getBindingOrThrow(key, errors, JitLimitation.EXISTING_JIT);
       errors.throwConfigurationExceptionIfErrorsExist();
@@ -171,7 +174,7 @@ final class InjectorImpl implements Injector, Lookups {
   @Override
   public <T> BindingImpl<T> getExistingBinding(Key<T> key) {
     // Check explicit bindings, i.e. bindings created by modules.
-    BindingImpl<T> explicitBinding = state.getExplicitBinding(key);
+    BindingImpl<T> explicitBinding = state.getExplicitBinding(checkNotNull(key, "key"));
     if (explicitBinding != null) {
       return explicitBinding;
     }
@@ -225,7 +228,7 @@ final class InjectorImpl implements Injector, Lookups {
 
   @Override
   public <T> Binding<T> getBinding(Class<T> type) {
-    return getBinding(Key.get(type));
+    return getBinding(Key.get(checkNotNull(type, "type")));
   }
 
   @Override
@@ -1031,6 +1034,7 @@ final class InjectorImpl implements Injector, Lookups {
 
   @Override
   public <T> MembersInjector<T> getMembersInjector(TypeLiteral<T> typeLiteral) {
+    checkNotNull(typeLiteral, "typeLiteral");
     Errors errors = new Errors(typeLiteral);
     try {
       return membersInjectorStore.get(typeLiteral, errors);
@@ -1046,7 +1050,7 @@ final class InjectorImpl implements Injector, Lookups {
 
   @Override
   public <T> Provider<T> getProvider(Class<T> type) {
-    return getProvider(Key.get(type));
+    return getProvider(Key.get(checkNotNull(type, "type")));
   }
 
   <T> Provider<T> getProviderOrThrow(final Dependency<T> dependency, Errors errors)
@@ -1081,6 +1085,7 @@ final class InjectorImpl implements Injector, Lookups {
 
   @Override
   public <T> Provider<T> getProvider(final Key<T> key) {
+    checkNotNull(key, "key");
     Errors errors = new Errors(key);
     try {
       Provider<T> result = getProviderOrThrow(Dependency.get(key), errors);

--- a/core/src/com/google/inject/internal/ProviderMethodsModule.java
+++ b/core/src/com/google/inject/internal/ProviderMethodsModule.java
@@ -107,7 +107,7 @@ public final class ProviderMethodsModule implements Module {
     // The highest class in the type hierarchy that contained a provider method definition.
     Class<?> superMostClass = delegate.getClass();
     for (Class<?> c = delegate.getClass(); c != Object.class; c = c.getSuperclass()) {
-      for (Method method : c.getDeclaredMethods()) {
+      for (Method method : DeclaredMembers.getDeclaredMethods(c)) {
         Annotation annotation = getAnnotation(binder, method);
         if (annotation != null) {
           if (result == null) {

--- a/pom.xml
+++ b/pom.xml
@@ -393,6 +393,10 @@ See the Apache License Version 2.0 for the specific language governing permissio
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.0.0</version>
+          <!--TODO(b/123646401): try out maven-javadoc-plugin 3.1.0 and see if source 8 can be removed then-->
+          <configuration>
+            <source>8</source>
+          </configuration>
           <executions>
             <execution>
               <phase>package</phase>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Ensure that we scan @Provides-like methods in a consistent ordering.  Previously we used the results of Class.getDeclaredMethods as-is, which can be non-deterministic from run to run on some JVMs.  This will allow some tests to have more stable behavior.

07b89d5ffa85bb2516978b0fefed4dc7b78eca4a

-------

<p> Add null checks earlier on in the injection stack.

7522acb4b44c0ac8175a1a831f511f1a55fd7248

-------

<p> Fix Javadoc breakage under JDK11 canary

38756fc46c7aef959ee2d6f9b68dd9651bd5f33e