### PR TITLE
Moe Sync

### DIFF
--- a/core/src/com/google/inject/internal/InternalInjectorCreator.java
+++ b/core/src/com/google/inject/internal/InternalInjectorCreator.java
@@ -230,10 +230,11 @@ public final class InternalInjectorCreator {
 
     // handle a corner case where a child injector links to a binding in a parent injector, and
     // that binding is singleton. We won't catch this otherwise because we only iterate the child's
-    // bindings.
+    // bindings. This only applies if the linked binding is not itself scoped.
     if (binding instanceof LinkedBindingImpl) {
       Key<?> linkedBinding = ((LinkedBindingImpl<?>) binding).getLinkedKey();
-      return isEagerSingleton(injector, injector.getBinding(linkedBinding), stage);
+      return binding.getScoping().isNoScope()
+          && isEagerSingleton(injector, injector.getBinding(linkedBinding), stage);
     }
 
     return false;

--- a/core/test/com/google/inject/ScopesTest.java
+++ b/core/test/com/google/inject/ScopesTest.java
@@ -1340,4 +1340,40 @@ public class ScopesTest extends TestCase {
                   }
                 }));
   }
+
+  public void testScopedLinkedBindingDoesNotPropagateEagerSingleton() {
+    final Key<String> a = Key.get(String.class, named("A"));
+    final Key<String> b = Key.get(String.class, named("B"));
+
+    final Scope notInScopeScope =
+        new Scope() {
+          @Override
+          public <T> Provider<T> scope(Key<T> key, Provider<T> unscoped) {
+            return new Provider<T>() {
+              @Override
+              public T get() {
+                throw new IllegalStateException("Not in scope");
+              }
+            };
+          }
+        };
+
+    Module module =
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(a).toInstance("a");
+            bind(b).to(a).in(CustomScoped.class);
+            bindScope(CustomScoped.class, notInScopeScope);
+          }
+        };
+
+    Injector injector = Guice.createInjector(module);
+    Provider<String> bProvider = injector.getProvider(b);
+    try {
+      bProvider.get();
+      fail("expected failure");
+    } catch (ProvisionException expected) {
+    }
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix a subtle bug in Guice eager singleton evaluation. Add a test.

A linked binding should only be treated as an eager singleton if the target binding is eager singleton *and* the source binding is unscoped. If the source binding is scoped, it may be a scope with context constraints (such as @RequestScoped) that shouldn't be evaluated during injector creation.

Bug repro:
bind(Key1).toInstance(<something>)
bind(Key2).to(Key1).in(RequestScoped.class);

f7c1a9698d63dd298590731d1ad61e976ff70f7c