### PR TITLE
Moe Sync

### DIFF
--- a/extensions/testlib/src/com/google/inject/testing/throwingproviders/CheckedProviderSubject.java
+++ b/extensions/testlib/src/com/google/inject/testing/throwingproviders/CheckedProviderSubject.java
@@ -37,8 +37,11 @@ public final class CheckedProviderSubject<T, P extends CheckedProvider<T>>
     return assertAbout(CheckedProviderSubject.<T, P>checkedProviders()).that(provider);
   }
 
+  private final P actual;
+
   private CheckedProviderSubject(FailureMetadata failureMetadata, @Nullable P subject) {
     super(failureMetadata, subject);
+    this.actual = subject;
   }
 
   /**
@@ -50,7 +53,7 @@ public final class CheckedProviderSubject<T, P extends CheckedProvider<T>>
    * @return a {@link Subject} for asserting against the return value of {@link CheckedProvider#get}
    */
   public Subject<?, Object> providedValue() {
-    P provider = actual();
+    P provider = actual;
     T got;
     try {
       got = provider.get();
@@ -71,7 +74,7 @@ public final class CheckedProviderSubject<T, P extends CheckedProvider<T>>
    *     CheckedProvider#get}
    */
   public ThrowableSubject thrownException() {
-    P provider = actual();
+    P provider = actual;
     T got;
     try {
       got = provider.get();
@@ -103,8 +106,11 @@ public final class CheckedProviderSubject<T, P extends CheckedProvider<T>>
 
   private static final class UnexpectedFailureSubject
       extends Subject<UnexpectedFailureSubject, Throwable> {
+    private final Throwable actual;
+
     UnexpectedFailureSubject(FailureMetadata metadata, @Nullable Throwable actual) {
       super(metadata, actual);
+      this.actual = actual;
     }
 
     void doFail(String format, Object... args) {

--- a/extensions/testlib/test/com/google/inject/testing/throwingproviders/CheckedProviderSubjectTest.java
+++ b/extensions/testlib/test/com/google/inject/testing/throwingproviders/CheckedProviderSubjectTest.java
@@ -38,8 +38,11 @@ public class CheckedProviderSubjectTest {
     CheckedProvider<String> provider = CheckedProviders.of(StringCheckedProvider.class, unexpected);
     String message =
         String.format(
-            "value provided by <%s>\nexpected: %s\nbut was : %s",
-            getReturningProviderName(unexpected), expected, unexpected);
+            "value of           : checkedProvider.get()\n"
+                + "expected           : %s\n"
+                + "but was            : %s\n"
+                + "checkedProvider was: %s",
+            expected, unexpected, getReturningProviderName(unexpected));
 
     expectWhenTesting().that(provider).providedValue().isEqualTo(expected);
     assertThat(expect.getFailure()).hasMessageThat().isEqualTo(message);
@@ -53,7 +56,9 @@ public class CheckedProviderSubjectTest {
         CheckedProviders.throwing(StringCheckedProvider.class, SummerException.class);
     String message =
         String.format(
-            "checked provider <%s> threw an exception",
+            "value of           : checkedProvider.get()\n"
+                + "checked provider was not expected to throw an exception\n"
+                + "checkedProvider was: %s",
             getThrowingProviderName(SummerException.class.getName()));
 
     expectWhenTesting().that(provider).providedValue();
@@ -78,14 +83,15 @@ public class CheckedProviderSubjectTest {
         CheckedProviders.throwing(StringCheckedProvider.class, unexpected);
     String message =
         String.format(
-            "exception thrown by <%s>\n"
+            "value of            : checkedProvider.get()'s exception\n"
                 + "expected instance of: %s\n"
                 + "but was instance of : %s\n"
-                + "with value          : %s",
-            getThrowingProviderName(UnsupportedOperationException.class.getName()),
+                + "with value          : %s\n"
+                + "checkedProvider was : %s",
             SummerException.class.getName(),
             UnsupportedOperationException.class.getName(),
-            UnsupportedOperationException.class.getName());
+            UnsupportedOperationException.class.getName(),
+            getThrowingProviderName(UnsupportedOperationException.class.getName()));
 
     expectWhenTesting().that(provider).thrownException().isInstanceOf(expected);
     assertThat(expect.getFailure()).hasMessageThat().isEqualTo(message);
@@ -95,10 +101,7 @@ public class CheckedProviderSubjectTest {
   public void thrownException_gets_expectFailure() {
     String getValue = "keep WINTER IS COMING safe";
     CheckedProvider<String> provider = CheckedProviders.of(StringCheckedProvider.class, getValue);
-    String message =
-        String.format(
-            "Not true that <%s> threw <an exception>. It provided <%s>",
-            getReturningProviderName(getValue), getValue);
+    String message = String.format("expected to throw\nbut provided: %s", getValue);
 
     expectWhenTesting().that(provider).thrownException();
     assertThat(expect.getFailure()).hasMessageThat().isEqualTo(message);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Instead of calling Subject.actual(), store the actual value in a field, and read that.

actual() is being removed.

9874c37f798dc46641acebf5932d9a85d6cf6e35

-------

<p> Migrate Truth Subjects from no-arg check() to the overload that accepts a description.

The overload that accepts a description generally produces better failure messages:
- The first line of the message it produces is something like: "value of: myProto.getResponse()" (where "getResponse()" is taken from the provided description)
- The last line of the message it produces is something like: "myProto was: response: query was throttled" (the full value of myProto)
- And the existing text goes in between.

Additional motivation: We are deleting the no-arg overload externally (and probably internally thereafter).

e74ca8bfdbc94285b6346fb198590c5f92a5128f