### PR TITLE
Fix OSGi manifest for no_aop: remove unnecessary aopalliance package

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,6 +13,10 @@
 
   <name>Google Guice - Core Library</name>
 
+  <properties>
+    <src.osgi.location>${project.build.sourceDirectory}</src.osgi.location>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>javax.inject</groupId>
@@ -114,6 +118,7 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
+          <scrLocation>${src.osgi.location}</scrLocation>
           <instructions>
             <Bundle-Name>${project.artifactId}$(if;$(classes;NAMED;*.MethodAspect);; (no_aop))</Bundle-Name>
             <Import-Package>!net.sf.cglib.*,!org.objectweb.asm.*,!com.google.inject.*,*</Import-Package>
@@ -159,6 +164,9 @@
        | No-AOP profile: repeat the build lifecycle with munged no-AOP source
       -->
       <id>guice.with.no_aop</id>
+      <properties>
+        <src.osgi.location>${project.build.directory}/munged/main</src.osgi.location>
+      </properties>
       <activation>
         <property>
           <name>guice.with.no_aop</name>
@@ -173,7 +181,7 @@
             <version>1.0</version>
             <executions>
               <execution>
-                <phase>prepare-package</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>munge-fork</goal>
                 </goals>


### PR DESCRIPTION
The MANIFEST.MF of the no_aop jar file shouldn't declare
an OSGi import package of org.aopalliance.intercept since no aop
is used.
The issue comes from the fact the maven-bundle-plugin generates
the MANIFEST.MF from the orginal source files and not the munged
source files for the 'guice.with.no_aop' profile.
This commit fixes the issue by:
 - defining the proper source location for the maven-bundle-plugin
   for the "aop" and "no_aop" profile
 - changing the phase of munge-maven-plugin to "generate-sources":
   this ensures the munge-maven-plugin is called before the
   maven-bundle-plugin, so that this latter one can use the proper
   source files to generate the appropriate MANIFEST.MF

By removing this import, using the guice_no_aop.jar within an OSGi
container does no more require to deploy an OSGi bundle of the aopalliance.