### PR TITLE
MOE Sync 2020-05-12

### DIFF
--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -625,6 +625,7 @@ public final class Errors implements Serializable {
       return;
     }
 
+
     throw new CreationException(getMessages());
   }
 
@@ -632,6 +633,7 @@ public final class Errors implements Serializable {
     if (!hasErrors()) {
       return;
     }
+
 
     throw new ConfigurationException(getMessages());
   }
@@ -641,6 +643,7 @@ public final class Errors implements Serializable {
     if (!hasErrors()) {
       return;
     }
+
 
     throw new ProvisionException(getMessages());
   }
@@ -681,6 +684,7 @@ public final class Errors implements Serializable {
     if (size() == expectedSize) {
       return;
     }
+
 
     throw toException();
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Report errors to MetricsRecorder when exceptions are thrown from Guice.

Changed `MetricsRecorder` to handle all messages inside an exception at once instead one by one. This is more efficient when a lot of errors are reported in a few exceptions and would also allow implementation of the `MetricsRecorder` to provide metrics on total error count per exception.

5c2e6467e01a8b784078042be5646feacd32fb82