### PR TITLE
The enhancement for the issue #216

### DIFF
--- a/core/src/com/google/inject/EagerSingleton.java
+++ b/core/src/com/google/inject/EagerSingleton.java
@@ -1,0 +1,19 @@
+package com.google.inject;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Apply this to implementation classes when you want only one instance (per {@link Injector}) to be
+ * reused for all injections for that binding.
+ *
+ * @author 11712617@mail.sustech.edu.cn (Xinhao Xiang)
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RUNTIME)
+@ScopeAnnotation
+public @interface EagerSingleton {
+}

--- a/core/src/com/google/inject/Guice.java
+++ b/core/src/com/google/inject/Guice.java
@@ -86,4 +86,14 @@ public final class Guice {
   public static Injector createInjector(Stage stage, Iterable<? extends Module> modules) {
     return new InternalInjectorCreator().stage(stage).addModules(modules).build();
   }
+
+  /**
+   * A static helper that returns whether a given instance has been enhanced
+   *
+   * @param obj the given instance wanted to be checked
+   * @return {@code true} if the given instance has been enhanced
+   */
+  public static boolean isGuiceEnhanced(Object obj){
+    return obj.getClass().getName().contains("EnhancerByGuice");
+  }
 }

--- a/core/src/com/google/inject/internal/Scoping.java
+++ b/core/src/com/google/inject/internal/Scoping.java
@@ -26,6 +26,7 @@ import com.google.inject.Stage;
 import com.google.inject.binder.ScopedBindingBuilder;
 import com.google.inject.spi.BindingScopingVisitor;
 import com.google.inject.spi.ScopeBinding;
+
 import java.lang.annotation.Annotation;
 
 /**
@@ -162,6 +163,9 @@ public abstract class Scoping {
   public static Scoping forAnnotation(final Class<? extends Annotation> scopingAnnotation) {
     if (scopingAnnotation == Singleton.class || scopingAnnotation == javax.inject.Singleton.class) {
       return SINGLETON_ANNOTATION;
+    }
+    if (scopingAnnotation == EagerSingleton.class) {
+        return EAGER_SINGLETON;
     }
 
     return new Scoping() {

--- a/core/src/com/google/inject/internal/Scoping.java
+++ b/core/src/com/google/inject/internal/Scoping.java
@@ -22,6 +22,7 @@ import com.google.inject.Provider;
 import com.google.inject.Scope;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.google.inject.EagerSingleton;
 import com.google.inject.Stage;
 import com.google.inject.binder.ScopedBindingBuilder;
 import com.google.inject.spi.BindingScopingVisitor;

--- a/core/test/com/google/inject/SingletonTest.java
+++ b/core/test/com/google/inject/SingletonTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2006 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.inject;
+
+
+import junit.framework.TestCase;
+
+/**
+ * @author 11712617@mail.sustech.edu.cn (Xinhao Xiang)
+ */
+public class SingletonTest extends TestCase {
+
+    static final long DEADLOCK_TIMEOUT_SECONDS = 1;
+
+    private final AbstractModule singletonsModule =
+            new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(ScopesTest.AnnotatedSingleton.class);
+                    bind(AnnotatedEagerSingleton.class);
+                }
+            };
+
+    @Override
+    protected void setUp() throws Exception {
+        ScopesTest.AnnotatedSingleton.nextInstanceId = 0;
+        AnnotatedEagerSingleton.nextInstanceId = 0;
+    }
+
+    public void testSingletonsInProductionStage() {
+        Guice.createInjector(Stage.PRODUCTION, singletonsModule);
+        assertEquals(1, ScopesTest.AnnotatedSingleton.nextInstanceId);
+    }
+
+    public void testSingletonsInDevelopmentStage() {
+        Guice.createInjector(Stage.DEVELOPMENT, singletonsModule);
+        assertEquals(0, ScopesTest.AnnotatedSingleton.nextInstanceId);
+    }
+
+    public void testStageEagerSingletonInDevelopmentStage() {
+        Guice.createInjector(Stage.DEVELOPMENT, singletonsModule);
+        assertEquals(1, AnnotatedEagerSingleton.nextInstanceId);
+    }
+
+    @EagerSingleton
+    static class AnnotatedEagerSingleton {
+        static int nextInstanceId;
+        final int instanceId = nextInstanceId++;
+    }
+}

--- a/core/test/com/googlecode/guice/BytecodeGenTest.java
+++ b/core/test/com/googlecode/guice/BytecodeGenTest.java
@@ -95,6 +95,12 @@ public class BytecodeGenTest extends TestCase {
             .startsWith(PublicUserOfPackagePrivate.class.getName() + "$$EnhancerByGuice$$"));
   }
 
+  public void testIsEnhancedJudge() {
+    Injector injector = Guice.createInjector(interceptorModule, new PackageVisibilityTestModule());
+    PublicUserOfPackagePrivate pupp = injector.getInstance(PublicUserOfPackagePrivate.class);
+    assertTrue(Guice.isGuiceEnhanced(pupp));
+  }
+
   // TODO(sameb): Figure out how to test FastClass naming tests.
 
   /** Custom URL classloader with basic visibility rules */


### PR DESCRIPTION
Solve issue #216 and add corresponding test for it.

I add an new way to create an eager singleton: use the annotation @EagerSingleton. 

In this way, when we do development in Stage.DEVELOPMENT, we can simply use the annotation to create an eager Injector, just like that in Stage.PRODUCTION and  use @Singleton to create a lazy injector.

**Test scenario**
When user both use @EagerSingleton in production stage, the injector should give an eager singleton instance.

When user both use @EagerSingleton in development stage, the injector should also give an eager singleton instance.
