### PR TITLE
MOE Sync 2020-05-17

### DIFF
--- a/core/src/com/google/inject/RestrictedBindingSource.java
+++ b/core/src/com/google/inject/RestrictedBindingSource.java
@@ -15,9 +15,10 @@ import java.lang.annotation.Target;
  *
  * <p>If a binding's type or qualifier annotation type is annotated with
  * {@code @RestrictedBindingSource}, then only modules annotated with a permit from {@link #permits}
- * are allowed to create it (note that if both the type and qualifier annotation type are restricted
- * this way, both restrictions are enforced) -- otherwise, an error message including the {@link
- * #explanation} is issued.
+ * are allowed to create it -- otherwise, an error message including the {@link #explanation} is
+ * issued. Note that if both the type and qualifier annotation type are restricted this way, the
+ * qualifier annotation restriction overrides the type restriction (annotating is essentially
+ * syntactic sugar for creating a new type that wraps the annotated type).
  *
  * <p>This allows libraries to prevent their clients from binding their keys, similar to how
  * declaring a class final prevents subtyping. For example, a library may want to prevent users from

--- a/core/src/com/google/inject/internal/GuiceInternal.java
+++ b/core/src/com/google/inject/internal/GuiceInternal.java
@@ -1,0 +1,14 @@
+package com.google.inject.internal;
+
+/**
+ * Class used for restricting APIs in other packages to only be used by this package.
+ *
+ * <p>Other packages can reference this class but only this package can reference an instance of it,
+ * so adding this class as a method param ensures that only this package can call it (provided null
+ * is disallowed).
+ */
+public final class GuiceInternal {
+  static final GuiceInternal GUICE_INTERNAL = new GuiceInternal();
+
+  private GuiceInternal() {}
+}

--- a/core/src/com/google/inject/internal/InjectorShell.java
+++ b/core/src/com/google/inject/internal/InjectorShell.java
@@ -129,6 +129,9 @@ final class InjectorShell {
       checkState(stage != null, "Stage not initialized");
       checkState(privateElements == null || parent != null, "PrivateElements with no parent");
       checkState(state != null, "no state. Did you remember to lock() ?");
+      checkState(
+          (privateElements == null && elements.isEmpty()) || modules.isEmpty(),
+          "The shell is either built from modules (root) or from PrivateElements (children).");
 
       // bind Singleton if this is a top-level injector
       if (parent == null) {

--- a/core/src/com/google/inject/internal/InjectorShell.java
+++ b/core/src/com/google/inject/internal/InjectorShell.java
@@ -18,6 +18,7 @@ package com.google.inject.internal;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -31,6 +32,7 @@ import com.google.inject.Stage;
 import com.google.inject.internal.InjectorImpl.InjectorOptions;
 import com.google.inject.internal.util.SourceProvider;
 import com.google.inject.internal.util.Stopwatch;
+import com.google.inject.spi.BindingSourceRestriction;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.Element;
 import com.google.inject.spi.Elements;
@@ -135,6 +137,14 @@ final class InjectorShell {
         modules.add(0, new InheritedScannersModule(parent.state));
       }
       elements.addAll(Elements.getElements(stage, modules));
+
+      // Check binding source restrictions only for the root shell (note that the root shell
+      // can have a parent Injector, when Injector.createChildInjector is called). It isn't
+      // necessary to call this check on child PrivateElements shells because it walks the entire
+      // tree of elements, recurring on PrivateElements.
+      if (privateElements == null) {
+        elements.addAll(BindingSourceRestriction.check(GUICE_INTERNAL, elements));
+      }
 
       // Look for injector-changing options
       InjectorOptionsProcessor optionsProcessor = new InjectorOptionsProcessor(errors);

--- a/core/src/com/google/inject/internal/LinkedBindingImpl.java
+++ b/core/src/com/google/inject/internal/LinkedBindingImpl.java
@@ -32,7 +32,7 @@ public final class LinkedBindingImpl<T> extends BindingImpl<T>
 
   final Key<? extends T> targetKey;
 
-  public LinkedBindingImpl(
+  LinkedBindingImpl(
       InjectorImpl injector,
       Key<T> key,
       Object source,
@@ -43,7 +43,7 @@ public final class LinkedBindingImpl<T> extends BindingImpl<T>
     this.targetKey = targetKey;
   }
 
-  public LinkedBindingImpl(Object source, Key<T> key, Scoping scoping, Key<? extends T> targetKey) {
+  LinkedBindingImpl(Object source, Key<T> key, Scoping scoping, Key<? extends T> targetKey) {
     super(source, key, scoping);
     this.targetKey = targetKey;
   }

--- a/core/src/com/google/inject/spi/BindingSourceRestriction.java
+++ b/core/src/com/google/inject/spi/BindingSourceRestriction.java
@@ -1,0 +1,288 @@
+package com.google.inject.spi;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.toList;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Binding;
+import com.google.inject.Key;
+import com.google.inject.RestrictedBindingSource;
+import com.google.inject.internal.GuiceInternal;
+import java.lang.annotation.Annotation;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Contains abstractions for enforcing {@link RestrictedBindingSource}.
+ *
+ * <p>Enforcement happens in two phases:
+ *
+ * <ol>
+ *   <li>Data structures for enforcement are built during Binder configuration. {@link
+ *       PermitMapConstruction} encapsulates this process, and the {@link PermitMap} is the end
+ *       result.
+ *   <li>Restrictions are enforced by checking each binding for violations with {@link #check},
+ *       which uses the {@link PermitMap}(s) built during Binder configuration.
+ * </ol>
+ *
+ * <p>Note: None of this is thread-safe because it's only used while the Injector is being built,
+ * which happens on a single thread.
+ *
+ * @author vzm@google.com (Vladimir Makaric)
+ */
+public final class BindingSourceRestriction {
+  private BindingSourceRestriction() {}
+
+  /** Mapping between an element source and its permit annotations. */
+  interface PermitMap {
+    ImmutableSet<Class<? extends Annotation>> getPermits(ElementSource elementSource);
+
+    void clear();
+  }
+
+  /**
+   * Returns all the restriction violations found on the given Module Elements, as error messages.
+   *
+   * <p>Note: Intended to be used on Module Elements, not Injector Elements, ie. the result of
+   * {@link Elements#getElements} not {@code Injector.getElements}. The Module Elements this check
+   * cares about are:
+   *
+   * <ul>
+   *   <li>Module Bindings, which are always explicit and always have an {@link ElementSource} (with
+   *       a Module Stack), unlike Injector Bindings, which may be implicit and bereft of an
+   *       ElementSource.
+   *   <li>{@link PrivateElements}, which represent the recursive case of this check. They contain a
+   *       list of elements that this check is recursively called on.
+   * </ul>
+   */
+  public static ImmutableList<Message> check(GuiceInternal guiceInternal, List<Element> elements) {
+    checkNotNull(guiceInternal);
+    ImmutableList<Message> errorMessages = check(elements);
+    // Clear all the permit maps after the checks are done.
+    elements.forEach(BindingSourceRestriction::clear);
+    return errorMessages;
+  }
+
+  private static ImmutableList<Message> check(List<Element> elements) {
+    ImmutableList.Builder<Message> errorMessagesBuilder = ImmutableList.builder();
+    for (Element element : elements) {
+      errorMessagesBuilder.addAll(check(element));
+    }
+    return errorMessagesBuilder.build();
+  }
+
+  private static ImmutableList<Message> check(Element element) {
+    return element.acceptVisitor(
+        new DefaultElementVisitor<ImmutableList<Message>>() {
+          // Base case.
+          @Override
+          protected ImmutableList<Message> visitOther(Element element) {
+            return ImmutableList.of();
+          }
+          // Base case.
+          @Override
+          public <T> ImmutableList<Message> visit(Binding<T> binding) {
+            Optional<Message> errorMessage = check(binding);
+            if (errorMessage.isPresent()) {
+              return ImmutableList.of(errorMessage.get());
+            }
+            return ImmutableList.of();
+          }
+          // Recursive case.
+          @Override
+          public ImmutableList<Message> visit(PrivateElements privateElements) {
+            return check(privateElements.getElements());
+          }
+        });
+  }
+
+  private static Optional<Message> check(Binding<?> binding) {
+    Key<?> key = binding.getKey();
+    // Module Bindings are all explicit and have an ElementSource.
+    ElementSource elementSource = (ElementSource) binding.getSource();
+    RestrictedBindingSource annotationRestriction =
+        key.getAnnotationType() == null
+            ? null
+            : key.getAnnotationType().getAnnotation(RestrictedBindingSource.class);
+    RestrictedBindingSource restriction = annotationRestriction;
+    if (annotationRestriction == null) {
+      // Annotation restriction overrides type restriction.
+      restriction = key.getTypeLiteral().getRawType().getAnnotation(RestrictedBindingSource.class);
+    }
+    // Exit if there is no binding source restrictions on the key.
+    if (restriction == null) {
+      return Optional.empty();
+    }
+    ImmutableSet<Class<? extends Annotation>> permits = getAllPermits(elementSource);
+    ImmutableSet<Class<? extends Annotation>> acceptablePermits =
+        ImmutableSet.copyOf(restriction.permits());
+    boolean bindingPermitted = permits.stream().anyMatch(acceptablePermits::contains);
+    if (!bindingPermitted) {
+      return Optional.of(
+          new Message(
+              elementSource,
+              getErrorMessage(
+                  key,
+                  restriction.explanation(),
+                  acceptablePermits,
+                  annotationRestriction != null)));
+    }
+    return Optional.empty();
+  }
+
+  private static String getErrorMessage(
+      Key<?> key,
+      String explanation,
+      ImmutableSet<Class<? extends Annotation>> acceptablePermits,
+      boolean annotationRestricted) {
+    return String.format(
+        "Unable to bind key: %s. One of the modules that created this binding has to be annotated"
+            + " with one of %s, because the key's %s is annotated with @RestrictedBindingSource."
+            + " %s",
+        key,
+        acceptablePermits.stream().map(a -> "@" + a.getName()).collect(toList()),
+        annotationRestricted ? "annotation" : "type",
+        explanation);
+  }
+
+  /**
+   * Get all permits on the element source chain. Trusting only original (parent) element sources if
+   * they are set by Modules.override.
+   */
+  private static ImmutableSet<Class<? extends Annotation>> getAllPermits(
+      ElementSource elementSource) {
+    ImmutableSet.Builder<Class<? extends Annotation>> permitsBuilder = ImmutableSet.builder();
+    ImmutableSet<Class<? extends Annotation>> permits =
+        elementSource.moduleSource.getPermitMap().getPermits(elementSource);
+    // Only trust if the element comes from Modules.override because otherwise the original element
+    // source can be spoofed.
+    // TODO(b/156495326): Remove this special case once we resolve the spoofing issue.
+    if (elementSource.getOriginalElementSource() == null
+        || !elementSource
+            .moduleSource
+            .getModuleClassName()
+            .equals("com.google.inject.util.Modules$OverrideModule")) {
+      return permits;
+    }
+    permitsBuilder.addAll(permits);
+    permitsBuilder.addAll(getAllPermits(elementSource.getOriginalElementSource()));
+    return permitsBuilder.build();
+  }
+
+  private static void clear(Element element) {
+    element.acceptVisitor(
+        new DefaultElementVisitor<Void>() {
+          // Base case.
+          @Override
+          protected Void visitOther(Element element) {
+            Object source = element.getSource();
+            // Some Module Elements, like Message, don't always have an ElementSource.
+            if (source instanceof ElementSource) {
+              clear((ElementSource) source);
+            }
+            return null;
+          }
+          // Recursive case.
+          @Override
+          public Void visit(PrivateElements privateElements) {
+            privateElements.getElements().forEach(BindingSourceRestriction::clear);
+            return null;
+          }
+        });
+  }
+
+  private static void clear(ElementSource elementSource) {
+    while (elementSource != null) {
+      elementSource.moduleSource.getPermitMap().clear();
+      elementSource = elementSource.getOriginalElementSource();
+    }
+  }
+
+  /**
+   * Builds the map from each module to all the permit annotations on its module stack.
+   *
+   * <p>Bindings refer to the module that created them via a {@link ModuleSource}. The map built
+   * here maps a module's {@link ModuleSource} to all the {@link RestrictedBindingSource.Permit}
+   * annotations found on the path from the root of the module hierarchy to it. This path contains
+   * all the modules that transitively install the module (including the module itself). This path
+   * is also known as the module stack.
+   *
+   * <p>The map is built by piggybacking on the depth-first traversal of the module hierarchy during
+   * Binder configuration.
+   */
+  static final class PermitMapConstruction {
+    private static final class PermitMapImpl implements PermitMap {
+      // TODO(user): Include permits on ModuleAnnotatedMethodScanners here.
+      ImmutableMap<ModuleSource, ImmutableSet<Class<? extends Annotation>>> modulePermits;
+
+      @Override
+      public ImmutableSet<Class<? extends Annotation>> getPermits(ElementSource elementSource) {
+        return modulePermits.get(elementSource.moduleSource);
+      }
+
+      @Override
+      public void clear() {
+        modulePermits = null;
+      }
+    }
+
+    final ImmutableMap.Builder<ModuleSource, ImmutableSet<Class<? extends Annotation>>>
+        modulePermits = ImmutableMap.builder();
+    // Maintains the permits on the current module installation path.
+    ImmutableSet<Class<? extends Annotation>> currentModulePermits = ImmutableSet.of();
+    // Stack tracking the currentModulePermits during module traversal.
+    final Deque<ImmutableSet<Class<? extends Annotation>>> modulePermitsStack = new ArrayDeque<>();
+
+    final PermitMapImpl permitMap = new PermitMapImpl();
+
+    /**
+     * Returns a possibly unfinished map. The map should only be used after the construction is
+     * finished.
+     */
+    PermitMap getPermitMap() {
+      return permitMap;
+    }
+
+    /** Called by the Binder prior to entering a module's configure method. */
+    void pushModule(Class<?> module, ModuleSource moduleSource) {
+      List<Class<? extends Annotation>> newModulePermits =
+          getPermits(module)
+              .filter(permit -> !currentModulePermits.contains(permit))
+              .collect(toList());
+      // Save the parent module's permits so that they can be restored when the Binder exits this
+      // new (child) module's configure method.
+      modulePermitsStack.push(currentModulePermits);
+      if (!newModulePermits.isEmpty()) {
+        currentModulePermits =
+            ImmutableSet.<Class<? extends Annotation>>builder()
+                .addAll(currentModulePermits)
+                .addAll(newModulePermits)
+                .build();
+      }
+      modulePermits.put(moduleSource, currentModulePermits);
+    }
+
+    private static Stream<Class<? extends Annotation>> getPermits(Class<?> clazz) {
+      return Arrays.stream(clazz.getAnnotations())
+          .map(Annotation::annotationType)
+          .filter(a -> a.isAnnotationPresent(RestrictedBindingSource.Permit.class));
+    }
+
+    /** Called by the Binder when it exits a module's configure method. */
+    void popModule() {
+      // Restore the parent module's permits.
+      currentModulePermits = modulePermitsStack.pop();
+    }
+
+    /** Finishes the {@link PermitMap}. Called by the Binder when all modules are installed. */
+    void finish() {
+      permitMap.modulePermits = modulePermits.build();
+    }
+  }
+}

--- a/core/test/com/google/inject/RestrictedBindingSourceTest.java
+++ b/core/test/com/google/inject/RestrictedBindingSourceTest.java
@@ -1,0 +1,600 @@
+package com.google.inject;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.lang.annotation.ElementType.METHOD;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.spi.ElementSource;
+import com.google.inject.spi.Elements;
+import com.google.inject.spi.InjectionPoint;
+import com.google.inject.spi.ModuleAnnotatedMethodScanner;
+import com.google.inject.util.Modules;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.Set;
+import javax.inject.Qualifier;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link RestrictedBindingSource}.
+ *
+ * @author vzm@google.com (Vladimir Makaric)
+ */
+@RunWith(JUnit4.class)
+public class RestrictedBindingSourceTest {
+
+  // --------------------------------------------------------------------------
+  // Core Functionality Tests
+  // --------------------------------------------------------------------------
+
+  private static final String BINDING_PERMISSION_ERROR = "Unable to bind key";
+  private static final String USE_NETWORK_MODULE = "Please install NetworkModule.";
+  private static final String USE_ROUTING_MODULE = "Please install RoutingModule.";
+  private static final String NETWORK_ANNOTATION_IS_RESTRICTED =
+      "The @Network annotation can only be used to annotate Network library Keys.";
+
+  @RestrictedBindingSource.Permit
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface NetworkLibrary {}
+
+  @Qualifier
+  @RestrictedBindingSource(
+      explanation = USE_NETWORK_MODULE,
+      permits = {NetworkLibrary.class})
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface GatewayIpAdress {}
+
+  @Qualifier
+  @RestrictedBindingSource(
+      explanation = USE_NETWORK_MODULE,
+      permits = {NetworkLibrary.class})
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface Hostname {}
+
+  @NetworkLibrary
+  private static class NetworkModule extends AbstractModule {
+    @Provides
+    @GatewayIpAdress
+    int provideIpAddress() {
+      return 21321566;
+    }
+
+    @Override
+    protected void configure() {
+      bind(String.class).annotatedWith(Hostname.class).toInstance("google.com");
+    }
+  }
+
+  @Test
+  public void networkLibraryCanProvideItsBindings() {
+    Guice.createInjector(new NetworkModule());
+  }
+
+  @RestrictedBindingSource(
+      explanation = USE_ROUTING_MODULE,
+      permits = {NetworkLibrary.class})
+  @ImplementedBy(RoutingTableImpl.class) // For testing untargetted bindings.
+  interface RoutingTable {
+    int getNextHopIpAddress(int destinationIpAddress);
+  }
+
+  @NetworkLibrary
+  private static class RoutingModule extends AbstractModule {
+    @Provides
+    RoutingTable provideRoutingTable(@GatewayIpAdress int gateway) {
+      return destinationIp -> gateway;
+    }
+  }
+
+  @Test
+  public void networkBindingCantBeProvidedByOtherModules() {
+    AbstractModule rogueModule =
+        new AbstractModule() {
+          // This will fail, the gateway IP can only be provided by the network library.
+          @Provides
+          @GatewayIpAdress
+          int provideGatewayIp() {
+            return 42;
+          }
+
+          @Override
+          protected void configure() {
+            install(new RoutingModule());
+          }
+        };
+
+    CreationException expected = assertThatInjectorCreationFails(rogueModule);
+
+    assertThat(expected).hasMessageThat().contains(BINDING_PERMISSION_ERROR);
+    assertThat(expected).hasMessageThat().contains(USE_NETWORK_MODULE);
+  }
+
+  @Test
+  public void twoRogueNetworkBindingsYieldTwoErrorMessages() {
+    AbstractModule rogueModule =
+        new AbstractModule() {
+          @Provides
+          @GatewayIpAdress
+          int provideGatewayIp() {
+            return 42;
+          }
+
+          @Provides
+          RoutingTable provideRoutingTable() {
+            return destinationIp -> 0;
+          }
+        };
+
+    CreationException expected = assertThatInjectorCreationFails(rogueModule);
+
+    assertThat(expected).hasMessageThat().contains(BINDING_PERMISSION_ERROR);
+    assertThat(expected).hasMessageThat().contains(USE_NETWORK_MODULE);
+    assertThat(expected).hasMessageThat().contains(USE_ROUTING_MODULE);
+  }
+
+  @RestrictedBindingSource.Permit
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface NetworkTestLibrary {}
+
+  @Qualifier
+  @RestrictedBindingSource(
+      explanation = USE_NETWORK_MODULE,
+      permits = {NetworkLibrary.class, NetworkTestLibrary.class})
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface MacAddress {}
+
+  @NetworkTestLibrary
+  private static class TestMacAddressModule extends AbstractModule {
+    @Provides
+    @MacAddress
+    String provideMacAddress() {
+      return "deadbeef";
+    }
+  }
+
+  @Test
+  public void bindingWithTwoPermitsAllowedIfOnePresent() {
+    Guice.createInjector(new TestMacAddressModule());
+  }
+
+  private static class RoutingTableImpl implements RoutingTable {
+    @Inject
+    RoutingTableImpl() {}
+
+    @Override
+    public int getNextHopIpAddress(int destinationIpAddress) {
+      return destinationIpAddress + 2;
+    }
+  }
+
+  @Test
+  public void untargettedBindingAllowedWithPermit() {
+    @NetworkLibrary
+    class PermittedNetworkModule extends AbstractModule {
+      @Override
+      protected void configure() {
+        bind(RoutingTable.class);
+      }
+    }
+
+    Guice.createInjector(new PermittedNetworkModule());
+  }
+
+  @Test
+  public void untargettedBindingDisallowedWithoutPermit() {
+    AbstractModule rogueModule =
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(RoutingTable.class);
+          }
+        };
+
+    CreationException expected = assertThatInjectorCreationFails(rogueModule);
+
+    assertThat(expected).hasMessageThat().contains(BINDING_PERMISSION_ERROR);
+    assertThat(expected).hasMessageThat().contains(USE_ROUTING_MODULE);
+  }
+
+  // --------------------------------------------------------------------------
+  // Binder.withSource Tests
+  // --------------------------------------------------------------------------
+
+  @NetworkLibrary
+  private static class PermittedModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+      Method userUnpermittedModuleMethod;
+      try {
+        userUnpermittedModuleMethod = UnpermittedModule.class.getMethod("foo");
+      } catch (NoSuchMethodException e) {
+        throw new RuntimeException(e);
+      }
+
+      binder()
+          .withSource(userUnpermittedModuleMethod)
+          .bind(String.class)
+          .annotatedWith(Hostname.class)
+          .toInstance("google.com");
+    }
+  }
+
+  private static class UnpermittedModule extends AbstractModule {
+    public String foo() {
+      return "bar";
+    }
+  }
+
+  @Test
+  public void permittedModuleCanWithSourceAnUnpermittedModuleMethod() {
+    Guice.createInjector(new PermittedModule());
+  }
+
+  @Test
+  public void unpermittedModuleCantWithSourceAPermittedModule() {
+    AbstractModule rogueModule =
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            binder()
+                .withSource(PermittedModule.class)
+                .bindConstant()
+                .annotatedWith(GatewayIpAdress.class)
+                .to(0);
+          }
+        };
+
+    CreationException expected = assertThatInjectorCreationFails(rogueModule);
+
+    assertThat(expected).hasMessageThat().contains(BINDING_PERMISSION_ERROR);
+    assertThat(expected).hasMessageThat().contains(USE_NETWORK_MODULE);
+  }
+
+  // --------------------------------------------------------------------------
+  // ModuleAnnotatedMethodScanner tests
+  // --------------------------------------------------------------------------
+
+  @Target(METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  private @interface NetworkProvides {}
+
+  @Qualifier
+  @RestrictedBindingSource(
+      explanation = NETWORK_ANNOTATION_IS_RESTRICTED,
+      permits = {NetworkLibrary.class})
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface Network {}
+
+  // Adds the NetworkLibrary-owned Network annotation to keys produced by @NetworkProvides methods.
+  private static class NetworkProvidesScanner extends ModuleAnnotatedMethodScanner {
+    static Module module() {
+      return new AbstractModule() {
+        @Override
+        protected void configure() {
+          binder().scanModulesForAnnotatedMethods(new NetworkProvidesScanner());
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      return "NetworkProvidesScanner";
+    }
+
+    @Override
+    public Set<? extends Class<? extends Annotation>> annotationClasses() {
+      return ImmutableSet.of(NetworkProvides.class);
+    }
+
+    @Override
+    public <T> Key<T> prepareMethod(
+        Binder binder, Annotation annotation, Key<T> key, InjectionPoint injectionPoint) {
+      return Key.get(key.getTypeLiteral(), Network.class);
+    }
+  }
+
+  @Test
+  public void rogueBindingByMethodScannerDenied() {
+    AbstractModule rogueModule =
+        new AbstractModule() {
+          @NetworkProvides
+          String provideNetworkString() {
+            return "lorem ipsum";
+          }
+        };
+
+    CreationException expected =
+        assertThatInjectorCreationFails(rogueModule, NetworkProvidesScanner.module());
+
+    assertThat(expected).hasMessageThat().contains(BINDING_PERMISSION_ERROR);
+    assertThat(expected).hasMessageThat().contains(NETWORK_ANNOTATION_IS_RESTRICTED);
+  }
+
+  @Test
+  public void bindingsAddedByMethodScannerAllowedByNetworkLib() {
+    @NetworkLibrary
+    class NetworkModuleWithCustomProvides extends AbstractModule {
+      @NetworkProvides
+      String provideNetworkString() {
+        return "the real network string";
+      }
+    }
+
+    Guice.createInjector(new NetworkModuleWithCustomProvides(), NetworkProvidesScanner.module());
+  }
+
+  // --------------------------------------------------------------------------
+  // Modules.override tests
+  // --------------------------------------------------------------------------
+
+  @Test
+  public void modulesOverrideCantOverrideRestrictedBinding() {
+    Module rogueModule =
+        Modules.override(new NetworkModule())
+            .with(
+                new AbstractModule() {
+                  @Provides
+                  @GatewayIpAdress
+                  int provideRogueGatewayIp() {
+                    return 12345;
+                  }
+                });
+
+    CreationException expected = assertThatInjectorCreationFails(rogueModule);
+
+    assertThat(expected).hasMessageThat().contains(BINDING_PERMISSION_ERROR);
+    assertThat(expected).hasMessageThat().contains(USE_NETWORK_MODULE);
+  }
+
+  @Test
+  public void modulesOverrideRestrictedBindingAllowedIfParentHasPermit() {
+    @NetworkLibrary
+    class NetworkModuleVersion2 extends AbstractModule {
+      @Override
+      protected void configure() {
+        install(
+            Modules.override(new NetworkModule())
+                .with(
+                    new AbstractModule() {
+                      @Provides
+                      @GatewayIpAdress
+                      int provideGatewayIpV2() {
+                        return 2;
+                      }
+                    }));
+      }
+    }
+
+    assertThat(
+            Guice.createInjector(new NetworkModuleVersion2())
+                .getInstance(Key.get(Integer.class, GatewayIpAdress.class)))
+        .isEqualTo(2);
+  }
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface UnrestrictedQualifier {}
+
+  @Test
+  public void modulesOverrideCanOverrideUnrestrictedBinding() {
+    Module overrideModule =
+        Modules.override(
+                new NetworkModule(),
+                new AbstractModule() {
+                  @Override
+                  protected void configure() {
+                    bindConstant().annotatedWith(UnrestrictedQualifier.class).to("foo");
+                  }
+                })
+            .with(
+                new AbstractModule() {
+                  @Provides
+                  @UnrestrictedQualifier
+                  String provideRogueGatewayIp() {
+                    return "bar";
+                  }
+                });
+
+    assertThat(
+            Guice.createInjector(overrideModule)
+                .getInstance(Key.get(String.class, UnrestrictedQualifier.class)))
+        .isEqualTo("bar");
+  }
+
+  @Test
+  public void nestedModulesOverrideCanOverrideUnrestrictedBindings() {
+    Module overrideModule =
+        Modules.override(
+                Modules.override(
+                        new NetworkModule(),
+                        new AbstractModule() {
+                          @Override
+                          protected void configure() {
+                            bindConstant().annotatedWith(UnrestrictedQualifier.class).to("foo");
+                            bindConstant().annotatedWith(UnrestrictedQualifier.class).to(42);
+                          }
+                        })
+                    .with(
+                        new AbstractModule() {
+                          @Provides
+                          @UnrestrictedQualifier
+                          String overrideString() {
+                            return "bar";
+                          }
+                        }))
+            .with(
+                new AbstractModule() {
+                  @Provides
+                  @UnrestrictedQualifier
+                  int overrideLong() {
+                    return 45;
+                  }
+                });
+
+    Injector injector = Guice.createInjector(overrideModule);
+    assertThat(injector.getInstance(Key.get(String.class, UnrestrictedQualifier.class)))
+        .isEqualTo("bar");
+    assertThat(injector.getInstance(Key.get(Integer.class, UnrestrictedQualifier.class)))
+        .isEqualTo(45);
+  }
+
+  @Test
+  public void originalElementSourceNotTrustedOutsideModuleOverride() {
+    ElementSource networkElementSource =
+        (ElementSource) Elements.getElements(new NetworkModule()).get(0).getSource();
+
+    AbstractModule rogueModule =
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            binder()
+                .withSource(networkElementSource)
+                .bindConstant()
+                .annotatedWith(GatewayIpAdress.class)
+                .to(12);
+          }
+        };
+
+    // Confirm that the original element source was spoofed.
+    @SuppressWarnings("unchecked")
+    Binding<Integer> rogueGatewayBinding =
+        (Binding<Integer>) Elements.getElements(rogueModule).get(0);
+    assertThat(((ElementSource) rogueGatewayBinding.getSource()).getOriginalElementSource())
+        .isEqualTo(networkElementSource);
+
+    // Will fail because the original element source isn't trusted, becase it wasn't set by
+    // Modules.override.
+    CreationException expected = assertThatInjectorCreationFails(rogueModule);
+
+    assertThat(expected).hasMessageThat().contains(BINDING_PERMISSION_ERROR);
+    assertThat(expected).hasMessageThat().contains(USE_NETWORK_MODULE);
+  }
+
+  // --------------------------------------------------------------------------
+  // PrivateModule tests
+  // --------------------------------------------------------------------------
+
+  @NetworkLibrary
+  private static class NetworkModuleThatInstalls extends AbstractModule {
+    final Module module;
+
+    NetworkModuleThatInstalls(Module module) {
+      this.module = module;
+    }
+
+    @Override
+    protected void configure() {
+      install(module);
+    }
+  }
+
+  private static class PrivateModuleCreatesUnexposedNetworkBinding extends PrivateModule {
+    @Override
+    protected void configure() {
+      bindConstant().annotatedWith(GatewayIpAdress.class).to(0);
+    }
+  }
+
+  @Test
+  public void parentHasPermit_childPrivateModuleCanBind() {
+    Guice.createInjector(
+        new NetworkModuleThatInstalls(
+            // Allowed because the parent has the @NetworkLibrary permit.
+            new PrivateModuleCreatesUnexposedNetworkBinding()));
+  }
+
+  @Test
+  public void noPermitOnStack_privateModuleCantBind() {
+    AbstractModule rogueModule =
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            // Disallowed because there's no permit on the module stack.
+            install(new PrivateModuleCreatesUnexposedNetworkBinding());
+          }
+        };
+
+    CreationException expected = assertThatInjectorCreationFails(rogueModule);
+
+    assertThat(expected).hasMessageThat().contains(BINDING_PERMISSION_ERROR);
+    assertThat(expected).hasMessageThat().contains(USE_NETWORK_MODULE);
+  }
+
+  private static class PrivateModuleExposesNetworkBinding extends PrivateModule {
+    @Override
+    protected void configure() {
+      install(
+          new AbstractModule() {
+            @Override
+            protected void configure() {
+              bindConstant().annotatedWith(GatewayIpAdress.class).to(0);
+            }
+          });
+      expose(Key.get(Integer.class, GatewayIpAdress.class));
+    }
+  }
+
+  @Test
+  public void parentHasPermit_childPrivateModuleCanExposeBinding() {
+    Guice.createInjector(
+        new NetworkModuleThatInstalls(
+            // Allowed because the parent has the @NetworkLibrary permit.
+            new PrivateModuleExposesNetworkBinding()));
+  }
+
+  @Test
+  public void noPermitOnStack_childPrivateModuleCantExposeBinding() {
+    AbstractModule rogueModule =
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            // Disallowed because there's no permit on the module stack.
+            install(new PrivateModuleExposesNetworkBinding());
+          }
+        };
+
+    CreationException expected = assertThatInjectorCreationFails(rogueModule);
+
+    assertThat(expected).hasMessageThat().contains(BINDING_PERMISSION_ERROR);
+    assertThat(expected).hasMessageThat().contains(USE_NETWORK_MODULE);
+  }
+
+  // --------------------------------------------------------------------------
+  // Child Injector tests
+  // --------------------------------------------------------------------------
+
+  @Test
+  public void childInjectorCantBindRestrictedBindingWithoutPermit() {
+    Injector parent = Guice.createInjector(new NetworkModule());
+    AbstractModule rogueModule =
+        new AbstractModule() {
+          @Provides
+          RoutingTable provideRoutingTable() {
+            return destinationIp -> 0;
+          }
+        };
+
+    CreationException expected =
+        assertThrows(CreationException.class, () -> parent.createChildInjector(rogueModule));
+
+    assertThat(expected).hasMessageThat().contains(BINDING_PERMISSION_ERROR);
+    assertThat(expected).hasMessageThat().contains(USE_ROUTING_MODULE);
+  }
+
+  @Test
+  public void childInjectorCanBindRestrictedBindingWithPermit() {
+    Injector parent = Guice.createInjector(new NetworkModule());
+    parent.createChildInjector(new RoutingModule());
+  }
+
+  CreationException assertThatInjectorCreationFails(Module... modules) {
+    return assertThrows(CreationException.class, () -> Guice.createInjector(modules));
+  }
+}

