### PR TITLE
Use lineSeparator() to make InternalProvisionExceptionTest.java cross-platform available

### DIFF
--- a/core/test/com/google/inject/internal/InternalProvisionExceptionTest.java
+++ b/core/test/com/google/inject/internal/InternalProvisionExceptionTest.java
@@ -24,7 +24,7 @@ public final class InternalProvisionExceptionTest extends TestCase {
 
   public void testSourceFormatting() {
     // Note that the duplicate source gets dropped as well as the unknown source
-    String ls = System.lineSeparator();
+    final String LINE_SEPARATOR = System.lineSeparator();
     assertThat(
             InternalProvisionException.create("An error")
                 .addSource("Source1")
@@ -35,12 +35,12 @@ public final class InternalProvisionExceptionTest extends TestCase {
                 .getMessage())
         .isEqualTo(
             ""
-                + "Unable to provision, see the following errors:" + ls 
-                + ls 
-                + "1) An error" + ls 
-                + "  at Source1" + ls 
-                + "  at Source2" + ls 
-                + "" + ls 
+                + "Unable to provision, see the following errors:" + LINE_SEPARATOR 
+                + LINE_SEPARATOR 
+                + "1) An error" + LINE_SEPARATOR 
+                + "  at Source1" + LINE_SEPARATOR 
+                + "  at Source2" + LINE_SEPARATOR 
+                + "" + LINE_SEPARATOR 
                 + "1 error");
   }
 }

--- a/core/test/com/google/inject/internal/InternalProvisionExceptionTest.java
+++ b/core/test/com/google/inject/internal/InternalProvisionExceptionTest.java
@@ -24,6 +24,7 @@ public final class InternalProvisionExceptionTest extends TestCase {
 
   public void testSourceFormatting() {
     // Note that the duplicate source gets dropped as well as the unknown source
+    String ls = System.lineSeparator();
     assertThat(
             InternalProvisionException.create("An error")
                 .addSource("Source1")
@@ -34,12 +35,12 @@ public final class InternalProvisionExceptionTest extends TestCase {
                 .getMessage())
         .isEqualTo(
             ""
-                + "Unable to provision, see the following errors:" + System.lineSeparator()
-                + System.lineSeparator()
-                + "1) An error" + System.lineSeparator()
-                + "  at Source1" + System.lineSeparator()
-                + "  at Source2" + System.lineSeparator()
-                + "" + System.lineSeparator()
+                + "Unable to provision, see the following errors:" + ls 
+                + ls 
+                + "1) An error" + ls 
+                + "  at Source1" + ls 
+                + "  at Source2" + ls 
+                + "" + ls 
                 + "1 error");
   }
 }

--- a/core/test/com/google/inject/internal/InternalProvisionExceptionTest.java
+++ b/core/test/com/google/inject/internal/InternalProvisionExceptionTest.java
@@ -34,12 +34,12 @@ public final class InternalProvisionExceptionTest extends TestCase {
                 .getMessage())
         .isEqualTo(
             ""
-                + "Unable to provision, see the following errors:\n"
-                + "\n"
-                + "1) An error\n"
-                + "  at Source1\n"
-                + "  at Source2\n"
-                + "\n"
+                + "Unable to provision, see the following errors:" + System.lineSeparator()
+                + System.lineSeparator()
+                + "1) An error" + System.lineSeparator()
+                + "  at Source1" + System.lineSeparator()
+                + "  at Source2" + System.lineSeparator()
+                + "" + System.lineSeparator()
                 + "1 error");
   }
 }


### PR DESCRIPTION
This resolves #1304
This PR brings related test into correct way in different operating system and resolves test problem on windows.
Before:
```
<testcase classname="com.google.inject.internal.InternalProvisionExceptionTest" name="testSourceFormatting" time="    0.172">
     <failure message="value of: getMessage()
 diff    : (line contents match, but line-break characters differ)" type="value of">value of: getMessage()
 diff    : (line contents match, but line-break characters differ)
         at com.google.inject.internal.InternalProvisionExceptionTest.testSourceFormatting(InternalProvisionException    Test.java:35)
```
After:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```
Thank you for taking the time to look at my PR.