### PR TITLE
Moe Sync

### DIFF
--- a/core/src/com/google/inject/Key.java
+++ b/core/src/com/google/inject/Key.java
@@ -141,12 +141,20 @@ public class Key<T> {
     return typeLiteral;
   }
 
-  /** Gets the annotation type. */
+  /** Gets the annotation type. Will be {@code null} if this key lacks an annotation. */
   public final Class<? extends Annotation> getAnnotationType() {
     return annotationStrategy.getAnnotationType();
   }
 
-  /** Gets the annotation. */
+  /**
+   * Gets the annotation instance if available. Will be {@code null} if this key lacks an annotation
+   * <i>or</i> the key was constructed with a {@code Class<Annotation>}.
+   *
+   * <p><b>Warning:</b> this can return null even if this key is annotated. To check whether a
+   * {@code Key} has an annotation use {@link #hasAnnotationType} instead.
+   */
+  // TODO(diamondm) consider deprecating this in favor of a method that ISEs if hasAnnotationType()
+  // is true but this would return null.
   public final Annotation getAnnotation() {
     return annotationStrategy.getAnnotation();
   }

--- a/core/src/com/google/inject/internal/ConstantBindingBuilderImpl.java
+++ b/core/src/com/google/inject/internal/ConstantBindingBuilderImpl.java
@@ -119,14 +119,7 @@ public final class ConstantBindingBuilderImpl<T> extends AbstractBindingBuilder<
     }
 
     BindingImpl<T> base = getBinding();
-    Key<T> key;
-    if (base.getKey().getAnnotation() != null) {
-      key = Key.get(typeAsClassT, base.getKey().getAnnotation());
-    } else if (base.getKey().getAnnotationType() != null) {
-      key = Key.get(typeAsClassT, base.getKey().getAnnotationType());
-    } else {
-      key = Key.get(typeAsClassT);
-    }
+    Key<T> key = base.getKey().ofType(typeAsClassT);
 
     if (instanceAsT == null) {
       binder.addError(BINDING_TO_NULL);

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -229,7 +229,7 @@ public final class Errors implements Serializable {
     // annotations on simple types. This is usually a bad idea.
     if (sameTypes.isEmpty()
         && possibleMatches.isEmpty()
-        && key.getAnnotation() == null
+        && key.getAnnotationType() == null
         && COMMON_AMBIGUOUS_TYPES.contains(key.getTypeLiteral().getRawType())) {
       // We don't recommend using such simple types without annotations.
       sb.append(format("%nThe key seems very generic, did you forget an annotation?"));

--- a/core/src/com/google/inject/internal/MoreTypes.java
+++ b/core/src/com/google/inject/internal/MoreTypes.java
@@ -69,12 +69,8 @@ public class MoreTypes {
     // Otherwise, recreate the key to avoid the subclass
     if (key.getClass() == Key.class) {
       return key;
-    } else if (key.getAnnotation() != null) {
-      return Key.get(key.getTypeLiteral(), key.getAnnotation());
-    } else if (key.getAnnotationType() != null) {
-      return Key.get(key.getTypeLiteral(), key.getAnnotationType());
     } else {
-      return Key.get(key.getTypeLiteral());
+      return key.ofType(key.getTypeLiteral());
     }
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Clarify the docs on Key.getAnnotation(), that it cannot be used to check whether an annotation is present on the key or not. Fix a few unnecessary usages of Key.getAnnotation(), and notably one erroneous usage (Errors.java) that would cause Guice to suggest the user forgot an annotation on an annotated binding.

175e2211d00407d3b5f8bb84333a4a13d8df9862