### PR TITLE
Fix #716: requireExplicitBindings support requiring explicit binding specific classes

### DIFF
--- a/core/src/com/google/inject/Binder.java
+++ b/core/src/com/google/inject/Binder.java
@@ -420,6 +420,16 @@ public interface Binder {
   void requireExplicitBindings();
 
   /**
+   * Extends {@link #requireExplicitBindings()} with an option to list specific types that should
+   * be explicitly bound in a module.
+   *
+   * @param types that require explicit binding.
+   *
+   * @since 4.2.4
+   */
+  void requireExplicitBindings(Class<?>... types);
+
+  /**
    * Prevents Guice from injecting dependencies that form a cycle, unless broken by a {@link
    * Provider}. By default, circular dependencies are not disabled.
    *

--- a/core/src/com/google/inject/spi/Elements.java
+++ b/core/src/com/google/inject/spi/Elements.java
@@ -546,6 +546,11 @@ public final class Elements {
     }
 
     @Override
+    public void requireExplicitBindings(Class<?>... types) {
+      elements.add(new RequireExplicitBindingsOption(getElementSource(), types));
+    }
+
+    @Override
     public void requireAtInjectOnConstructors() {
       elements.add(new RequireAtInjectOnConstructorsOption(getElementSource()));
     }

--- a/core/src/com/google/inject/spi/RequireExplicitBindingsOption.java
+++ b/core/src/com/google/inject/spi/RequireExplicitBindingsOption.java
@@ -18,7 +18,10 @@ package com.google.inject.spi;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
+
+import java.util.Set;
 
 /**
  * A request to require explicit bindings.
@@ -28,9 +31,15 @@ import com.google.inject.Binder;
  */
 public final class RequireExplicitBindingsOption implements Element {
   private final Object source;
+  private final Set<Class<?>> types;
 
   RequireExplicitBindingsOption(Object source) {
+    this(source, new Class<?>[0]);
+  }
+
+  RequireExplicitBindingsOption(Object source, Class<?>... types) {
     this.source = checkNotNull(source, "source");
+    this.types = ImmutableSet.copyOf(checkNotNull(types, "types"));
   }
 
   @Override
@@ -38,9 +47,17 @@ public final class RequireExplicitBindingsOption implements Element {
     return source;
   }
 
+  public Set<Class<?>> getTypes() {
+    return types;
+  }
+
   @Override
   public void applyTo(Binder binder) {
-    binder.withSource(getSource()).requireExplicitBindings();
+    if (types.isEmpty()) {
+      binder.withSource(getSource()).requireExplicitBindings();
+    } else {
+      binder.withSource(getSource()).requireExplicitBindings(types.toArray(new Class<?>[0]));
+    }
   }
 
   @Override


### PR DESCRIPTION
### Description

As per title. I have a real life example which made me search for this issue:

`ClientConfiguration` from AWS SDK is shared a lot in a project that I work on. It has a default constructor which makes it easy to accidentally require default implementation. I've created a custom qualifier to make sure that `ClientConfiguration` has an explicit binding. I think it is not the best solution and so I ended up writing this.

### Notes

* not so many tests now. I'm glad to add more if you would agree to have this feature as part of Guice.
* I'm not very good at benchmarks but I've tried to test field vs method access (as I have replaced direct `.jitDisabled` call with `.isJitDisabled(...` method) with JMH and haven't spotted a significant difference for a common case (`Predicates#alwaysTrue()` is invoked). Of course there is a difference when `requireExplicitBindings` is invoked with parameters.