### PR TITLE
MOE Sync 2020-05-20

### DIFF
--- a/core/src/com/google/inject/RestrictedBindingSource.java
+++ b/core/src/com/google/inject/RestrictedBindingSource.java
@@ -63,6 +63,19 @@ public @interface RestrictedBindingSource {
    */
   Class<? extends Annotation>[] permits();
 
+  /**
+   * Exempt modules whose fully qualified class names match this regex.
+   *
+   * <p>If any module on the binding's module stack matches this regex, the binding is allowed (no
+   * permit necessary). No module is exempt by default (empty string).
+   *
+   * <p>Inteded to be used when retrofitting a binding with this restriction. When restricting an
+   * existing binding, it's often practical to first restrict with exemptions for existing
+   * violations (to prevent new violations), before updating the code in violation to use the
+   * permitted module(s).
+   */
+  String exemptModules() default "";
+
   /** Level of restriction. Determines how violations are handled. */
   public static enum RestrictionLevel {
     WARNING,
@@ -70,6 +83,4 @@ public @interface RestrictedBindingSource {
   }
 
   RestrictionLevel restrictionLevel() default RestrictionLevel.ERROR;
-
-  // TODO(user): Add exemption mechanism similar to RestrictedApi's allowedOnPath.
 }

--- a/core/src/com/google/inject/Scopes.java
+++ b/core/src/com/google/inject/Scopes.java
@@ -16,11 +16,12 @@
 
 package com.google.inject;
 
+import com.google.inject.internal.BindingImpl;
 import com.google.inject.internal.CircularDependencyProxy;
-import com.google.inject.internal.LinkedBindingImpl;
 import com.google.inject.internal.SingletonScope;
 import com.google.inject.spi.BindingScopingVisitor;
 import com.google.inject.spi.ExposedBinding;
+import com.google.inject.spi.LinkedKeyBinding;
 import java.lang.annotation.Annotation;
 
 /**
@@ -97,9 +98,9 @@ public class Scopes {
         return true;
       }
 
-      if (binding instanceof LinkedBindingImpl) {
-        LinkedBindingImpl<?> linkedBinding = (LinkedBindingImpl) binding;
-        Injector injector = linkedBinding.getInjector();
+      if (binding instanceof LinkedKeyBinding) {
+        LinkedKeyBinding<?> linkedBinding = (LinkedKeyBinding) binding;
+        Injector injector = getInjector(linkedBinding);
         if (injector != null) {
           binding = injector.getBinding(linkedBinding.getLinkedKey());
           continue;
@@ -159,9 +160,9 @@ public class Scopes {
         return true;
       }
 
-      if (binding instanceof LinkedBindingImpl) {
-        LinkedBindingImpl<?> linkedBinding = (LinkedBindingImpl) binding;
-        Injector injector = linkedBinding.getInjector();
+      if (binding instanceof LinkedKeyBinding) {
+        LinkedKeyBinding<?> linkedBinding = (LinkedKeyBinding) binding;
+        Injector injector = getInjector(linkedBinding);
         if (injector != null) {
           binding = injector.getBinding(linkedBinding.getLinkedKey());
           continue;
@@ -177,6 +178,13 @@ public class Scopes {
 
       return false;
     } while (true);
+  }
+
+  private static Injector getInjector(LinkedKeyBinding<?> linkedKeyBinding) {
+    if (linkedKeyBinding instanceof BindingImpl) {
+      return ((BindingImpl<?>) linkedKeyBinding).getInjector();
+    }
+    return null;
   }
 
   /**

--- a/core/src/com/google/inject/internal/BindingImpl.java
+++ b/core/src/com/google/inject/internal/BindingImpl.java
@@ -33,7 +33,7 @@ public abstract class BindingImpl<T> implements Binding<T> {
   private final Scoping scoping;
   private final InternalFactory<? extends T> internalFactory;
 
-  public BindingImpl(
+  BindingImpl(
       InjectorImpl injector,
       Key<T> key,
       Object source,
@@ -46,7 +46,7 @@ public abstract class BindingImpl<T> implements Binding<T> {
     this.scoping = scoping;
   }
 
-  protected BindingImpl(Object source, Key<T> key, Scoping scoping) {
+  BindingImpl(Object source, Key<T> key, Scoping scoping) {
     this.internalFactory = null;
     this.injector = null;
     this.source = source;

--- a/core/src/com/google/inject/internal/ExposedBindingImpl.java
+++ b/core/src/com/google/inject/internal/ExposedBindingImpl.java
@@ -27,11 +27,11 @@ import com.google.inject.spi.ExposedBinding;
 import com.google.inject.spi.PrivateElements;
 import java.util.Set;
 
-public final class ExposedBindingImpl<T> extends BindingImpl<T> implements ExposedBinding<T> {
+final class ExposedBindingImpl<T> extends BindingImpl<T> implements ExposedBinding<T> {
 
   private final PrivateElements privateElements;
 
-  public ExposedBindingImpl(
+  ExposedBindingImpl(
       InjectorImpl injector,
       Object source,
       Key<T> key,

--- a/core/src/com/google/inject/internal/LinkedBindingImpl.java
+++ b/core/src/com/google/inject/internal/LinkedBindingImpl.java
@@ -27,7 +27,7 @@ import com.google.inject.spi.HasDependencies;
 import com.google.inject.spi.LinkedKeyBinding;
 import java.util.Set;
 
-public final class LinkedBindingImpl<T> extends BindingImpl<T>
+final class LinkedBindingImpl<T> extends BindingImpl<T>
     implements LinkedKeyBinding<T>, HasDependencies {
 
   final Key<? extends T> targetKey;

--- a/core/src/com/google/inject/spi/BindingSourceRestriction.java
+++ b/core/src/com/google/inject/spi/BindingSourceRestriction.java
@@ -3,6 +3,7 @@ package com.google.inject.spi;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toList;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -283,6 +284,12 @@ public final class BindingSourceRestriction {
     /** Finishes the {@link PermitMap}. Called by the Binder when all modules are installed. */
     void finish() {
       permitMap.modulePermits = modulePermits.build();
+    }
+
+    @VisibleForTesting
+    static boolean isElementSourceCleared(ElementSource elementSource) {
+      PermitMapImpl permitMap = (PermitMapImpl) elementSource.moduleSource.getPermitMap();
+      return permitMap.modulePermits == null;
     }
   }
 }

