### PR TITLE
Moe Sync

### DIFF
--- a/extensions/dagger-adapter/pom.xml
+++ b/extensions/dagger-adapter/pom.xml
@@ -27,6 +27,18 @@
       <artifactId>truth</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+      <version>1.6.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <version>1.6.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
+++ b/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
@@ -74,7 +74,6 @@ import java.util.Set;
 public final class DaggerAdapter {
   /** Creates a new {@link DaggerAdapter} from {@code daggerModuleObjects}. */
   public static Module from(Object... daggerModuleObjects) {
-    // TODO(cgruber): Gather injects=, dedupe, factor out instances, instantiate the rest, and go.
     return new DaggerCompatibilityModule(ImmutableList.copyOf(daggerModuleObjects));
   }
 

--- a/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
+++ b/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerAdapter.java
@@ -17,7 +17,7 @@ package com.google.inject.daggeradapter;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getFirst;
-import static com.google.inject.daggeradapter.SupportedAnnotations.allSupportedAnnotations;
+import static com.google.inject.daggeradapter.SupportedAnnotations.isAnnotationSupported;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
@@ -116,7 +116,7 @@ public final class DaggerAdapter {
         for (Annotation annotation : method.getAnnotations()) {
           Class<? extends Annotation> annotationClass = annotation.annotationType();
           if (annotationClass.getName().startsWith("dagger.")
-              && !allSupportedAnnotations().contains(annotationClass)) {
+              && !isAnnotationSupported(annotationClass)) {
             binder.addError(
                 "%s is annotated with @%s which is not supported by DaggerAdapter",
                 method, annotationClass.getCanonicalName());

--- a/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerMethodScanner.java
+++ b/extensions/dagger-adapter/src/com/google/inject/daggeradapter/DaggerMethodScanner.java
@@ -18,6 +18,7 @@ package com.google.inject.daggeradapter;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.inject.daggeradapter.Annotations.getAnnotatedAnnotation;
 import static com.google.inject.daggeradapter.Keys.parameterKey;
+import static com.google.inject.daggeradapter.SupportedAnnotations.supportedBindingAnnotations;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -62,12 +63,9 @@ final class DaggerMethodScanner extends ModuleAnnotatedMethodScanner {
    */
   static final DaggerMethodScanner INSTANCE = new DaggerMethodScanner();
 
-  private static final ImmutableSet<Class<? extends Annotation>> ANNOTATIONS =
-      ImmutableSet.of(Provides.class, Binds.class, Multibinds.class, BindsOptionalOf.class);
-
   @Override
-  public Set<? extends Class<? extends Annotation>> annotationClasses() {
-    return ANNOTATIONS;
+  public ImmutableSet<Class<? extends Annotation>> annotationClasses() {
+    return supportedBindingAnnotations();
   }
 
   @Override

--- a/extensions/dagger-adapter/src/com/google/inject/daggeradapter/SupportedAnnotations.java
+++ b/extensions/dagger-adapter/src/com/google/inject/daggeradapter/SupportedAnnotations.java
@@ -1,0 +1,31 @@
+package com.google.inject.daggeradapter;
+
+import com.google.common.collect.ImmutableSet;
+import dagger.Binds;
+import dagger.BindsOptionalOf;
+import dagger.Provides;
+import dagger.multibindings.IntoSet;
+import dagger.multibindings.Multibinds;
+import java.lang.annotation.Annotation;
+
+/** Collections of annotations that are supported by {@link DaggerAdapter}. */
+final class SupportedAnnotations {
+  private static final ImmutableSet<Class<? extends Annotation>> BINDING_ANNOTATIONS =
+      ImmutableSet.of(Provides.class, Binds.class, Multibinds.class, BindsOptionalOf.class);
+
+  private static final ImmutableSet<Class<? extends Annotation>> ALL_SUPPORTED_ANNOTATIONS =
+      ImmutableSet.<Class<? extends Annotation>>builder()
+          .addAll(BINDING_ANNOTATIONS)
+          .add(IntoSet.class)
+          .build();
+
+  /** Returns all binding annotations supported by {@link DaggerAdapter}. */
+  static ImmutableSet<Class<? extends Annotation>> supportedBindingAnnotations() {
+    return BINDING_ANNOTATIONS;
+  }
+
+  /** Returns all annotations from dagger packages that are supported by {@link DaggerAdapter}. */
+  static ImmutableSet<Class<? extends Annotation>> allSupportedAnnotations() {
+    return ALL_SUPPORTED_ANNOTATIONS;
+  }
+}

--- a/extensions/dagger-adapter/src/com/google/inject/daggeradapter/SupportedAnnotations.java
+++ b/extensions/dagger-adapter/src/com/google/inject/daggeradapter/SupportedAnnotations.java
@@ -3,7 +3,9 @@ package com.google.inject.daggeradapter;
 import com.google.common.collect.ImmutableSet;
 import dagger.Binds;
 import dagger.BindsOptionalOf;
+import dagger.MapKey;
 import dagger.Provides;
+import dagger.multibindings.IntoMap;
 import dagger.multibindings.IntoSet;
 import dagger.multibindings.Multibinds;
 import java.lang.annotation.Annotation;
@@ -17,6 +19,8 @@ final class SupportedAnnotations {
       ImmutableSet.<Class<? extends Annotation>>builder()
           .addAll(BINDING_ANNOTATIONS)
           .add(IntoSet.class)
+          .add(IntoMap.class)
+          // TODO(ronshapiro): should we support (and automatically bind?) dagger.Reusable?
           .build();
 
   /** Returns all binding annotations supported by {@link DaggerAdapter}. */
@@ -24,8 +28,14 @@ final class SupportedAnnotations {
     return BINDING_ANNOTATIONS;
   }
 
-  /** Returns all annotations from dagger packages that are supported by {@link DaggerAdapter}. */
-  static ImmutableSet<Class<? extends Annotation>> allSupportedAnnotations() {
-    return ALL_SUPPORTED_ANNOTATIONS;
+  /**
+   * Returns true if {@code annotation} is in a dagger package and is supported by {@link
+   * DaggerAdapter}.
+   */
+  static boolean isAnnotationSupported(Class<? extends Annotation> annotation) {
+    if (ALL_SUPPORTED_ANNOTATIONS.contains(annotation)) {
+      return true;
+    }
+    return annotation.isAnnotationPresent(MapKey.class);
   }
 }

--- a/extensions/dagger-adapter/test/com/google/inject/daggeradapter/DaggerAdapterTest.java
+++ b/extensions/dagger-adapter/test/com/google/inject/daggeradapter/DaggerAdapterTest.java
@@ -144,6 +144,15 @@ public class DaggerAdapterTest extends TestCase {
   }
 
   @dagger.Module
+  static class UnsupportedAnnotationStaticModule {
+    @dagger.Provides
+    @ElementsIntoSet
+    static Set<Object> noGuiceEquivalentForElementsIntoSet() {
+      return ImmutableSet.of();
+    }
+  }
+
+  @dagger.Module
   static class UnsupportedAnnotationSubclassModule extends UnsupportedAnnotationModule {}
 
   public void testUnsupportedBindingAnnotation() {
@@ -151,6 +160,24 @@ public class DaggerAdapterTest extends TestCase {
       Guice.createInjector(DaggerAdapter.from(new UnsupportedAnnotationModule()));
       fail();
     } catch (CreationException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .contains(
+              "noGuiceEquivalentForElementsIntoSet() is annotated with"
+                  + " @dagger.multibindings.ElementsIntoSet which is not supported by"
+                  + " DaggerAdapter");
+    }
+
+    try {
+      Guice.createInjector(DaggerAdapter.from(UnsupportedAnnotationStaticModule.class));
+      fail();
+    } catch (CreationException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .contains(
+              "noGuiceEquivalentForElementsIntoSet() is annotated with"
+                  + " @dagger.multibindings.ElementsIntoSet which is not supported by"
+                  + " DaggerAdapter");
     }
   }
 
@@ -247,28 +274,6 @@ public class DaggerAdapterTest extends TestCase {
       assertThat(expected)
           .hasMessageThat()
           .contains("ProducerModuleWithProvidesMethod must be annotated with @dagger.Module");
-    }
-  }
-
-  @dagger.Module
-  static class ElementsIntoSetModule {
-    @dagger.Provides
-    @ElementsIntoSet
-    static Set<Integer> elements() {
-      return ImmutableSet.of();
-    }
-  }
-
-  public void testElementsIntoSetNotSupported() {
-    try {
-      Guice.createInjector(DaggerAdapter.from(ElementsIntoSetModule.class));
-      fail();
-    } catch (CreationException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .contains(
-              "elements() is annotated with @dagger.multibindings.ElementsIntoSet which is not"
-                  + " supported by DaggerAdapter");
     }
   }
 }

--- a/extensions/dagger-adapter/test/com/google/inject/daggeradapter/DaggerAdapterTest.java
+++ b/extensions/dagger-adapter/test/com/google/inject/daggeradapter/DaggerAdapterTest.java
@@ -54,7 +54,7 @@ public class DaggerAdapterTest extends TestCase {
 
   public void testSimpleModule() {
     Injector i = Guice.createInjector(DaggerAdapter.from(new SimpleDaggerModule()));
-    assertEquals((Integer) 1, i.getInstance(Integer.class));
+    assertThat(i.getInstance(Integer.class)).isEqualTo(1);
   }
 
   static class SimpleGuiceModule extends AbstractModule {
@@ -67,7 +67,7 @@ public class DaggerAdapterTest extends TestCase {
   public void testInteractionWithGuiceModules() {
     Injector i =
         Guice.createInjector(new SimpleGuiceModule(), DaggerAdapter.from(new SimpleDaggerModule()));
-    assertEquals("1", i.getInstance(String.class));
+    assertThat(i.getInstance(String.class)).isEqualTo("1");
   }
 
   @dagger.Module
@@ -92,7 +92,7 @@ public class DaggerAdapterTest extends TestCase {
     Injector i =
         Guice.createInjector(
             DaggerAdapter.from(new SetBindingDaggerModule1(), new SetBindingDaggerModule2()));
-    assertEquals(ImmutableSet.of(3, 5), i.getInstance(new Key<Set<Integer>>() {}));
+    assertThat(i.getInstance(new Key<Set<Integer>>() {})).isEqualTo(ImmutableSet.of(3, 5));
   }
 
   @Qualifier
@@ -112,9 +112,8 @@ public class DaggerAdapterTest extends TestCase {
   public void testSetBindingsWithAnnotation() {
     Injector i =
         Guice.createInjector(DaggerAdapter.from(new SetBindingWithAnnotationDaggerModule()));
-    assertEquals(
-        ImmutableSet.of(4),
-        i.getInstance(Key.get(new TypeLiteral<Set<Integer>>() {}, AnnotationOnSet.class)));
+    assertThat(i.getInstance(Key.get(new TypeLiteral<Set<Integer>>() {}, AnnotationOnSet.class)))
+        .isEqualTo(ImmutableSet.of(4));
   }
 
   static class MultibindingGuiceModule implements Module {
@@ -131,7 +130,7 @@ public class DaggerAdapterTest extends TestCase {
         Guice.createInjector(
             new MultibindingGuiceModule(),
             DaggerAdapter.from(new SetBindingDaggerModule1(), new SetBindingDaggerModule2()));
-    assertEquals(ImmutableSet.of(13, 3, 5, 8), i.getInstance(new Key<Set<Integer>>() {}));
+    assertThat(i.getInstance(new Key<Set<Integer>>() {})).isEqualTo(ImmutableSet.of(13, 3, 5, 8));
   }
 
   @dagger.Module
@@ -210,20 +209,20 @@ public class DaggerAdapterTest extends TestCase {
   public void testStaticProvidesMethods() {
     Injector injector = Guice.createInjector(DaggerAdapter.from(new StaticProvidesMethods()));
     String staticProvision = injector.getInstance(String.class);
-    assertEquals("class", staticProvision);
+    assertThat(staticProvision).isEqualTo("class");
   }
 
   public void testStaticProvidesMethods_classLiteral() {
     Injector injector = Guice.createInjector(DaggerAdapter.from(StaticProvidesMethods.class));
     String staticProvision = injector.getInstance(String.class);
-    assertEquals("class", staticProvision);
+    assertThat(staticProvision).isEqualTo("class");
   }
 
   public void testStaticProvidesMethods_interface() {
     Injector injector =
         Guice.createInjector(DaggerAdapter.from(StaticProvidesMethodsInterface.class));
     String staticProvision = injector.getInstance(String.class);
-    assertEquals("interface", staticProvision);
+    assertThat(staticProvision).isEqualTo("interface");
   }
 
   @dagger.Module

--- a/extensions/dagger-adapter/test/com/google/inject/daggeradapter/DaggerAdapterTest.java
+++ b/extensions/dagger-adapter/test/com/google/inject/daggeradapter/DaggerAdapterTest.java
@@ -249,4 +249,26 @@ public class DaggerAdapterTest extends TestCase {
           .contains("ProducerModuleWithProvidesMethod must be annotated with @dagger.Module");
     }
   }
+
+  @dagger.Module
+  static class ElementsIntoSetModule {
+    @dagger.Provides
+    @ElementsIntoSet
+    static Set<Integer> elements() {
+      return ImmutableSet.of();
+    }
+  }
+
+  public void testElementsIntoSetNotSupported() {
+    try {
+      Guice.createInjector(DaggerAdapter.from(ElementsIntoSetModule.class));
+      fail();
+    } catch (CreationException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .contains(
+              "elements() is annotated with @dagger.multibindings.ElementsIntoSet which is not"
+                  + " supported by DaggerAdapter");
+    }
+  }
 }

--- a/extensions/dagger-adapter/test/com/google/inject/daggeradapter/IntoMapTest.java
+++ b/extensions/dagger-adapter/test/com/google/inject/daggeradapter/IntoMapTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.inject.daggeradapter;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.MapBinder;
+import com.google.inject.util.Providers;
+import dagger.Binds;
+import dagger.multibindings.IntoMap;
+import dagger.multibindings.StringKey;
+import java.lang.annotation.Retention;
+import java.util.Map;
+import javax.inject.Qualifier;
+import junit.framework.TestCase;
+
+/** {@link IntoMap} tests for {@link DaggerAdapter}. */
+
+public class IntoMapTest extends TestCase {
+  @dagger.Module
+  static class MapBindingDaggerModule1 {
+    @dagger.Provides
+    @IntoMap
+    @StringKey("five")
+    Integer boxedPrimitive() {
+      return 5;
+    }
+
+    @dagger.Provides
+    @IntoMap
+    @StringKey("ten")
+    int primitive() {
+      return 10;
+    }
+  }
+
+  @dagger.Module
+  static class MapBindingDaggerModule2 {
+    @dagger.Provides
+    @IntoMap
+    @StringKey("twenty")
+    Integer anInteger() {
+      return 20;
+    }
+  }
+
+  public void testMapBindings() {
+    Injector injector =
+        Guice.createInjector(
+            DaggerAdapter.from(new MapBindingDaggerModule1(), new MapBindingDaggerModule2()));
+    assertEquals(
+        ImmutableMap.of("five", 5, "ten", 10, "twenty", 20),
+        injector.getInstance(new Key<Map<String, Integer>>() {}));
+  }
+
+  @Qualifier
+  @Retention(RUNTIME)
+  public @interface AnnotationOnMap {}
+
+  @dagger.Module
+  static class MapBindingWithAnnotationDaggerModule {
+    @dagger.Provides
+    @IntoMap
+    @StringKey("qualified")
+    @AnnotationOnMap
+    Integer anInteger() {
+      return 4;
+    }
+  }
+
+  public void testMapBindingsWithAnnotation() {
+    Injector injector =
+        Guice.createInjector(DaggerAdapter.from(new MapBindingWithAnnotationDaggerModule()));
+    assertEquals(
+        ImmutableMap.of("qualified", 4),
+        injector.getInstance(
+            Key.get(new TypeLiteral<Map<String, Integer>>() {}, AnnotationOnMap.class)));
+  }
+
+  static class MultibindingGuiceModule implements Module {
+    @Override
+    public void configure(Binder binder) {
+      MapBinder<String, Integer> mb = MapBinder.newMapBinder(binder, String.class, Integer.class);
+      mb.addBinding("guice-zero").toInstance(0);
+      mb.addBinding("guice-provider-2").toProvider(Providers.of(2)); // mix'n'match.
+    }
+  }
+
+  public void testMapBindingsWithGuiceModule() {
+    Injector injector =
+        Guice.createInjector(
+            new MultibindingGuiceModule(),
+            DaggerAdapter.from(new MapBindingDaggerModule1(), new MapBindingDaggerModule2()));
+    assertEquals(
+        ImmutableMap.of("five", 5, "ten", 10, "twenty", 20, "guice-zero", 0, "guice-provider-2", 2),
+        injector.getInstance(new Key<Map<String, Integer>>() {}));
+  }
+
+  @dagger.MapKey(unwrapValue = false)
+  @Retention(RUNTIME)
+  @interface Wrapped {
+    int i();
+    long l();
+    String defaultValue() default "";
+  }
+
+  @dagger.Module
+  static class WrappedMapKeyModule {
+    @dagger.Provides
+    @IntoMap
+    @Wrapped(i = 0, l = 0)
+    int defaultValue() {
+      return 0;
+    }
+
+    @dagger.Provides
+    @IntoMap
+    @Wrapped(i = 1, l = 1, defaultValue = "1")
+    int ones() {
+      return 1;
+    }
+
+    @dagger.Provides
+    @IntoMap
+    @Wrapped(i = 2, l = 2, defaultValue = "2")
+    int twos() {
+      return 2;
+    }
+  }
+
+  public void testWrappedMapKeys() {
+    Injector injector = Guice.createInjector(DaggerAdapter.from(new WrappedMapKeyModule()));
+    Map<Wrapped, Integer> map = injector.getInstance(new Key<Map<Wrapped, Integer>>() {});
+    assertEquals(3, map.size());
+    map.forEach((key, value) -> {
+      if (value == 0) {
+        assertWrappedEquals(0, 0, "", key);
+      } else if (value == 1) {
+        assertWrappedEquals(1, 1, "1", key);
+      } else if (value == 2) {
+        assertWrappedEquals(2, 2, "2", key);
+      } else {
+        throw new AssertionError();
+      }
+    });
+  }
+
+  private static void assertWrappedEquals(int i, long l, String defaultValue, Wrapped actual) {
+    assertEquals(i, actual.i());
+    assertEquals(l, actual.l());
+    assertEquals(defaultValue, actual.defaultValue());
+  }
+
+  @dagger.Module
+  static class HasConflict {
+    @dagger.Provides
+    @IntoMap
+    @Wrapped(i = 1, l = 1, defaultValue = "1")
+    int ones() {
+      return 1;
+    }
+  }
+
+  @dagger.Module
+  interface BindsModule {
+    @Binds
+    @IntoMap
+    @StringKey("hello")
+    Object binds(String value);
+
+    @dagger.Provides
+    static String world() {
+      return "world";
+    }
+  }
+
+  public void testBinds() {
+    Injector injector = Guice.createInjector(DaggerAdapter.from(BindsModule.class));
+    Map<String, Object> map = injector.getInstance(new Key<Map<String, Object>>() {});
+    assertEquals(ImmutableMap.of("hello", "world"), map);
+  }
+}

--- a/extensions/dagger-adapter/test/com/google/inject/daggeradapter/IntoMapTest.java
+++ b/extensions/dagger-adapter/test/com/google/inject/daggeradapter/IntoMapTest.java
@@ -15,9 +15,9 @@
  */
 package com.google.inject.daggeradapter;
 
+import static com.google.common.truth.Truth.assertThat;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -68,9 +68,8 @@ public class IntoMapTest extends TestCase {
     Injector injector =
         Guice.createInjector(
             DaggerAdapter.from(new MapBindingDaggerModule1(), new MapBindingDaggerModule2()));
-    assertEquals(
-        ImmutableMap.of("five", 5, "ten", 10, "twenty", 20),
-        injector.getInstance(new Key<Map<String, Integer>>() {}));
+    assertThat(injector.getInstance(new Key<Map<String, Integer>>() {}))
+        .containsExactly("five", 5, "ten", 10, "twenty", 20);
   }
 
   @Qualifier
@@ -91,10 +90,10 @@ public class IntoMapTest extends TestCase {
   public void testMapBindingsWithAnnotation() {
     Injector injector =
         Guice.createInjector(DaggerAdapter.from(new MapBindingWithAnnotationDaggerModule()));
-    assertEquals(
-        ImmutableMap.of("qualified", 4),
-        injector.getInstance(
-            Key.get(new TypeLiteral<Map<String, Integer>>() {}, AnnotationOnMap.class)));
+    assertThat(
+            injector.getInstance(
+                Key.get(new TypeLiteral<Map<String, Integer>>() {}, AnnotationOnMap.class)))
+        .containsExactly("qualified", 4);
   }
 
   static class MultibindingGuiceModule implements Module {
@@ -111,9 +110,9 @@ public class IntoMapTest extends TestCase {
         Guice.createInjector(
             new MultibindingGuiceModule(),
             DaggerAdapter.from(new MapBindingDaggerModule1(), new MapBindingDaggerModule2()));
-    assertEquals(
-        ImmutableMap.of("five", 5, "ten", 10, "twenty", 20, "guice-zero", 0, "guice-provider-2", 2),
-        injector.getInstance(new Key<Map<String, Integer>>() {}));
+    assertThat(injector.getInstance(new Key<Map<String, Integer>>() {}))
+        .containsExactly(
+            "five", 5, "ten", 10, "twenty", 20, "guice-zero", 0, "guice-provider-2", 2);
   }
 
   @dagger.MapKey(unwrapValue = false)
@@ -151,7 +150,7 @@ public class IntoMapTest extends TestCase {
   public void testWrappedMapKeys() {
     Injector injector = Guice.createInjector(DaggerAdapter.from(new WrappedMapKeyModule()));
     Map<Wrapped, Integer> map = injector.getInstance(new Key<Map<Wrapped, Integer>>() {});
-    assertEquals(3, map.size());
+    assertThat(map).hasSize(3);
     map.forEach((key, value) -> {
       if (value == 0) {
         assertWrappedEquals(0, 0, "", key);
@@ -166,9 +165,9 @@ public class IntoMapTest extends TestCase {
   }
 
   private static void assertWrappedEquals(int i, long l, String defaultValue, Wrapped actual) {
-    assertEquals(i, actual.i());
-    assertEquals(l, actual.l());
-    assertEquals(defaultValue, actual.defaultValue());
+    assertThat(actual.i()).isEqualTo(i);
+    assertThat(actual.l()).isEqualTo(l);
+    assertThat(actual.defaultValue()).isEqualTo(defaultValue);
   }
 
   @dagger.Module
@@ -197,6 +196,6 @@ public class IntoMapTest extends TestCase {
   public void testBinds() {
     Injector injector = Guice.createInjector(DaggerAdapter.from(BindsModule.class));
     Map<String, Object> map = injector.getInstance(new Key<Map<String, Object>>() {});
-    assertEquals(ImmutableMap.of("hello", "world"), map);
+    assertThat(map).containsExactly("hello", "world");
   }
 }

--- a/extensions/dagger-adapter/test/com/google/inject/daggeradapter/ModuleIncludesTest.java
+++ b/extensions/dagger-adapter/test/com/google/inject/daggeradapter/ModuleIncludesTest.java
@@ -45,7 +45,7 @@ public class ModuleIncludesTest extends TestCase {
 
   public void testIncludedModules() {
     Injector injector = Guice.createInjector(DaggerAdapter.from(Declared.class, Included.class));
-    assertEquals("included", injector.getInstance(String.class));
+    assertThat(injector.getInstance(String.class)).isEqualTo("included");
   }
 
   @Module
@@ -64,7 +64,7 @@ public class ModuleIncludesTest extends TestCase {
 
   public void testDeduplicated() {
     Injector injector = Guice.createInjector(DaggerAdapter.from(Includes1.class, Includes2.class));
-    assertEquals("deduplicated", injector.getInstance(String.class));
+    assertThat(injector.getInstance(String.class)).isEqualTo("deduplicated");
   }
 
   public void testInstanceOfModuleAndClassLiteral() {
@@ -81,7 +81,7 @@ public class ModuleIncludesTest extends TestCase {
             DaggerAdapter.from(Includes1.class),
             DaggerAdapter.from(Includes2.class),
             DaggerAdapter.from(Includes2.class));
-    assertEquals("deduplicated", injector.getInstance(String.class));
+    assertThat(injector.getInstance(String.class)).isEqualTo("deduplicated");
   }
 
   @Module

--- a/extensions/dagger-adapter/test/com/google/inject/daggeradapter/ModuleIncludesTest.java
+++ b/extensions/dagger-adapter/test/com/google/inject/daggeradapter/ModuleIncludesTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.inject.daggeradapter;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.inject.CreationException;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import dagger.Module;
+import dagger.Provides;
+import junit.framework.TestCase;
+
+/** Tests for {@code @Module.includes} */
+
+public class ModuleIncludesTest extends TestCase {
+  @Module(includes = Included.class)
+  static class Declared {
+    @Provides
+    static Object object() {
+      return new Object();
+    }
+  }
+
+  @Module
+  static class Included {
+    @Provides
+    static String string(Object object) {
+      return "included";
+    }
+  }
+
+  public void testIncludedModules() {
+    Injector injector = Guice.createInjector(DaggerAdapter.from(Declared.class, Included.class));
+    assertEquals("included", injector.getInstance(String.class));
+  }
+
+  @Module
+  static class Deduplicated {
+    @Provides
+    static String string() {
+      return "deduplicated";
+    }
+  }
+
+  @Module(includes = Deduplicated.class)
+  static class Includes1 {}
+
+  @Module(includes = Deduplicated.class)
+  static class Includes2 {}
+
+  public void testDeduplicated() {
+    Injector injector = Guice.createInjector(DaggerAdapter.from(Includes1.class, Includes2.class));
+    assertEquals("deduplicated", injector.getInstance(String.class));
+  }
+
+  public void testInstanceOfModuleAndClassLiteral() {
+    Guice.createInjector(DaggerAdapter.from(Deduplicated.class, new Deduplicated()));
+  }
+
+  // ProviderMethodsModule, which DaggerAdapter uses under the hood, de-duplicates modules that have
+  // the same Scanner instance and same delegate module. So any Class object passed to DaggerAdapter
+  // should be fine to use.
+  public void testDeduplicatedModulesFromSeparateDaggerAdapters() {
+    Injector injector =
+        Guice.createInjector(
+            DaggerAdapter.from(Includes1.class),
+            DaggerAdapter.from(Includes1.class),
+            DaggerAdapter.from(Includes2.class),
+            DaggerAdapter.from(Includes2.class));
+    assertEquals("deduplicated", injector.getInstance(String.class));
+  }
+
+  @Module
+  static final class ModuleWithIdentity {}
+
+  public void testConflictingModuleInstances() {
+    try {
+      Guice.createInjector(DaggerAdapter.from(new ModuleWithIdentity(), new ModuleWithIdentity()));
+      fail();
+    } catch (CreationException e) {
+      assertThat(e)
+          .hasMessageThat()
+          .contains(
+              "Duplicate module instances provided for " + ModuleWithIdentity.class.getName());
+    }
+  }
+
+  @Module
+  static final class ModuleWithInstanceProvidesMethod {
+    private int i;
+
+    @Provides
+    int i() {
+      return i++;
+    }
+  }
+
+  public void testInstanceOfModuleAndClassLiteral_InstanceWins() {
+    Injector instanceModuleFirst =
+        Guice.createInjector(
+            DaggerAdapter.from(
+                new ModuleWithInstanceProvidesMethod(), ModuleWithInstanceProvidesMethod.class));
+    assertThat(instanceModuleFirst.getInstance(Integer.class)).isEqualTo(0);
+    assertThat(instanceModuleFirst.getInstance(Integer.class)).isEqualTo(1);
+
+    Injector classLiteralFirst =
+        Guice.createInjector(
+            DaggerAdapter.from(
+                ModuleWithInstanceProvidesMethod.class, new ModuleWithInstanceProvidesMethod()));
+    assertThat(classLiteralFirst.getInstance(Integer.class)).isEqualTo(0);
+    assertThat(classLiteralFirst.getInstance(Integer.class)).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Install @Module(includes = ...) modules in DaggerAdapter.

Also validate that duplicates are passed as the declared modules to DaggerAdapter

346e44b47e5a9b6d5d417865d0aaf33b165b5435

-------

<p> Remove stale TODO

e4f5b9ec1e8e23b83e1c5aa9e4a46ce4ca2a1ab7

-------

<p> Fix support for DaggerAdapter's unsupported annotations checker for modules that are passed as class literals.

We were incorrectly checking for Class.class in this case, which is never what we wanted.

In the process, also refactor the set of annotations which should have caught this discrepancy when we added support for abstract binding methods.

ccda97d9004780bd3dad9d8925a82b6189d70ce9

-------

<p> Consolidate two different yet similar tests

eba92ec0ec4388c08501151dc228ab5db600176d

-------

<p> Support @IntoMap in DaggerAdapter

6ecb9027e5e9c615a910fd7f5e0537366f1b68b1

-------

<p> Migrate DaggerAdapter tests off of JUnit3 assertions and onto Truth

b65628fc0069eb8a4712d82bc38c59bccf8c7f3a