### PR TITLE
Moe Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ cache:
 
 jdk:
   - oraclejdk11
-  - oraclejdk9
-  - oraclejdk8
+  - openjdk9
+  - openjdk8
 
 env:
   global:

--- a/core/src/com/google/inject/internal/ProviderMethod.java
+++ b/core/src/com/google/inject/internal/ProviderMethod.java
@@ -64,7 +64,10 @@ public abstract class ProviderMethod<T> extends InternalProviderInstanceBindingI
       Annotation annotation) {
     int modifiers = method.getModifiers();
     /*if[AOP]*/
-    if (!skipFastClassGeneration) {
+    if (!skipFastClassGeneration
+        // Protect against a bug in cglib where static interface methods were invoked with
+        // invokeinterface and not invokestatic. See https://github.com/cglib/cglib/pull/153
+        && instance != null) {
       try {
         net.sf.cglib.reflect.FastClass fc = BytecodeGen.newFastClassForMember(method);
         if (fc != null) {
@@ -220,7 +223,7 @@ public abstract class ProviderMethod<T> extends InternalProviderInstanceBindingI
     if (obj instanceof ProviderMethod) {
       ProviderMethod<?> o = (ProviderMethod<?>) obj;
       return method.equals(o.method)
-          && instance.equals(o.instance)
+          && Objects.equal(instance, o.instance)
           && annotation.equals(o.annotation);
     } else {
       return false;

--- a/core/src/com/google/inject/spi/Elements.java
+++ b/core/src/com/google/inject/spi/Elements.java
@@ -323,14 +323,14 @@ public final class Elements {
           // ModuleAnnotatedMethodScanner lets users scan their own modules for @Provides-like
           // bindings.  If they install the module at a top-level, then moduleSource can be null.
           // Also, if they pass something other than 'this' to it, we'd have the wrong source.
-          Object delegate = ((ProviderMethodsModule) module).getDelegateModule();
+          Class<?> delegateClass = ((ProviderMethodsModule) module).getDelegateModuleClass();
           if (moduleSource == null
-              || !moduleSource.getModuleClassName().equals(delegate.getClass().getName())) {
-            moduleSource = getModuleSource(delegate);
+              || !moduleSource.getModuleClassName().equals(delegateClass.getName())) {
+            moduleSource = getModuleSource(delegateClass);
             unwrapModuleSource = true;
           }
         } else {
-          moduleSource = getModuleSource(module);
+          moduleSource = getModuleSource(module.getClass());
           unwrapModuleSource = true;
         }
         boolean skipScanning = false;
@@ -514,7 +514,7 @@ public final class Elements {
       return builder;
     }
 
-    private ModuleSource getModuleSource(Object module) {
+    private ModuleSource getModuleSource(Class<?> module) {
       StackTraceElement[] partialCallStack;
       if (getIncludeStackTraceOption() == IncludeStackTraceOption.COMPLETE) {
         partialCallStack = getPartialCallStack(new Throwable().getStackTrace());

--- a/core/src/com/google/inject/spi/ModuleAnnotatedMethodScanner.java
+++ b/core/src/com/google/inject/spi/ModuleAnnotatedMethodScanner.java
@@ -39,9 +39,9 @@ public abstract class ModuleAnnotatedMethodScanner {
   /**
    * Prepares a method for binding. This {@code key} parameter is the key discovered from looking at
    * the binding annotation and return value of the method. Implementations can modify the key to
-   * instead bind to another key. For example, Multibinder may want to change {@code @SetProvides
-   * String provideFoo()} to bind into a unique Key within the multibinder instead of binding {@code
-   * String}.
+   * instead bind to another key. For example, Multibinder may want to change
+   * {@code @ProvidesIntoSet String provideFoo()} to bind into a unique Key within the multibinder
+   * instead of binding {@code String}.
    *
    * <p>The injection point and annotation are provided in case the implementation wants to set the
    * key based on the property of the annotation or if any additional preparation is needed for any

--- a/core/src/com/google/inject/spi/ModuleSource.java
+++ b/core/src/com/google/inject/spi/ModuleSource.java
@@ -47,30 +47,32 @@ final class ModuleSource {
   /**
    * Creates a new {@link ModuleSource} with a {@literal null} parent.
    *
-   * @param module the corresponding module
+   * @param moduleClass the corresponding module
    * @param partialCallStack the chunk of call stack that starts from the parent module {@link
    *     Module#configure(Binder) configure(Binder)} call and ends just before the module {@link
    *     Module#configure(Binder) configure(Binder)} method invocation
    */
-  ModuleSource(Object module, StackTraceElement[] partialCallStack) {
-    this(null, module, partialCallStack);
+  ModuleSource(Class<?> moduleClass, StackTraceElement[] partialCallStack) {
+    this(null, moduleClass, partialCallStack);
   }
 
   /**
    * Creates a new {@link ModuleSource} Object.
    *
    * @param parent the parent module {@link ModuleSource source}
-   * @param module the corresponding module
+   * @param moduleClass the corresponding module
    * @param partialCallStack the chunk of call stack that starts from the parent module {@link
    *     Module#configure(Binder) configure(Binder)} call and ends just before the module {@link
    *     Module#configure(Binder) configure(Binder)} method invocation
    */
   private ModuleSource(
-      /* @Nullable */ ModuleSource parent, Object module, StackTraceElement[] partialCallStack) {
-    Preconditions.checkNotNull(module, "module cannot be null.");
+      /* @Nullable */ ModuleSource parent,
+      Class<?> moduleClass,
+      StackTraceElement[] partialCallStack) {
+    Preconditions.checkNotNull(moduleClass, "module cannot be null.");
     Preconditions.checkNotNull(partialCallStack, "partialCallStack cannot be null.");
     this.parent = parent;
-    this.moduleClassName = module.getClass().getName();
+    this.moduleClassName = moduleClass.getName();
     this.partialCallStack = StackTraceElements.convertToInMemoryStackTraceElement(partialCallStack);
   }
 
@@ -101,13 +103,13 @@ final class ModuleSource {
   /**
    * Creates and returns a child {@link ModuleSource} corresponding to the {@link Module module}.
    *
-   * @param module the corresponding module
+   * @param moduleClass the corresponding module
    * @param partialCallStack the chunk of call stack that starts from the parent module {@link
    *     Module#configure(Binder) configure(Binder)} call and ends just before the module {@link
    *     Module#configure(Binder) configure(Binder)} method invocation
    */
-  ModuleSource createChild(Object module, StackTraceElement[] partialCallStack) {
-    return new ModuleSource(this, module, partialCallStack);
+  ModuleSource createChild(Class<?> moduleClass, StackTraceElement[] partialCallStack) {
+    return new ModuleSource(this, moduleClass, partialCallStack);
   }
 
   /** Returns the parent module {@link ModuleSource source}. */

--- a/core/test/com/google/inject/spi/ElementSourceTest.java
+++ b/core/test/com/google/inject/spi/ElementSourceTest.java
@@ -128,14 +128,14 @@ public class ElementSourceTest extends TestCase {
     // First module
     StackTraceElement[] partialCallStack = new StackTraceElement[1];
     partialCallStack[0] = BINDER_INSTALL;
-    ModuleSource moduleSource = new ModuleSource(new A(), partialCallStack);
+    ModuleSource moduleSource = new ModuleSource(A.class, partialCallStack);
     // Second module
     partialCallStack = new StackTraceElement[2];
     partialCallStack[0] = BINDER_INSTALL;
     partialCallStack[1] =
         new StackTraceElement(
             "com.google.inject.spi.moduleSourceTest$A", "configure", "Unknown Source", 100);
-    moduleSource = moduleSource.createChild(new B(), partialCallStack);
+    moduleSource = moduleSource.createChild(B.class, partialCallStack);
     // Third module
     partialCallStack = new StackTraceElement[4];
     partialCallStack[0] = BINDER_INSTALL;
@@ -144,7 +144,7 @@ public class ElementSourceTest extends TestCase {
     partialCallStack[3] =
         new StackTraceElement(
             "com.google.inject.spi.moduleSourceTest$B", "configure", "Unknown Source", 200);
-    return moduleSource.createChild(new C(), partialCallStack);
+    return moduleSource.createChild(C.class, partialCallStack);
   }
 
   private static class A extends AbstractModule {

--- a/core/test/com/google/inject/spi/ModuleSourceTest.java
+++ b/core/test/com/google/inject/spi/ModuleSourceTest.java
@@ -81,7 +81,7 @@ public class ModuleSourceTest extends TestCase {
   private ModuleSource createWithSizeOne() {
     StackTraceElement[] partialCallStack = new StackTraceElement[1];
     partialCallStack[0] = BINDER_INSTALL;
-    return new ModuleSource(new A(), partialCallStack);
+    return new ModuleSource(A.class, partialCallStack);
   }
 
   private ModuleSource createWithSizeTwo() {
@@ -91,7 +91,7 @@ public class ModuleSourceTest extends TestCase {
     partialCallStack[1] =
         new StackTraceElement(
             "com.google.inject.spi.moduleSourceTest$A", "configure", "moduleSourceTest.java", 100);
-    return moduleSource.createChild(new B(), partialCallStack);
+    return moduleSource.createChild(B.class, partialCallStack);
   }
 
   private ModuleSource createWithSizeThree() {
@@ -103,7 +103,7 @@ public class ModuleSourceTest extends TestCase {
     partialCallStack[3] =
         new StackTraceElement(
             "com.google.inject.spi.moduleSourceTest$B", "configure", "moduleSourceTest.java", 200);
-    return moduleSource.createChild(new C(), partialCallStack);
+    return moduleSource.createChild(C.class, partialCallStack);
   }
 
   private static class A extends AbstractModule {

--- a/extensions/dagger-adapter/pom.xml
+++ b/extensions/dagger-adapter/pom.xml
@@ -17,6 +17,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.google.dagger</groupId>
+      <artifactId>dagger-producers</artifactId>
+      <version>2.22.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <scope>test</scope>

--- a/extensions/dagger-adapter/pom.xml
+++ b/extensions/dagger-adapter/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -13,7 +13,8 @@
     <dependency>
       <groupId>com.google.dagger</groupId>
       <artifactId>dagger</artifactId>
-      <version>2.4</version>
+      <version>2.22.1</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>

--- a/extensions/dagger-adapter/pom.xml
+++ b/extensions/dagger-adapter/pom.xml
@@ -15,6 +15,11 @@
       <artifactId>dagger</artifactId>
       <version>2.4</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
+++ b/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
@@ -16,6 +16,7 @@
 package com.google.inject.daggeradapter;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.internal.ProviderMethodsModule;
@@ -59,7 +60,7 @@ public final class DaggerAdapter {
    */
   public static Module from(Object... daggerModuleObjects) {
     // TODO(cgruber): Gather injects=, dedupe, factor out instances, instantiate the rest, and go.
-    return new DaggerCompatibilityModule(daggerModuleObjects);
+    return new DaggerCompatibilityModule(ImmutableList.copyOf(daggerModuleObjects));
   }
 
   /**
@@ -68,9 +69,9 @@ public final class DaggerAdapter {
    * ModuleAnnotatedMethodScanner}.
    */
   private static final class DaggerCompatibilityModule implements Module {
-    private final Object[] daggerModuleObjects;
+    private final ImmutableList<Object> daggerModuleObjects;
 
-    private DaggerCompatibilityModule(Object... daggerModuleObjects) {
+    private DaggerCompatibilityModule(ImmutableList<Object> daggerModuleObjects) {
       this.daggerModuleObjects = daggerModuleObjects;
     }
 

--- a/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
+++ b/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
@@ -91,10 +91,20 @@ public final class DaggerAdapter {
     public void configure(Binder binder) {
       binder = binder.skipSources(getClass());
       for (Object module : daggerModuleObjects) {
+        checkIsDaggerModule(module, binder);
         validateNoSubcomponents(binder, module);
+        checkUnsupportedDaggerAnnotations(module, binder);
 
         binder.install(ProviderMethodsModule.forModule(module, DaggerMethodScanner.INSTANCE));
-        checkUnsupportedDaggerAnnotations(module, binder);
+      }
+    }
+
+    private void checkIsDaggerModule(Object module, Binder binder) {
+      Class<?> moduleClass = module instanceof Class ? (Class<?>) module : module.getClass();
+      if (!moduleClass.isAnnotationPresent(dagger.Module.class)) {
+        binder
+            .skipSources(getClass())
+            .addError("%s must be annotated with @dagger.Module", moduleClass.getCanonicalName());
       }
     }
 

--- a/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
+++ b/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
@@ -35,23 +35,28 @@ import java.util.Arrays;
  * <p>Simple example:
  *
  * <pre>{@code
- * Guice.createInjector(...other modules..., DaggerAdapter.from(new SomeDaggerAdapter()));
+ * Guice.createInjector(
+ *   DaggerAdapter.from(SomeDaggerModule.class, new AnotherModuleWithConstructor());
  * }</pre>
+ *
+ * <p>For modules with no instance binding methods, prefer using a class literal. If there are
+ * instance binding methods, an instance of the module must be passed.
  *
  * <p>Some notes on usage and compatibility.
  *
  * <ul>
- * <li>Dagger provider methods have a "SET_VALUES" provision mode not supported by Guice.
- * <li>MapBindings are not yet implemented (pending).
- * <li>Be careful about stateful modules. In contrast to Dagger (where components are expected to be
- *     recreated on-demand with new Module instances), Guice typically has a single injector with a
- *     long lifetime, so your module instance will be used throughout the lifetime of the entire
- *     app.
- * <li>Dagger 1.x uses {@link @Singleton} for all scopes, including shorter-lived scopes like
- *     per-request or per-activity. Using modules written with Dagger 1.x usage in mind may result
- *     in mis-scoped objects.
- * <li>Dagger 2.x supports custom scope annotations, but for use in Guice, a custom scope
- *     implementation must be registered in order to support the custom lifetime of that annotation.
+ *   <li>Dagger provider methods have a "SET_VALUES" provision mode not supported by Guice.
+ *   <li>MapBindings are not yet implemented (pending).
+ *   <li>Be careful about stateful modules. In contrast to Dagger (where components are expected to
+ *       be recreated on-demand with new Module instances), Guice typically has a single injector
+ *       with a long lifetime, so your module instance will be used throughout the lifetime of the
+ *       entire app.
+ *   <li>Dagger 1.x uses {@link @Singleton} for all scopes, including shorter-lived scopes like
+ *       per-request or per-activity. Using modules written with Dagger 1.x usage in mind may result
+ *       in mis-scoped objects.
+ *   <li>Dagger 2.x supports custom scope annotations, but for use in Guice, a custom scope
+ *       implementation must be registered in order to support the custom lifetime of that
+ *       annotation.
  * </ul>
  *
  * @author cgruber@google.com (Christian Gruber)

--- a/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
+++ b/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
@@ -25,7 +25,6 @@ import com.google.inject.internal.ProviderMethodsModule;
 import com.google.inject.spi.ModuleAnnotatedMethodScanner;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 
 /**
  * A utility to adapt classes annotated with {@link @dagger.Module} such that their
@@ -119,9 +118,7 @@ public final class DaggerAdapter {
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("modules", Arrays.asList(daggerModuleObjects))
-          .toString();
+      return MoreObjects.toStringHelper(this).add("modules", daggerModuleObjects).toString();
     }
   }
 

--- a/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerMethodScanner.java
+++ b/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerMethodScanner.java
@@ -23,7 +23,6 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.ModuleAnnotatedMethodScanner;
 import dagger.Provides;
-import dagger.Provides.Type;
 import dagger.multibindings.IntoSet;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -53,19 +52,7 @@ final class DaggerMethodScanner extends ModuleAnnotatedMethodScanner {
       return processSetBinding(binder, key);
     }
 
-    switch (annotation.type()) {
-      case UNIQUE:
-        return key;
-      case SET:
-        return processSetBinding(binder, key);
-      case SET_VALUES:
-        binder.addError(
-            Type.SET_VALUES.name() + " contributions are not supported by Guice.", providesMethod);
-        return key;
-      default:
-        binder.addError("Unknown @Provides type " + annotation.type() + ".", providesMethod);
-        return key;
-    }
+    return key;
   }
 
   private static <T> Key<T> processSetBinding(Binder binder, Key<T> key) {

--- a/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerMethodScanner.java
+++ b/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerMethodScanner.java
@@ -24,8 +24,6 @@ import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.ModuleAnnotatedMethodScanner;
 import dagger.Provides;
 import dagger.Provides.Type;
-import dagger.multibindings.ElementsIntoSet;
-import dagger.multibindings.IntoMap;
 import dagger.multibindings.IntoSet;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -53,13 +51,6 @@ final class DaggerMethodScanner extends ModuleAnnotatedMethodScanner {
     Provides annotation = (Provides) rawAnnotation;
     if (providesMethod.isAnnotationPresent(IntoSet.class)) {
       return processSetBinding(binder, key);
-    } else if (providesMethod.isAnnotationPresent(ElementsIntoSet.class)) {
-      binder.addError("@ElementsIntoSet contributions are not suppored by Guice.", providesMethod);
-      return key;
-    } else if (providesMethod.isAnnotationPresent(IntoMap.class)) {
-      /* TODO(cgruber) implement map bindings */
-      binder.addError("Map bindings are not yet supported.");
-      return key;
     }
 
     switch (annotation.type()) {

--- a/extensions/dagger-adapter/test/com/google/inject/daggeradapter/DaggerAdapterTest.java
+++ b/extensions/dagger-adapter/test/com/google/inject/daggeradapter/DaggerAdapterTest.java
@@ -219,4 +219,34 @@ public class DaggerAdapterTest extends TestCase {
                   + " passed. Make this method static or pass an instance of the module instead.");
     }
   }
+
+  public void testModuleObjectsMustBeDaggerModules() {
+    try {
+      Guice.createInjector(DaggerAdapter.from(new Object()));
+      fail();
+    } catch (CreationException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .contains("Object must be annotated with @dagger.Module");
+    }
+  }
+
+  @dagger.producers.ProducerModule
+  static class ProducerModuleWithProvidesMethod {
+    @dagger.Provides
+    int i() {
+      return 1;
+    }
+  }
+
+  public void testProducerModulesNotSupported() {
+    try {
+      Guice.createInjector(DaggerAdapter.from(new ProducerModuleWithProvidesMethod()));
+      fail();
+    } catch (CreationException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .contains("ProducerModuleWithProvidesMethod must be annotated with @dagger.Module");
+    }
+  }
 }

--- a/extensions/dagger-adapter/test/com/google/inject/daggeradapter/ModuleSubcomponentsTest.java
+++ b/extensions/dagger-adapter/test/com/google/inject/daggeradapter/ModuleSubcomponentsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.inject.daggeradapter;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.inject.CreationException;
+import com.google.inject.Guice;
+import dagger.Module;
+import dagger.Subcomponent;
+import junit.framework.TestCase;
+
+/** Tests for {@code @Module(subcomponents = Foo.class)} */
+
+public class ModuleSubcomponentsTest extends TestCase {
+
+  @Module(subcomponents = TestSubcomponent.class)
+  static class ModuleWithSubcomponents {}
+
+  @Subcomponent
+  interface TestSubcomponent {
+    @Subcomponent.Builder
+    interface Builder {
+      TestSubcomponent build();
+    }
+  }
+
+  public void testModuleSubcomponentsNotSupported() {
+    try {
+      Guice.createInjector(DaggerAdapter.from(ModuleWithSubcomponents.class));
+      fail();
+    } catch (CreationException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .contains("Subcomponents cannot be configured for modules used with DaggerAdapter");
+      assertThat(expected).hasMessageThat().contains("ModuleWithSubcomponents specifies: ");
+      assertThat(expected).hasMessageThat().contains("TestSubcomponent");
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -154,12 +154,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>7.0</version>
+        <version>7.1</version>
       </dependency>
       <dependency>
         <groupId>cglib</groupId>
         <artifactId>cglib</artifactId>
-        <version>3.2.9</version>
+        <version>3.2.12</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix @ProvidesIntoSet reference

e2d7db78bc1b9a4f4b2925d902320c54d395ecb7

-------

<p> Create an immutable snapshot of the modules provided to DaggerAdapter.from

57bfb02d9ccfce0ca6be41ed6d34c572a0f0cf49

-------

<p> Validate that no unsupported annotations exist on modules from DaggerAdapter usages

b8e70ba02046a3dd2b2ad55b5e7fe6479cb83ca9

-------

<p> change to openjdk8/9 since travis likes those better now.

d42adbe71cc710625f6555ae5d5deba79de942ad

-------

<p> Add support for passing class literals to DaggerAdapter (and therefore ProviderMethodsModule).

This allows static @Provides methods to work correctly for interface modules. static @Provides + interface is not a huge win, but similar support will be necessary when we add support for abstract binding methods.

This temporarily avoids using FastClass for static methods when a class literal is passed due to a bug in cglib. https://github.com/cglib/cglib/pull/153 is out to fix that, at which point we can enable FastClass support as usual.

0b77bc04a93491a245c367eda6143ef4caa9a315

-------

<p> No longer use Arrays.asList() now that we're using an ImmutableList

e0470189b524cd992b174edd7f39f9f91c2892e5

-------

<p> Compile against the newest version of Dagger for dagger-adapter, and make it optional so that users must bring their own version of dagger.

1bb06a11aef0925a0760dd4331e5a9bb74ed447f

-------

<p> Ban @Module(subcomponents) from DaggerAdapter until we properly support it

Supporting it correctly requires a fair amount of thought - Guice and Dagger scopes are different, multibindings are different, and implementing subcomponent factories+builders would be non-trivial. (We could possibly take advantage of child injectors to help?) Anyway, there's more to considered before traversing down this path.

fd95e8fa9cbb8f76f3669111fad6eb82c9c299a7

-------

<p> update the opensource asm to 7.1 & cglib to 3.2.12.

25979192a9f02e6da612fcdcafb68e4332a51103

-------

<p> Validate that all modules passed to DaggerAdapter are in fact Dagger modules

16e647d5e7e3252249e884f565f3199542731ee7