### PR TITLE
MOE Sync 2020-06-01

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ jdk:
   - openjdk8
 
 before_install:
-  - if [ "$LABEL" == "docs" ]; then wget --no-check-certificate https://www.apache.org/dist/ant/binaries/apache-ant-1.10.6-bin.tar.gz;  fi
-  - if [ "$LABEL" == "docs" ]; then tar -xzvf apache-ant-1.10.6-bin.tar.gz; fi
-  - if [ "$LABEL" == "docs" ]; then export PATH="$(pwd)/apache-ant-1.10.6/bin:$PATH"; fi
+  - if [ "$LABEL" == "docs" ]; then wget --no-check-certificate "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT-bin.tar.gz";  fi
+  - if [ "$LABEL" == "docs" ]; then tar -xzvf "apache-ant-$ANT-bin.tar.gz"; fi
+  - if [ "$LABEL" == "docs" ]; then export PATH="$(pwd)/apache-ant-$ANT/bin:$PATH"; fi
 
 env:
   global:
@@ -21,7 +21,7 @@ env:
     - secure: "pAeI941ODNSo6F7A94WFafxYqp2kdeFTJksMLVHljT0h2nX6/236OXn/iZXiB+FbXe/DkQIHN3n1IZRwE8UJAbSAwoaPUWenPy4mNAhnI4L/rwysREwq5FKSFTWJet9HitfFR57ezLGOV0VLFfH1xGsNWabHzzbwbV3WMl9pH0M="
     - secure: "Pqj194YmdK0va4bOkbjVG0wCZ7sbB5k3Qq66zSG2M26M21uHonwhXprdtSeYZ5Oy9fWcQte7jSA69euyYyLriDH6DU2NE34scK2Y1yO6SCfx5SGr3XuxHWqxtNOxoUaH4RP1WR/9CRkBg8kBxzWus3M2ZeqElu33/p2CtgJEdJg="
   matrix:
-    - LABEL=docs       CMD="ant javadoc jdiff" INSTALL="/bin/true"
+    - LABEL=docs       CMD="ant javadoc jdiff" INSTALL="/bin/true" ANT=1.10.8
     - LABEL=mvn        CMD="mvn -B -P!standard-with-extra-repos verify --fail-at-end -Dsource.skip=true -Dmaven.javadoc.skip=true" INSTALL="mvn -P!standard-with-extra-repos dependency:go-offline test clean --quiet --fail-never -DskipTests=true"
 
 install:

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -340,7 +340,8 @@ public final class Errors implements Serializable {
 
   public Errors recursiveImplementationType() {
     return addMessage(
-        ErrorId.RECURSIVE_BINDING, "@ImplementedBy points to the same class it annotates.");
+        ErrorId.RECURSIVE_IMPLEMENTATION_TYPE,
+        "@ImplementedBy points to the same class it annotates.");
   }
 
   public Errors recursiveProviderType() {
@@ -569,7 +570,7 @@ public final class Errors implements Serializable {
 
   public Errors keyNotFullySpecified(TypeLiteral<?> typeLiteral) {
     return addMessage(
-        ErrorId.EXPOSED_BUT_NOT_BOUND,
+        ErrorId.KEY_NOT_FULLY_SPECIFIED,
         "%s cannot be used as a key; It is not fully specified.",
         typeLiteral);
   }

--- a/core/src/com/google/inject/spi/Elements.java
+++ b/core/src/com/google/inject/spi/Elements.java
@@ -139,12 +139,10 @@ public final class Elements {
   }
 
   private static class ModuleInfo {
-    private final Binder binder;
     private final ModuleSource moduleSource;
     private final boolean skipScanning;
 
-    private ModuleInfo(Binder binder, ModuleSource moduleSource, boolean skipScanning) {
-      this.binder = binder;
+    private ModuleInfo(ModuleSource moduleSource, boolean skipScanning) {
       this.moduleSource = moduleSource;
       this.skipScanning = skipScanning;
     }
@@ -304,7 +302,7 @@ public final class Elements {
           }
           moduleSource = entry.getValue().moduleSource;
           try {
-            info.binder.install(ProviderMethodsModule.forModule(module, scanner));
+            install(ProviderMethodsModule.forModule(module, scanner));
           } catch (RuntimeException e) {
             Collection<Message> messages = Errors.getMessagesFromThrowable(e);
             if (!messages.isEmpty()) {
@@ -348,12 +346,12 @@ public final class Elements {
       if (module instanceof PrivateModule) {
         binder = (RecordingBinder) binder.newPrivateBinder();
         // Store the module in the private binder too so we scan for it.
-        binder.modules.put(module, new ModuleInfo(binder, moduleSource, false));
+        binder.modules.put(module, new ModuleInfo(moduleSource, false));
         skipScanning = true; // don't scan this module in the parent's module set.
       }
       // Always store this in the parent binder (even if it was a private module)
       // so that we know not to process it again, and so that scanners inherit down.
-      modules.put(module, new ModuleInfo(binder, moduleSource, skipScanning));
+      modules.put(module, new ModuleInfo(moduleSource, skipScanning));
       try {
         module.configure(binder);
       } catch (RuntimeException e) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove the binder from ModuleInfo, it's used in one place and it's always == this.

a8df9ee16b325501089b32d071333e60d4c88964

-------

<p> Fix incorrect error id.

1aa06223f21eda56a2f8149c28050bf03918dfac

-------

<p> Update ant to 1.10.8 since 1.10.6 is obsolete and no longer available at the normal download URL.

e504126f0a69a7bb5ed2dff3c4966a6eb019b96a