### PR TITLE
Fix OSGi manifest for no_aop: remove unnecessary aopalliance package

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -173,7 +173,7 @@
             <version>1.0</version>
             <executions>
               <execution>
-                <phase>prepare-package</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>munge-fork</goal>
                 </goals>


### PR DESCRIPTION
The MANIFEST.MF of the no_aop jar file shouldn't declare
an OSGi import package of org.aopalliance.intercept since no aop
is used.
The issue comes from the fact the maven-bundle-plugin generates
the MANIFEST.MF from the orginal source files and not the munged
source files for the 'guice.with.no_aop' profile.
This commit fixes the issue by:
  - defining the proper source location for the maven-bundle-plugin
    for the "aop" and "no_aop" profile
  - changing the phase of munge-maven-plugin to "generate-sources":
    this ensures the munge-maven-plugin is called before the
    maven-bundle-plugin, so that this latter one can use the proper
    source files to generate the appropriate MANIFEST.MF

By removing this import, using the guice_no_aop.jar within an OSGi
container does no more require to deploy an OSGi bundle of the aopalliance.