### PR TITLE
MOE Sync 2020-06-22

### DIFF
--- a/core/src/com/google/inject/RestrictedBindingSource.java
+++ b/core/src/com/google/inject/RestrictedBindingSource.java
@@ -13,12 +13,13 @@ import java.lang.annotation.Target;
 /**
  * Annotation restricting the binding of the target type to permitted modules.
  *
- * <p>If a binding's type or qualifier annotation type is annotated with
- * {@code @RestrictedBindingSource}, then only modules annotated with a permit from {@link #permits}
- * are allowed to create it -- otherwise, an error message including the {@link #explanation} is
- * issued. Note that if both the type and qualifier annotation type are restricted this way, the
- * qualifier annotation restriction overrides the type restriction (annotating is essentially
- * syntactic sugar for creating a new type that wraps the annotated type).
+ * <p>Bindings restricted by this annotation may only be created by modules annotated with a permit
+ * from {@link #permits} -- otherwise, an error message including the {@link #explanation} is
+ * issued.
+ *
+ * <p>Bindings with qualifier annotations are restricted solely by the annotation on their qualifier
+ * (restrictions on the type are ignored for qualified bindings). Unqualified bindings are
+ * restricted by the annotation on their type.
  *
  * <p>This allows libraries to prevent their clients from binding their keys, similar to how
  * declaring a class final prevents subtyping. For example, a library may want to prevent users from

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -148,8 +148,7 @@ final class InjectorImpl implements Injector, Lookups {
     }
   }
 
-  /** Indexes bindings by type. */
-  void index() {
+  void indexBindingsByType() {
     for (Binding<?> binding : state.getExplicitBindingsThisLevel().values()) {
       bindingsMultimap.put(binding.getKey().getTypeLiteral(), binding);
     }

--- a/core/src/com/google/inject/internal/InternalFlags.java
+++ b/core/src/com/google/inject/internal/InternalFlags.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.inject.internal;
 
 import java.security.AccessController;
@@ -49,9 +48,7 @@ public class InternalFlags {
     COMPLETE
   }
 
-  /**
-   * The options for Guice custom class loading.
-   */
+  /** The options for Guice custom class loading. */
   public enum CustomClassLoadingOption {
     /** No custom class loading */
     OFF,
@@ -59,6 +56,7 @@ public class InternalFlags {
     BRIDGE
   }
 
+  /** Options for handling nullable parameters used in provides methods. */
   public enum NullableProvidesOption {
     /** Ignore null parameters to @Provides methods. */
     IGNORE,
@@ -68,6 +66,7 @@ public class InternalFlags {
     ERROR
   }
 
+  /** Options for enable or disable the new experimental error messages. */
   public enum ExperimentalErrorMessagesOption {
     DISABLED,
     ENABLED,

--- a/core/src/com/google/inject/internal/InternalFlags.java
+++ b/core/src/com/google/inject/internal/InternalFlags.java
@@ -16,11 +16,11 @@
 
 package com.google.inject.internal;
 
-
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.logging.Logger;
+
 /**
  * Contains flags for Guice.
  */
@@ -68,6 +68,11 @@ public class InternalFlags {
     ERROR
   }
 
+  public enum ExperimentalErrorMessagesOption {
+    DISABLED,
+    ENABLED,
+  }
+
   public static IncludeStackTraceOption getIncludeStackTraceOption() {
     return INCLUDE_STACK_TRACES;
   }
@@ -78,6 +83,11 @@ public class InternalFlags {
 
   public static NullableProvidesOption getNullableProvidesOption() {
     return NULLABLE_PROVIDES;
+  }
+
+
+  public static boolean enableExperimentalErrorMessages() {
+    return false;
   }
 
   private static IncludeStackTraceOption parseIncludeStackTraceOption() {

--- a/core/src/com/google/inject/internal/InternalInjectorCreator.java
+++ b/core/src/com/google/inject/internal/InternalInjectorCreator.java
@@ -125,7 +125,7 @@ public final class InternalInjectorCreator {
     stopwatch.resetAndLog("Binding initialization");
 
     for (InjectorShell shell : shells) {
-      shell.getInjector().index();
+      shell.getInjector().indexBindingsByType();
     }
     stopwatch.resetAndLog("Binding indexing");
 

--- a/core/src/com/google/inject/spi/BindingSourceRestriction.java
+++ b/core/src/com/google/inject/spi/BindingSourceRestriction.java
@@ -110,16 +110,12 @@ public final class BindingSourceRestriction {
     Key<?> key = binding.getKey();
     // Module Bindings are all explicit and have an ElementSource.
     ElementSource elementSource = (ElementSource) binding.getSource();
-    RestrictedBindingSource annotationRestriction =
+    // If the key is annotated then only the annotation restriction matters, the type restriction is
+    // ignored (an annotated type is essentially a new type).
+    RestrictedBindingSource restriction =
         key.getAnnotationType() == null
-            ? null
+            ? key.getTypeLiteral().getRawType().getAnnotation(RestrictedBindingSource.class)
             : key.getAnnotationType().getAnnotation(RestrictedBindingSource.class);
-    RestrictedBindingSource restriction = annotationRestriction;
-    if (annotationRestriction == null) {
-      // Annotation restriction overrides type restriction.
-      restriction = key.getTypeLiteral().getRawType().getAnnotation(RestrictedBindingSource.class);
-    }
-    // Exit if there is no binding source restrictions on the key.
     if (restriction == null) {
       return Optional.empty();
     }
@@ -134,7 +130,10 @@ public final class BindingSourceRestriction {
         new Message(
             elementSource,
             getErrorMessage(
-                key, restriction.explanation(), acceptablePermits, annotationRestriction != null)));
+                key,
+                restriction.explanation(),
+                acceptablePermits,
+                key.getAnnotationType() != null)));
   }
 
   private static String getErrorMessage(

--- a/core/test/com/google/inject/RestrictedBindingSourceTest.java
+++ b/core/test/com/google/inject/RestrictedBindingSourceTest.java
@@ -117,6 +117,18 @@ public class RestrictedBindingSourceTest {
   }
 
   @Test
+  public void canBindRestrictedTypeWithUnrestrictedQualifierAnnotation() {
+    Guice.createInjector(
+        new AbstractModule() {
+          @Provides
+          @Named("custom")
+          RoutingTable provideRoutingTable() {
+            return ip -> ip;
+          }
+        });
+  }
+
+  @Test
   public void twoRogueNetworkBindingsYieldTwoErrorMessages() {
     AbstractModule rogueModule =
         new AbstractModule() {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Change @RestrictedBindingSource semantics such that qualified bindings are only restricted by their annotation's restriciton.

Since qualifier annotations are just cheap ways to create a wrapper type this seems like the most logical thing to do.

0e9e869ab29c9f0e9d8602360cda6868da6d7971

-------

<p> Rename index() -> indexBindingsByType(), so it's more explicit what's being indexed and so it mirrors the findBindingsByType() method name.

88a3b6176c992597d96914d2aa80991d8d4d55ac

-------

<p> Add a new flag to control whether to enable the new error message format.

084d4f43c85497d2e29c2e1ed283d14f6adda02c

-------

<p> Remove unnecessary AOP munged builds in InternalFlags.

dd162324b9840912e185fb31a597e12320bb7c35