--- a/core/test/com/google/inject/spi/ElementSourceTest.java
+++ b/core/test/com/google/inject/spi/ElementSourceTest.java
@@ -128,7 +128,7 @@ public class ElementSourceTest extends TestCase {
     // First module
     StackTraceElement[] partialCallStack = new StackTraceElement[1];
     partialCallStack[0] = BINDER_INSTALL;
-    ModuleSource moduleSource = new ModuleSource(A.class, partialCallStack);
+    ModuleSource moduleSource = new ModuleSource(A.class, partialCallStack, /* permitMap = */ null);
     // Second module
     partialCallStack = new StackTraceElement[2];
     partialCallStack[0] = BINDER_INSTALL;

--- a/core/test/com/google/inject/spi/ModuleSourceTest.java
+++ b/core/test/com/google/inject/spi/ModuleSourceTest.java
@@ -81,7 +81,7 @@ public class ModuleSourceTest extends TestCase {
   private ModuleSource createWithSizeOne() {
     StackTraceElement[] partialCallStack = new StackTraceElement[1];
     partialCallStack[0] = BINDER_INSTALL;
-    return new ModuleSource(A.class, partialCallStack);
+    return new ModuleSource(A.class, partialCallStack, /* permitMap = */ null);
   }
 
   private ModuleSource createWithSizeTwo() {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Implement @RestrictedBindingSource.

Change semantics when both type and qualifier annotation are restricted (annotation wins).

ec0b7974632c2034d55488138790dfefb76e22c4

-------

<p> Add precondition documenting the difference between a root and child InjectorShell.

3b8b2ebcef2e03651f99eff8e78729454430c0b2

-------

<p> Make LinkedBindingImpl constructors package-private to prevent original element source spoofing.

1f19197cf1338372980f8db708fb8e9a12070900