### PR TITLE
Fix toString implementation of annotations for Java 14

### DIFF
--- a/core/src/com/google/inject/internal/Annotations.java
+++ b/core/src/com/google/inject/internal/Annotations.java
@@ -221,14 +221,14 @@ public class Annotations {
     return QUOTE_MEMBER_VALUES ? "\"" + value + "\"" : value;
   }
 
-  private static final boolean SINGLE_MEMBER_PREFIX = determineWhetherToElideKePrefix();
+  private static final boolean SINGLE_VALUE_MEMBER_PREFIX = determineWhetherToElideValuePrefix();
 
   /**
    * Returns the member value key prefix {@code value=}, or the empty string. In Java
    * 14, annotations with just one element named {@code value} elide the `value=` prefix.
    */
   public static String memberKeyString() {
-    return SINGLE_MEMBER_PREFIX ? "value=" : "";
+    return SINGLE_VALUE_MEMBER_PREFIX ? "value=" : "";
   }
 
   @Retention(RUNTIME)
@@ -250,12 +250,12 @@ public class Annotations {
     }
   }
 
-  @TestAnnotation("determineWhetherToElideKePrefix")
-  private static boolean determineWhetherToElideKePrefix() {
+  @TestAnnotation("determineWhetherToElideValuePrefix")
+  private static boolean determineWhetherToElideValuePrefix() {
     try {
       String annotation =
           Annotations.class
-              .getDeclaredMethod("determineWhetherToElideKePrefix")
+              .getDeclaredMethod("determineWhetherToElideValuePrefix")
               .getAnnotation(TestAnnotation.class)
               .toString();
       return annotation.contains("value=");

--- a/core/src/com/google/inject/internal/Annotations.java
+++ b/core/src/com/google/inject/internal/Annotations.java
@@ -221,6 +221,16 @@ public class Annotations {
     return QUOTE_MEMBER_VALUES ? "\"" + value + "\"" : value;
   }
 
+  private static final boolean SINGLE_MEMBER_PREFIX = determineWhetherToElideKePrefix();
+
+  /**
+   * Returns the member value key prefix {@code value=}, or the empty string. In Java
+   * 14, annotations with just one element named {@code value} elide the `value=` prefix.
+   */
+  public static String memberKeyString() {
+    return SINGLE_MEMBER_PREFIX ? "value=" : "";
+  }
+
   @Retention(RUNTIME)
   private @interface TestAnnotation {
     String value();
@@ -235,6 +245,20 @@ public class Annotations {
               .getAnnotation(TestAnnotation.class)
               .toString();
       return annotation.contains("\"determineWhetherToQuote\"");
+    } catch (NoSuchMethodException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @TestAnnotation("determineWhetherToElideKePrefix")
+  private static boolean determineWhetherToElideKePrefix() {
+    try {
+      String annotation =
+          Annotations.class
+              .getDeclaredMethod("determineWhetherToElideKePrefix")
+              .getAnnotation(TestAnnotation.class)
+              .toString();
+      return annotation.contains("value=");
     } catch (NoSuchMethodException e) {
       throw new AssertionError(e);
     }

--- a/core/src/com/google/inject/internal/UniqueAnnotations.java
+++ b/core/src/com/google/inject/internal/UniqueAnnotations.java
@@ -51,7 +51,10 @@ public class UniqueAnnotations {
 
       @Override
       public String toString() {
-        return "@" + Internal.class.getName() + "(value=" + value + ")";
+        return String.format("@%s(%s%s)",
+                Internal.class.getName(),
+                Annotations.memberKeyString(),
+                value);
       }
 
       @Override

--- a/core/src/com/google/inject/name/NamedImpl.java
+++ b/core/src/com/google/inject/name/NamedImpl.java
@@ -53,7 +53,10 @@ class NamedImpl implements Named, Serializable {
 
   @Override
   public String toString() {
-    return "@" + Named.class.getName() + "(value=" + Annotations.memberValueString(value) + ")";
+    return String.format("@%s(%s%s)",
+            Named.class.getName(),
+            Annotations.memberKeyString(),
+            Annotations.memberValueString(value));
   }
 
   @Override

--- a/core/test/com/google/inject/BinderTest.java
+++ b/core/test/com/google/inject/BinderTest.java
@@ -132,7 +132,8 @@ public class BinderTest extends TestCase {
       String segment4 =
           "No implementation for java.util.Date annotated with @"
               + Named.class.getName()
-              + "(value="
+              + "("
+              + Annotations.memberKeyString()
               + Annotations.memberValueString("date")
               + ") was bound.";
       String atSegment = "at " + getClass().getName();

--- a/core/test/com/google/inject/BindingAnnotationTest.java
+++ b/core/test/com/google/inject/BindingAnnotationTest.java
@@ -22,6 +22,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
+
+import com.google.inject.internal.Annotations;
 import junit.framework.TestCase;
 
 /** @author crazybob@google.com (Bob Lee) */
@@ -60,7 +62,7 @@ public class BindingAnnotationTest extends TestCase {
           expected.getMessage(),
           true,
           "No implementation for java.lang.String annotated with",
-          "BindingAnnotationTest$Blue(value=5) was bound",
+          "BindingAnnotationTest$Blue(" + Annotations.memberKeyString() + "5) was bound",
           "at " + BindingAnnotationTest.class.getName(),
           getDeclaringSourcePart(getClass()));
     }
@@ -119,7 +121,7 @@ public class BindingAnnotationTest extends TestCase {
           expected.getMessage(),
           true,
           "No implementation for java.lang.String annotated with",
-          "BindingAnnotationTest$Blue(value=5) was bound",
+          "BindingAnnotationTest$Blue(" + Annotations.memberKeyString() + "5) was bound",
           "at " + BindingAnnotationTest.class.getName(),
           getDeclaringSourcePart(getClass()));
     }

--- a/core/test/com/google/inject/BindingTest.java
+++ b/core/test/com/google/inject/BindingTest.java
@@ -518,7 +518,7 @@ public class BindingTest extends TestCase {
       this.stage = stage;
     }
   }
-  
+
   public void testTurkeyBaconProblemUsingToConstuctor() {
     Injector injector = Guice.createInjector(new AbstractModule() {
       @SuppressWarnings("unchecked")
@@ -534,11 +534,11 @@ public class BindingTest extends TestCase {
     Bacon bacon = injector.getInstance(Bacon.class);
     assertEquals(Food.PORK, bacon.getMaterial());
     assertFalse(bacon.isCooked());
-    
+
     Bacon turkeyBacon = injector.getInstance(Key.get(Bacon.class, named("Turkey")));
     assertEquals(Food.TURKEY, turkeyBacon.getMaterial());
     assertTrue(turkeyBacon.isCooked());
-    
+
     Bacon cookedBacon = injector.getInstance(Key.get(Bacon.class, named("Cooked")));
     assertEquals(Food.PORK, cookedBacon.getMaterial());
     assertTrue(cookedBacon.isCooked());
@@ -554,21 +554,21 @@ public class BindingTest extends TestCase {
           "Guice configuration errors:",
           "1) No implementation for"
               + " com.google.inject.BindingTest$Bacon annotated with"
-              + " @com.google.inject.name.Named(value="
+              + " @com.google.inject.name.Named(" + Annotations.memberKeyString()
               + Annotations.memberValueString("Turky")
               + ") was bound.",
           "Did you mean?",
           "* com.google.inject.BindingTest$Bacon annotated with"
-              + " @com.google.inject.name.Named(value="
+              + " @com.google.inject.name.Named(" + Annotations.memberKeyString()
               + Annotations.memberValueString("Turkey")
               + ")",
           "* com.google.inject.BindingTest$Bacon annotated with"
-              + " @com.google.inject.name.Named(value="
+              + " @com.google.inject.name.Named(" + Annotations.memberKeyString()
               + Annotations.memberValueString("Tofu")
               + ")",
           "1 more binding with other annotations.",
           "while locating com.google.inject.BindingTest$Bacon annotated with"
-              + " @com.google.inject.name.Named(value="
+              + " @com.google.inject.name.Named(" + Annotations.memberKeyString()
               + Annotations.memberValueString("Turky")
               + ")");
     }
@@ -594,16 +594,16 @@ public class BindingTest extends TestCase {
           msg,
           "1) No implementation for com.google.inject.BindingTest$Bacon"
               + " annotated with"
-              + " @com.google.inject.name.Named(value="
+              + " @com.google.inject.name.Named(" + Annotations.memberKeyString()
               + Annotations.memberValueString("turkey")
               + ") was bound.",
           "Did you mean?",
           "* com.google.inject.BindingTest$Bacon annotated with"
-              + " @com.google.inject.name.Named(value="
+              + " @com.google.inject.name.Named(" + Annotations.memberKeyString()
               + Annotations.memberValueString("Turkey")
               + ")",
           "while locating com.google.inject.BindingTest$Bacon annotated with"
-              + " @com.google.inject.name.Named(value="
+              + " @com.google.inject.name.Named(" + Annotations.memberKeyString()
               + Annotations.memberValueString("turkey")
               + ")");
     }

--- a/core/test/com/google/inject/ImplicitBindingTest.java
+++ b/core/test/com/google/inject/ImplicitBindingTest.java
@@ -100,13 +100,13 @@ public class ImplicitBindingTest extends TestCase {
           "1) No implementation for " + I.class.getName(),
           "annotated with @"
               + Named.class.getName()
-              + "(value="
+              + "(" + Annotations.memberKeyString()
               + Annotations.memberValueString("i")
               + ") was bound.",
           "while locating " + I.class.getName(),
           " annotated with @"
               + Named.class.getName()
-              + "(value="
+              + "(" + Annotations.memberKeyString()
               + Annotations.memberValueString("i")
               + ")");
     }

--- a/core/test/com/google/inject/MembersInjectorTest.java
+++ b/core/test/com/google/inject/MembersInjectorTest.java
@@ -280,7 +280,7 @@ public class MembersInjectorTest extends TestCase {
       assertContains(
           expected.getMessage(),
           "1) No implementation for com.google.inject.MembersInjector<java.lang.String> "
-              + "annotated with @com.google.inject.name.Named(value="
+              + "annotated with @com.google.inject.name.Named(" + Annotations.memberKeyString()
               + Annotations.memberValueString("foo")
               + ") was bound.");
     }

--- a/core/test/com/google/inject/PrivateModuleTest.java
+++ b/core/test/com/google/inject/PrivateModuleTest.java
@@ -296,10 +296,10 @@ public class PrivateModuleTest extends TestCase {
           "at " + getClass().getName(),
           getDeclaringSourcePart(getClass()),
           "2) No implementation for " + String.class.getName(),
-          "Named(value=" + Annotations.memberValueString("a") + ") was bound.",
+          "Named(" + Annotations.memberKeyString() + Annotations.memberValueString("a") + ") was bound.",
           "for field at " + AB.class.getName() + ".a(PrivateModuleTest.java:",
           "3) No implementation for " + String.class.getName(),
-          "Named(value=" + Annotations.memberValueString("b") + ") was bound.",
+          "Named(" + Annotations.memberKeyString() + Annotations.memberValueString("b") + ") was bound.",
           "for field at " + AB.class.getName() + ".b(PrivateModuleTest.java:",
           "3 errors");
     }

--- a/core/test/com/google/inject/name/NamedEquivalanceTest.java
+++ b/core/test/com/google/inject/name/NamedEquivalanceTest.java
@@ -124,7 +124,7 @@ public class NamedEquivalanceTest extends TestCase {
       assertContains(
           e.getMessage(),
           "No implementation for java.lang.String annotated with "
-              + "@com.google.inject.name.Named(value="
+              + "@com.google.inject.name.Named(" + Annotations.memberKeyString()
               + Annotations.memberValueString("foo")
               + ") was bound.");
     }
@@ -140,7 +140,8 @@ public class NamedEquivalanceTest extends TestCase {
       if (fails) {
         assertContains(
             e.getMessage(),
-            "A binding to java.lang.String annotated with @com.google.inject.name.Named(value="
+            "A binding to java.lang.String annotated with @com.google.inject.name.Named("
+                + Annotations.memberKeyString()
                 + Annotations.memberValueString("foo")
                 + ") was already configured");
       } else {
@@ -238,7 +239,7 @@ public class NamedEquivalanceTest extends TestCase {
     public String toString() {
       return "@"
           + javax.inject.Named.class.getName()
-          + "(value="
+          + "(" + Annotations.memberKeyString()
           + Annotations.memberValueString(value)
           + ")";
     }
@@ -283,7 +284,7 @@ public class NamedEquivalanceTest extends TestCase {
     public String toString() {
       return "@"
           + com.google.inject.name.Named.class.getName()
-          + "(value="
+          + "(" + Annotations.memberKeyString()
           + Annotations.memberValueString(value)
           + ")";
     }

--- a/core/test/com/google/inject/spi/InjectionPointTest.java
+++ b/core/test/com/google/inject/spi/InjectionPointTest.java
@@ -69,7 +69,8 @@ public class InjectionPointTest extends TestCase {
 
     Dependency<?> dependency = getOnlyElement(injectionPoint.getDependencies());
     assertEquals(
-        "Key[type=java.lang.String, annotation=@com.google.inject.name.Named(value="
+        "Key[type=java.lang.String, annotation=@com.google.inject.name.Named("
+            + Annotations.memberKeyString()
             + Annotations.memberValueString("a")
             + ")]@"
             + getClass().getName()
@@ -98,7 +99,8 @@ public class InjectionPointTest extends TestCase {
 
     Dependency<?> dependency = getOnlyElement(injectionPoint.getDependencies());
     assertEquals(
-        "Key[type=java.lang.String, annotation=@com.google.inject.name.Named(value="
+        "Key[type=java.lang.String, annotation=@com.google.inject.name.Named("
+            + Annotations.memberKeyString()
             + Annotations.memberValueString("b")
             + ")]@"
             + getClass().getName()
@@ -128,7 +130,8 @@ public class InjectionPointTest extends TestCase {
 
     Dependency<?> dependency = getOnlyElement(injectionPoint.getDependencies());
     assertEquals(
-        "Key[type=java.lang.String, annotation=@com.google.inject.name.Named(value="
+        "Key[type=java.lang.String, annotation=@com.google.inject.name.Named("
+            + Annotations.memberKeyString()
             + Annotations.memberValueString("c")
             + ")]@"
             + Constructable.class.getName()
@@ -146,7 +149,8 @@ public class InjectionPointTest extends TestCase {
   public void testUnattachedDependency() throws IOException {
     Dependency<String> dependency = Dependency.get(Key.get(String.class, named("d")));
     assertEquals(
-        "Key[type=java.lang.String, annotation=@com.google.inject.name.Named(value="
+        "Key[type=java.lang.String, annotation=@com.google.inject.name.Named("
+            + Annotations.memberKeyString()
             + Annotations.memberValueString("d")
             + ")]",
         dependency.toString());

--- a/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
+++ b/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
@@ -122,7 +122,8 @@ final class FactoryProvider2<F>
         public String toString() {
           return "@"
               + Assisted.class.getName()
-              + "(value="
+              + "("
+              + Annotations.memberKeyString()
               + Annotations.memberValueString("")
               + ")";
         }

--- a/extensions/assistedinject/test/com/google/inject/assistedinject/FactoryProvider2Test.java
+++ b/extensions/assistedinject/test/com/google/inject/assistedinject/FactoryProvider2Test.java
@@ -673,7 +673,8 @@ public class FactoryProvider2Test extends TestCase {
               + " [com.google.inject.Provider<"
               + Color.class.getName()
               + ">"
-              + " annotated with @com.google.inject.assistedinject.Assisted(value="
+              + " annotated with @com.google.inject.assistedinject.Assisted("
+              + Annotations.memberKeyString()
               + Annotations.memberValueString("color")
               + ")]"
               + " on method ["
@@ -731,7 +732,8 @@ public class FactoryProvider2Test extends TestCase {
               + " [com.google.inject.Provider<"
               + Color.class.getName()
               + ">"
-              + " annotated with @com.google.inject.assistedinject.Assisted(value="
+              + " annotated with @com.google.inject.assistedinject.Assisted("
+              + Annotations.memberKeyString()
               + Annotations.memberValueString("color")
               + ")]"
               + " on method ["
@@ -866,7 +868,8 @@ public class FactoryProvider2Test extends TestCase {
               + Color.class.getName()
               + " annotated with @"
               + Assisted.class.getName()
-              + "(value="
+              + "("
+              + Annotations.memberKeyString()
               + Annotations.memberValueString("paint")
               + ") was already configured at");
     }

--- a/extensions/grapher/test/com/google/inject/grapher/ShortNameFactoryTest.java
+++ b/extensions/grapher/test/com/google/inject/grapher/ShortNameFactoryTest.java
@@ -103,7 +103,7 @@ public class ShortNameFactoryTest extends TestCase {
   public void testGetAnnotationName_annotationInstanceWithParameters() throws Exception {
     Key<?> key = Key.get(String.class, Names.named("name"));
     assertEquals(
-        "@Named(value=" + Annotations.memberValueString("name") + ")",
+        "@Named(" + Annotations.memberKeyString() + Annotations.memberValueString("name") + ")",
         nameFactory.getAnnotationName(key));
   }
 


### PR DESCRIPTION
Fixes #1312

The explicitly-not-specified toString implementation of annotations has changed in Java 14. See JDK-8225356 - "Make javac's toString() on annotation objects consistent with core reflection" [1], for specific details.

At a minimum, annotations with just one element named value elide the "value=" prefix. This has some impact on the toString implementations in Guice. To be consistent with the Java 14 string representation of such annotations the "value=" should be dropped. This can be determined at runtime, so that behaviour can be consistent with the actual Java runtime behaviour.

[1] https://bugs.openjdk.java.net/browse/JDK-8225356