### PR TITLE
MOE Sync 2020-06-01

### DIFF
--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -340,7 +340,8 @@ public final class Errors implements Serializable {
 
   public Errors recursiveImplementationType() {
     return addMessage(
-        ErrorId.RECURSIVE_BINDING, "@ImplementedBy points to the same class it annotates.");
+        ErrorId.RECURSIVE_IMPLEMENTATION_TYPE,
+        "@ImplementedBy points to the same class it annotates.");
   }
 
   public Errors recursiveProviderType() {
@@ -569,7 +570,7 @@ public final class Errors implements Serializable {
 
   public Errors keyNotFullySpecified(TypeLiteral<?> typeLiteral) {
     return addMessage(
-        ErrorId.EXPOSED_BUT_NOT_BOUND,
+        ErrorId.KEY_NOT_FULLY_SPECIFIED,
         "%s cannot be used as a key; It is not fully specified.",
         typeLiteral);
   }

--- a/core/src/com/google/inject/spi/Elements.java
+++ b/core/src/com/google/inject/spi/Elements.java
@@ -139,12 +139,10 @@ public final class Elements {
   }
 
   private static class ModuleInfo {
-    private final Binder binder;
     private final ModuleSource moduleSource;
     private final boolean skipScanning;
 
-    private ModuleInfo(Binder binder, ModuleSource moduleSource, boolean skipScanning) {
-      this.binder = binder;
+    private ModuleInfo(ModuleSource moduleSource, boolean skipScanning) {
       this.moduleSource = moduleSource;
       this.skipScanning = skipScanning;
     }
@@ -304,7 +302,7 @@ public final class Elements {
           }
           moduleSource = entry.getValue().moduleSource;
           try {
-            info.binder.install(ProviderMethodsModule.forModule(module, scanner));
+            install(ProviderMethodsModule.forModule(module, scanner));
           } catch (RuntimeException e) {
             Collection<Message> messages = Errors.getMessagesFromThrowable(e);
             if (!messages.isEmpty()) {
@@ -348,12 +346,12 @@ public final class Elements {
       if (module instanceof PrivateModule) {
         binder = (RecordingBinder) binder.newPrivateBinder();
         // Store the module in the private binder too so we scan for it.
-        binder.modules.put(module, new ModuleInfo(binder, moduleSource, false));
+        binder.modules.put(module, new ModuleInfo(moduleSource, false));
         skipScanning = true; // don't scan this module in the parent's module set.
       }
       // Always store this in the parent binder (even if it was a private module)
       // so that we know not to process it again, and so that scanners inherit down.
-      modules.put(module, new ModuleInfo(binder, moduleSource, skipScanning));
+      modules.put(module, new ModuleInfo(moduleSource, skipScanning));
       try {
         module.configure(binder);
       } catch (RuntimeException e) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove the binder from ModuleInfo, it's used in one place and it's always == this.

617293be8efdebcb48f7b4deb1029ecc3edbb4fe

-------

<p> Fix incorrect error id.

2fae3d9a6932e8a67a925271b0b25eeac2104296