### PR TITLE
handle optionals

### DIFF
--- a/core/src/com/google/inject/binder/ConstantBindingBuilder.java
+++ b/core/src/com/google/inject/binder/ConstantBindingBuilder.java
@@ -16,11 +16,16 @@
 
 package com.google.inject.binder;
 
+import java.util.Optional;
+
 /** Binds to a constant value. */
 public interface ConstantBindingBuilder {
 
   /** Binds constant to the given value. */
   void to(String value);
+
+  /** Binds constant to the given optional value */
+  void to(Optional optionalValue);
 
   /** Binds constant to the given value. */
   void to(int value);

--- a/core/src/com/google/inject/internal/ConstantBindingBuilderImpl.java
+++ b/core/src/com/google/inject/internal/ConstantBindingBuilderImpl.java
@@ -25,6 +25,7 @@ import com.google.inject.spi.Element;
 import com.google.inject.spi.InjectionPoint;
 import java.lang.annotation.Annotation;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Bind a constant.
@@ -54,6 +55,11 @@ public final class ConstantBindingBuilderImpl<T> extends AbstractBindingBuilder<
   @Override
   public void to(final String value) {
     toConstant(String.class, value);
+  }
+
+  @Override
+  public void to(final Optional value) {
+    toConstant(Optional.class, value);
   }
 
   @Override


### PR DESCRIPTION
I would like to inject Optional properties without using the optional binder.  This lets me do @Property(ProxyPort.class) Optional<Integer> proxyPort so I can bind a property with an annotation.