### PR TITLE
Unnecessary null check

### DIFF
--- a/core/src/com/google/inject/internal/InternalInjectorCreator.java
+++ b/core/src/com/google/inject/internal/InternalInjectorCreator.java
@@ -95,10 +95,6 @@ public final class InternalInjectorCreator {
   }
 
   public Injector build() {
-    if (shellBuilder == null) {
-      throw new AssertionError("Already built, builders are not reusable.");
-    }
-
     // Synchronize while we're building up the bindings and other injector state. This ensures that
     // the JIT bindings in the parent injector don't change while we're being built
     synchronized (shellBuilder.lock()) {


### PR DESCRIPTION
The '[shellBuilder](https://github.com/wangyuntao/guice/blob/master/core/src/com/google/inject/internal/InternalInjectorCreator.java#L69)' is declared as final, it can't be modified, so the null check is unnecessary.

