### PR TITLE
Include meaningful diagnostics when getDeclaredFields/getDeclaredMethods fails due to linkage errors

### DIFF
--- a/core/src/com/google/inject/spi/InjectionPoint.java
+++ b/core/src/com/google/inject/spi/InjectionPoint.java
@@ -660,7 +660,7 @@ public final class InjectionPoint {
 
       TypeLiteral<?> current = hierarchy.get(i);
 
-      for (Field field : getDeclaredFields(current)) {
+      for (Field field : getDeclaredFields(current, errors)) {
         if (Modifier.isStatic(field.getModifiers()) == statics) {
           Annotation atInject = getAtInject(field);
           if (atInject != null) {
@@ -673,7 +673,7 @@ public final class InjectionPoint {
         }
       }
 
-      for (Method method : getDeclaredMethods(current)) {
+      for (Method method : getDeclaredMethods(current, errors)) {
         if (isEligibleForInjection(method, statics)) {
           Annotation atInject = getAtInject(method);
           if (atInject != null) {
@@ -749,12 +749,22 @@ public final class InjectionPoint {
     return builder.build();
   }
 
-  private static Field[] getDeclaredFields(TypeLiteral<?> type) {
-    return DeclaredMembers.getDeclaredFields(type.getRawType());
+  private static Field[] getDeclaredFields(TypeLiteral<?> type, Errors errors) {
+    try {
+      return DeclaredMembers.getDeclaredFields(type.getRawType());
+    } catch (Throwable x) {
+      errors.errorInUserCode(x, "Failed to inspect fields in %s", type);
+      return new Field[0];
+    }
   }
 
-  private static Method[] getDeclaredMethods(TypeLiteral<?> type) {
-    return DeclaredMembers.getDeclaredMethods(type.getRawType());
+  private static Method[] getDeclaredMethods(TypeLiteral<?> type, Errors errors) {
+    try {
+      return DeclaredMembers.getDeclaredMethods(type.getRawType());
+    } catch (Throwable x) {
+      errors.errorInUserCode(x, "Failed to inspect methods in %s", type);
+      return new Method[0];
+    }
   }
 
   /**


### PR DESCRIPTION
Similar to #1279 but covering a different error condition. Before:

```
java.lang.ClassNotFoundException: a.A
	at …
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
Caused: java.lang.NoClassDefFoundError: a/A
	at java.lang.Class.getDeclaredMethods0(Native Method)
	at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
	at java.lang.Class.getDeclaredMethods(Class.java:1975)
	at com.google.inject.internal.DeclaredMembers.getDeclaredMethods(DeclaredMembers.java:40)
	at com.google.inject.spi.InjectionPoint.getDeclaredMethods(InjectionPoint.java:757)
	at com.google.inject.spi.InjectionPoint.getInjectionPoints(InjectionPoint.java:676)
	at com.google.inject.spi.InjectionPoint.forInstanceMethodsAndFields(InjectionPoint.java:376)
	at com.google.inject.internal.MembersInjectorStore.createWithListeners(MembersInjectorStore.java:92)
	at com.google.inject.internal.MembersInjectorStore.access$000(MembersInjectorStore.java:40)
	at com.google.inject.internal.MembersInjectorStore$1.create(MembersInjectorStore.java:49)
	at com.google.inject.internal.MembersInjectorStore$1.create(MembersInjectorStore.java:45)
	at com.google.inject.internal.FailableCache$1.load(FailableCache.java:43)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
Caused: com.google.common.util.concurrent.ExecutionError
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2049)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3953)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3976)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4960)
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4966)
	at com.google.inject.internal.FailableCache.get(FailableCache.java:54)
	at com.google.inject.internal.MembersInjectorStore.get(MembersInjectorStore.java:69)
	at com.google.inject.internal.ConstructorInjectorStore.createConstructor(ConstructorInjectorStore.java:75)
	at com.google.inject.internal.ConstructorInjectorStore.access$000(ConstructorInjectorStore.java:30)
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:38)
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:34)
	at com.google.inject.internal.FailableCache$1.load(FailableCache.java:43)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
Caused: com.google.common.util.concurrent.ExecutionError
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2049)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3953)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3976)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4960)
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4966)
	at com.google.inject.internal.FailableCache.get(FailableCache.java:54)
	at com.google.inject.internal.ConstructorInjectorStore.get(ConstructorInjectorStore.java:49)
	at com.google.inject.internal.ConstructorBindingImpl.initialize(ConstructorBindingImpl.java:155)
	at com.google.inject.internal.InjectorImpl.initializeBinding(InjectorImpl.java:590)
	at com.google.inject.internal.AbstractBindingProcessor$Processor.initializeBinding(AbstractBindingProcessor.java:173)
	at com.google.inject.internal.AbstractBindingProcessor$Processor.lambda$scheduleInitialization$0(AbstractBindingProcessor.java:160)
	at com.google.inject.internal.ProcessedBindingData.initializeBindings(ProcessedBindingData.java:49)
	at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:124)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:108)
	at com.google.inject.internal.InjectorImpl.createChildInjector(InjectorImpl.java:246)
	at …
```

After:

```
java.lang.ClassNotFoundException: a.A
	at …
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
Caused: java.lang.NoClassDefFoundError: a/A
	at java.lang.Class.getDeclaredMethods0(Native Method)
	at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
	at java.lang.Class.getDeclaredMethods(Class.java:1975)
	at com.google.inject.internal.DeclaredMembers.getDeclaredMethods(DeclaredMembers.java:40)
	at com.google.inject.spi.InjectionPoint.getDeclaredMethods(InjectionPoint.java:763)
	at com.google.inject.spi.InjectionPoint.getInjectionPoints(InjectionPoint.java:676)
	at com.google.inject.spi.InjectionPoint.forInstanceMethodsAndFields(InjectionPoint.java:376)
	at com.google.inject.internal.MembersInjectorStore.createWithListeners(MembersInjectorStore.java:92)
	at com.google.inject.internal.MembersInjectorStore.access$000(MembersInjectorStore.java:40)
	at com.google.inject.internal.MembersInjectorStore$1.create(MembersInjectorStore.java:49)
	at com.google.inject.internal.MembersInjectorStore$1.create(MembersInjectorStore.java:45)
	at com.google.inject.internal.FailableCache$1.load(FailableCache.java:43)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3953)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3976)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4960)
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4966)
	at com.google.inject.internal.FailableCache.get(FailableCache.java:54)
	at com.google.inject.internal.MembersInjectorStore.get(MembersInjectorStore.java:69)
	at com.google.inject.internal.ConstructorInjectorStore.createConstructor(ConstructorInjectorStore.java:75)
	at com.google.inject.internal.ConstructorInjectorStore.access$000(ConstructorInjectorStore.java:30)
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:38)
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:34)
	at com.google.inject.internal.FailableCache$1.load(FailableCache.java:43)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3953)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3976)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4960)
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4966)
	at com.google.inject.internal.FailableCache.get(FailableCache.java:54)
	at com.google.inject.internal.ConstructorInjectorStore.get(ConstructorInjectorStore.java:49)
	at com.google.inject.internal.ConstructorBindingImpl.initialize(ConstructorBindingImpl.java:155)
	at com.google.inject.internal.InjectorImpl.initializeBinding(InjectorImpl.java:590)
	at com.google.inject.internal.AbstractBindingProcessor$Processor.initializeBinding(AbstractBindingProcessor.java:173)
	at com.google.inject.internal.AbstractBindingProcessor$Processor.lambda$scheduleInitialization$0(AbstractBindingProcessor.java:160)
	at com.google.inject.internal.ProcessedBindingData.initializeBindings(ProcessedBindingData.java:49)
	at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:124)
Caused: com.google.inject.CreationException: Unable to create injector, see the following errors:

1) Failed to inspect methods in b.B
  at …

1 error
	at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:554)
	at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:161)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:108)
	at com.google.inject.internal.InjectorImpl.createChildInjector(InjectorImpl.java:246)
	at …
```