--- a/core/test/com/google/inject/spi/BindingSourceRestrictionTest.java
+++ b/core/test/com/google/inject/spi/BindingSourceRestrictionTest.java
@@ -1,0 +1,118 @@
+package com.google.inject.spi;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
+import com.google.inject.RestrictedBindingSource;
+import com.google.inject.util.Modules;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.inject.Named;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for the cleanup of {@link BindingSourceRestriction} data after enforcement.
+ *
+ * <p>The rest of this class is tested through the public {@code RestrictedBindingSource} API it's
+ * implementing.
+ *
+ * @author vzm@google.com (Vladimir Makaric)
+ */
+@RunWith(JUnit4.class)
+public final class BindingSourceRestrictionTest {
+
+  @RestrictedBindingSource.Permit
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface Permit1 {}
+
+  @RestrictedBindingSource.Permit
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface Permit2 {}
+
+  @RestrictedBindingSource.Permit
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface Permit3 {}
+
+  @Permit1
+  static class Module1 extends AbstractModule {
+    @Provides
+    @Named("1")
+    String provideFoo() {
+      return "foo";
+    }
+  }
+
+  @Permit2
+  static class Module2 extends AbstractModule {
+    @Provides
+    @Named("2")
+    String provideFoo2() {
+      return "foo2";
+    }
+
+    @Override
+    protected void configure() {
+      install(new Module1());
+    }
+  }
+
+  @Permit3
+  static class Module3 extends AbstractModule {
+    @Override
+    protected void configure() {
+      install(new Module2());
+    }
+  }
+
+  @Test
+  public void singleBinder() throws Exception {
+    assertThatInjectorIsWiped(Guice.createInjector(new Module3()));
+  }
+
+  @Test
+  public void multipleNestedBinders() throws Exception {
+    assertThatInjectorIsWiped(
+        Guice.createInjector(
+            Modules.override(
+                    Modules.override(new Module3())
+                        .with(
+                            new AbstractModule() {
+                              @Provides
+                              @Named("2")
+                              String provideFoo2() {
+                                return "foo2.1";
+                              }
+                            }))
+                .with(
+                    new AbstractModule() {
+                      @Provides
+                      @Named("1")
+                      String provideFoo() {
+                        return "foo1.1";
+                      }
+                    })));
+  }
+
+  void assertThatInjectorIsWiped(Injector injector) {
+    for (Element element : injector.getElements()) {
+      Object source = element.getSource();
+      if (source instanceof ElementSource) {
+        assertThatTheElementSourceChainIsWiped((ElementSource) source);
+      }
+    }
+  }
+
+  void assertThatTheElementSourceChainIsWiped(ElementSource elementSource) {
+    while (elementSource != null) {
+      assertThat(
+              BindingSourceRestriction.PermitMapConstruction.isElementSourceCleared(elementSource))
+          .isTrue();
+      elementSource = elementSource.getOriginalElementSource();
+    }
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Test clearing the binding source restriction permit maps.

da48d9db3dc3de3331d437d0779c44f5954a79f9

-------

<p> Add mechanism to exempt modules from @RestrictedBindingSource (useful when retrofitting bindings with this restriction).

Based on @RestrictedApi's allowedOnPath exemption mechanism.

90f78e7274da769aeb7632c6d179a82dac726513

-------

<p> Visibility-restrict some more binding internals.

withScoping, withKey, and the BindingImpl constructor are spoofing vectors.

404fb7851505fbc0bd8ae3da02e89b8a495e472a