### PR TITLE
Moe Sync

### DIFF
--- a/core/src/com/google/inject/Binder.java
+++ b/core/src/com/google/inject/Binder.java
@@ -128,7 +128,7 @@ import java.lang.reflect.Method;
  *     bindConstant().annotatedWith(ServerHost.class).to(args[0]);</pre>
  *
  * Sets up a constant binding. Constant injections must always be annotated. When a constant
- * binding's value is a string, it is eligile for conversion to all primitive types, to {@link
+ * binding's value is a string, it is eligible for conversion to all primitive types, to {@link
  * Enum#valueOf(Class, String) all enums}, and to {@link Class#forName class literals}. Conversions
  * for other types can be configured using {@link #convertToTypes(Matcher, TypeConverter)
  * convertToTypes()}.

--- a/extensions/testlib/src/com/google/inject/testing/throwingproviders/CheckedProviderSubject.java
+++ b/extensions/testlib/src/com/google/inject/testing/throwingproviders/CheckedProviderSubject.java
@@ -15,8 +15,7 @@ import javax.annotation.Nullable;
  *
  * @author eatnumber1@google.com (Russ Harmon)
  */
-public final class CheckedProviderSubject<T, P extends CheckedProvider<T>>
-    extends Subject<CheckedProviderSubject<T, P>, P> {
+public final class CheckedProviderSubject<T, P extends CheckedProvider<T>> extends Subject {
 
   private static final class CheckedProviderSubjectFactory<T, P extends CheckedProvider<T>>
       implements Subject.Factory<CheckedProviderSubject<T, P>, P> {
@@ -52,7 +51,7 @@ public final class CheckedProviderSubject<T, P extends CheckedProvider<T>>
    *
    * @return a {@link Subject} for asserting against the return value of {@link CheckedProvider#get}
    */
-  public Subject<?, Object> providedValue() {
+  public Subject providedValue() {
     T got;
     try {
       got = provider.get();
@@ -102,8 +101,7 @@ public final class CheckedProviderSubject<T, P extends CheckedProvider<T>>
     };
   }
 
-  private static final class UnexpectedFailureSubject
-      extends Subject<UnexpectedFailureSubject, Throwable> {
+  private static final class UnexpectedFailureSubject extends Subject {
     UnexpectedFailureSubject(FailureMetadata metadata, @Nullable Throwable actual) {
       super(metadata, actual);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
       <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
-        <version>0.44</version>
+        <version>0.45</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update to Truth 0.45, and address deprecations.

Renames may include:
- containsAllOf => containsAtLeast
- containsAllIn => containsAtLeastElementsIn
- isSameAs => isSameInstanceAs
- isOrdered => isInOrder
- isStrictlyOrdered => isInStrictOrder

The other major change is to change custom subjects to extend raw Subject instead of supplying type parameters. The type parameters are being removed from Subject. This CL will temporarily produce rawtypes warnings, which will go away when I remove the type parameters (as soon as this batch of CLs is submitted).

Some CLs in this batch also migrate calls away from actualAsString(). Its literal replacement is `"<" + actual + ">"` (unless an object overrides actualCustomStringRepresentation()), but usually I've made a larger change, such as switching from an old-style "Not true that..." failure message to one generated with the Fact API. In that case, the new code usually contains a direct reference to this.actual (a field that I occasionally had to create). Another larger change I sometimes made is to switch from a manual check-and-fail approach to instead use check(...). And sometimes I just remove a withMessage() call that's no longer necessary now that the code uses check(...), or I introduce a check(...) call. (An assertion made with check(...) automatically includes the actual value from the original subject, so there's no need to set it again with withMessage().)

Finally, there's one CL in this batch in which I migrate a Correspondence subclass to instead use Correspondence.from.

ea5391e83f4d3fd1ad160555cb3c6d42c0097d54

-------

<p> Fix typo in Binder javadoc.

65bc860dbe6cc92d88b471f8581a57a8dbe649e5