### PR TITLE
MOE Sync 2020-06-09

### DIFF
--- a/core/src/com/google/inject/internal/ConstructorBindingImpl.java
+++ b/core/src/com/google/inject/internal/ConstructorBindingImpl.java
@@ -18,6 +18,8 @@ package com.google.inject.internal;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.inject.internal.Annotations.findScopeAnnotation;
+import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
+import static com.google.inject.spi.Elements.withTrustedSource;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -175,13 +177,13 @@ final class ConstructorBindingImpl<T> extends BindingImpl<T>
     ImmutableSet.Builder<InjectionPoint> builder = ImmutableSet.builder();
     if (factory.constructorInjector == null) {
       builder.add(constructorInjectionPoint);
-      // If the below throws, it's OK -- we just ignore those dependencies, because no one
-      // could have used them anyway.
       try {
         builder.addAll(
             InjectionPoint.forInstanceMethodsAndFields(
                 constructorInjectionPoint.getDeclaringType()));
       } catch (ConfigurationException ignored) {
+        // This is OK -- we just ignore those dependencies, because no one could have used them
+        // anyway.
       }
     } else {
       builder.add(getConstructor()).addAll(getInjectableMembers());
@@ -243,8 +245,7 @@ final class ConstructorBindingImpl<T> extends BindingImpl<T>
     InjectionPoint constructor = getConstructor();
     getScoping()
         .applyTo(
-            binder
-                .withSource(getSource())
+            withTrustedSource(GUICE_INTERNAL, binder, getSource())
                 .bind(getKey())
                 .toConstructor(
                     (Constructor) getConstructor().getMember(),

--- a/core/src/com/google/inject/internal/InstanceBindingImpl.java
+++ b/core/src/com/google/inject/internal/InstanceBindingImpl.java
@@ -16,6 +16,9 @@
 
 package com.google.inject.internal;
 
+import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
+import static com.google.inject.spi.Elements.withTrustedSource;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
@@ -87,7 +90,7 @@ final class InstanceBindingImpl<T> extends BindingImpl<T> implements InstanceBin
   @Override
   public void applyTo(Binder binder) {
     // instance bindings aren't scoped
-    binder.withSource(getSource()).bind(getKey()).toInstance(instance);
+    withTrustedSource(GUICE_INTERNAL, binder, getSource()).bind(getKey()).toInstance(instance);
   }
 
   @Override

--- a/core/src/com/google/inject/internal/LinkedBindingImpl.java
+++ b/core/src/com/google/inject/internal/LinkedBindingImpl.java
@@ -16,6 +16,9 @@
 
 package com.google.inject.internal;
 
+import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
+import static com.google.inject.spi.Elements.withTrustedSource;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
@@ -75,7 +78,11 @@ final class LinkedBindingImpl<T> extends BindingImpl<T>
 
   @Override
   public void applyTo(Binder binder) {
-    getScoping().applyTo(binder.withSource(getSource()).bind(getKey()).to(getLinkedKey()));
+    getScoping()
+        .applyTo(
+            withTrustedSource(GUICE_INTERNAL, binder, getSource())
+                .bind(getKey())
+                .to(getLinkedKey()));
   }
 
   @Override

--- a/core/src/com/google/inject/internal/LinkedProviderBindingImpl.java
+++ b/core/src/com/google/inject/internal/LinkedProviderBindingImpl.java
@@ -16,6 +16,9 @@
 
 package com.google.inject.internal;
 
+import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
+import static com.google.inject.spi.Elements.withTrustedSource;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
@@ -113,7 +116,10 @@ final class LinkedProviderBindingImpl<T> extends BindingImpl<T>
   @Override
   public void applyTo(Binder binder) {
     getScoping()
-        .applyTo(binder.withSource(getSource()).bind(getKey()).toProvider(getProviderKey()));
+        .applyTo(
+            withTrustedSource(GUICE_INTERNAL, binder, getSource())
+                .bind(getKey())
+                .toProvider(getProviderKey()));
   }
 
   @Override

--- a/core/src/com/google/inject/internal/ProviderInstanceBindingImpl.java
+++ b/core/src/com/google/inject/internal/ProviderInstanceBindingImpl.java
@@ -16,6 +16,9 @@
 
 package com.google.inject.internal;
 
+import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
+import static com.google.inject.spi.Elements.withTrustedSource;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
@@ -61,7 +64,6 @@ class ProviderInstanceBindingImpl<T> extends BindingImpl<T> implements ProviderI
   }
 
   @Override
-  @SuppressWarnings("unchecked") // the extension type is always consistent with the provider type
   public <V> V acceptTargetVisitor(BindingTargetVisitor<? super T, V> visitor) {
     if (providerInstance instanceof ProviderWithExtensionVisitor) {
       return ((ProviderWithExtensionVisitor<? extends T>) providerInstance)
@@ -108,7 +110,9 @@ class ProviderInstanceBindingImpl<T> extends BindingImpl<T> implements ProviderI
   public void applyTo(Binder binder) {
     getScoping()
         .applyTo(
-            binder.withSource(getSource()).bind(getKey()).toProvider(getUserSuppliedProvider()));
+            withTrustedSource(GUICE_INTERNAL, binder, getSource())
+                .bind(getKey())
+                .toProvider(getUserSuppliedProvider()));
   }
 
   @Override

--- a/core/src/com/google/inject/internal/UntargettedBindingImpl.java
+++ b/core/src/com/google/inject/internal/UntargettedBindingImpl.java
@@ -16,6 +16,9 @@
 
 package com.google.inject.internal;
 
+import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
+import static com.google.inject.spi.Elements.withTrustedSource;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.inject.Binder;
@@ -61,7 +64,7 @@ final class UntargettedBindingImpl<T> extends BindingImpl<T> implements Untarget
 
   @Override
   public void applyTo(Binder binder) {
-    getScoping().applyTo(binder.withSource(getSource()).bind(getKey()));
+    getScoping().applyTo(withTrustedSource(GUICE_INTERNAL, binder, getSource()).bind(getKey()));
   }
 
   @Override

--- a/core/src/com/google/inject/spi/BindingSourceRestriction.java
+++ b/core/src/com/google/inject/spi/BindingSourceRestriction.java
@@ -162,7 +162,7 @@ public final class BindingSourceRestriction {
     ImmutableSet<Class<? extends Annotation>> permits =
         elementSource.moduleSource.getPermitMap().getPermits(elementSource);
     if (elementSource.getOriginalElementSource() == null
-        || !isOriginalElementSourceTrustworthy(elementSource)) {
+        || !elementSource.trustedOriginalElementSource) {
       return permits;
     }
     permitsBuilder.addAll(permits);
@@ -175,7 +175,7 @@ public final class BindingSourceRestriction {
       return false;
     }
     Pattern exemptModulePattern = Pattern.compile(exemptModulesRegex);
-    //TODO(b/156759807): Switch to Streams.stream (instead of inlining it).
+    // TODO(b/156759807): Switch to Streams.stream (instead of inlining it).
     return StreamSupport.stream(getAllModules(elementSource).spliterator(), false)
         .anyMatch(moduleName -> exemptModulePattern.matcher(moduleName).matches());
   }
@@ -183,20 +183,10 @@ public final class BindingSourceRestriction {
   private static Iterable<String> getAllModules(ElementSource elementSource) {
     List<String> modules = elementSource.getModuleClassNames();
     if (elementSource.getOriginalElementSource() == null
-        || !isOriginalElementSourceTrustworthy(elementSource)) {
+        || !elementSource.trustedOriginalElementSource) {
       return modules;
     }
     return Iterables.concat(modules, getAllModules(elementSource.getOriginalElementSource()));
-  }
-
-  private static boolean isOriginalElementSourceTrustworthy(ElementSource elementSource) {
-    // Only trust if the element comes from Modules.override because otherwise the original element
-    // source can be spoofed.
-    // TODO(b/156495326): Remove this special case once we resolve the spoofing issue.
-    return elementSource
-        .moduleSource
-        .getModuleClassName()
-        .equals("com.google.inject.util.Modules$OverrideModule");
   }
 
   private static void clear(Element element) {

--- a/core/src/com/google/inject/spi/ElementSource.java
+++ b/core/src/com/google/inject/spi/ElementSource.java
@@ -58,6 +58,15 @@ public final class ElementSource {
    */
   final ElementSource originalElementSource;
 
+  /**
+   * Wheather the originalElementSource was set externaly (untrusted) or by Guice internals
+   * (trusted).
+   *
+   * <p>External code can set the originalElementSource to an arbitrary ElementSource via
+   * Binder.withSource(ElementSource), thereby spoofing the element origin.
+   */
+  final boolean trustedOriginalElementSource;
+
   /** The {@link ModuleSource source} of module creates the element. */
   final ModuleSource moduleSource;
 
@@ -87,6 +96,7 @@ public final class ElementSource {
    */
   ElementSource(
       /* @Nullable */ ElementSource originalSource,
+      boolean trustedOriginalSource,
       Object declaringSource,
       ModuleSource moduleSource,
       StackTraceElement[] partialCallStack) {
@@ -94,6 +104,7 @@ public final class ElementSource {
     Preconditions.checkNotNull(moduleSource, "moduleSource cannot be null.");
     Preconditions.checkNotNull(partialCallStack, "partialCallStack cannot be null.");
     this.originalElementSource = originalSource;
+    this.trustedOriginalElementSource = trustedOriginalSource;
     this.declaringSource = declaringSource;
     this.moduleSource = moduleSource;
     this.partialCallStack = StackTraceElements.convertToInMemoryStackTraceElement(partialCallStack);

--- a/core/test/com/google/inject/spi/ElementSourceTest.java
+++ b/core/test/com/google/inject/spi/ElementSourceTest.java
@@ -39,8 +39,9 @@ public class ElementSourceTest extends TestCase {
             "com.google.inject.spi.moduleSourceTest$C", "configure", "Unknown Source", 100);
     ElementSource elementSource =
         new ElementSource(
-            null /* No original element source */,
-            "" /* Don't care */,
+            /* originalSource = */ null,
+            /* trustedOriginalSource = */ false,
+            /* declaringSource = */ "",
             moduleSource,
             bindingCallStack);
     assertEquals(10 /* call stack size */, elementSource.getStackTrace().length);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix order-dependent private module scanner inheritance.

1161b5509a55500e21b89befd681cba23c6b111c

-------

<p> Add withTrustedSource API to RecordingBinder.

This API enables the re-writing of Module Bindings - via Element.applyTo(Binder) - to be trustworthy for @RestrictedBindingSource.

Use the API on all 6 Module Binding implementations:
- InstanceBindingImpl
- ConstructorBindingImpl
- ProviderInstanceBindingImpl
- LinkedBindingImpl
- LinkedProviderBindingImpl
- UntargettedBindingImpl

These are exhaustive based on auditing RecordingBinder's implementaiton of Binder APIs for adding bindings: bind(*) and bindConstant().

- bind(*) calls add bindings through com.google.inject.internal.BindingBuilder, which creates all 6 kinds of binding.
- bindConstant() creates a InstanceBindingImpl.

cc7d4ab64139db92a62c367b3947a6655a63eed2