### PR TITLE
MOE Sync 2020-07-10

### DIFF
--- a/core/src/com/google/inject/internal/AbstractBindingProcessor.java
+++ b/core/src/com/google/inject/internal/AbstractBindingProcessor.java
@@ -97,7 +97,7 @@ abstract class AbstractBindingProcessor extends AbstractProcessor {
     }
 
     // prevent the parent from creating a JIT binding for this key
-    injector.state.parent().blacklist(key, injector.state, binding.getSource());
+    injector.getJitBindingData().banKeyInParent(key, injector.state, binding.getSource());
     injector.state.putBinding(key, binding);
   }
 

--- a/core/src/com/google/inject/internal/InheritingState.java
+++ b/core/src/com/google/inject/internal/InheritingState.java
@@ -64,13 +64,11 @@ final class InheritingState implements State {
   private final List<TypeListenerBinding> typeListenerBindings = Lists.newArrayList();
   private final List<ProvisionListenerBinding> provisionListenerBindings = Lists.newArrayList();
   private final List<ModuleAnnotatedMethodScannerBinding> scannerBindings = Lists.newArrayList();
-  private final WeakKeySet blacklistedKeys;
   private final Object lock;
 
   InheritingState(State parent) {
     this.parent = checkNotNull(parent, "parent");
     this.lock = (parent == State.NONE) ? this : parent.lock();
-    this.blacklistedKeys = new WeakKeySet(lock);
   }
 
   @Override
@@ -251,22 +249,6 @@ final class InheritingState implements State {
   @Override
   public List<ModuleAnnotatedMethodScannerBinding> getScannerBindingsThisLevel() {
     return scannerBindings;
-  }
-
-  @Override
-  public void blacklist(Key<?> key, State state, Object source) {
-    parent.blacklist(key, state, source);
-    blacklistedKeys.add(key, state, source);
-  }
-
-  @Override
-  public boolean isBlacklisted(Key<?> key) {
-    return blacklistedKeys.contains(key);
-  }
-
-  @Override
-  public Set<Object> getSourcesForBlacklistedKey(Key<?> key) {
-    return blacklistedKeys.getSources(key);
   }
 
   @Override

--- a/core/src/com/google/inject/internal/InjectorJitBindingData.java
+++ b/core/src/com/google/inject/internal/InjectorJitBindingData.java
@@ -1,0 +1,87 @@
+package com.google.inject.internal;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.inject.Key;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/** A container for just-in-time (JIT) binding data corresponding to an Injector. */
+final class InjectorJitBindingData {
+  // TODO(b/159459925): the State object is currently used as the lock for accessing all the JIT
+  //   binding data fields. Migrate to using InjectorJitBindingData as a lock for these accesses
+  //   instead.
+  // TODO(b/159459925): Hide direct access to internal jitBindings and failedJitBindings fields once
+  //  locks are managed by this class
+  /** Just-in-time binding cache. Guarded by state.lock() */
+  private final Map<Key<?>, BindingImpl<?>> jitBindings = Maps.newHashMap();
+  /**
+   * Cache of Keys that we were unable to create JIT bindings for, so we don't keep trying. Also
+   * guarded by state.lock().
+   */
+  private final Set<Key<?>> failedJitBindings = Sets.newHashSet();
+
+  // The set of JIT binding keys that are banned for this particular injector, because a binding
+  // already exists in a child injector.
+  private final WeakKeySet bannedKeys;
+
+  // The InjectorJitBindingData corresponding to the Injector's parent, if it exists.
+  private final Optional<InjectorJitBindingData> parent;
+
+  InjectorJitBindingData(Optional<InjectorJitBindingData> parent, State state) {
+    this.parent = parent;
+    this.bannedKeys = new WeakKeySet(state.lock());
+  }
+
+  /**
+   * Returns a mutable map containing the JIT bindings for the injector. Accesses to this need to be
+   * guarded by state.lock().
+   */
+  Map<Key<?>, BindingImpl<?>> getJitBindings() {
+    return jitBindings;
+  }
+
+  /**
+   * Returns a mutable set containing the failed JIT bindings for the injector. Accesses to this
+   * need to be guarded by state.lock().
+   */
+  Set<Key<?>> getFailedJitBindings() {
+    return failedJitBindings;
+  }
+
+  /**
+   * Forbids the corresponding injector and its ancestors from creating a binding to {@code key}.
+   * Child injectors ban their bound keys on their parent injectors to prevent just-in-time bindings
+   * on the parent injector that would conflict, and pass along their State to control the banned
+   * key's lifetime.
+   */
+  void banKey(Key<?> key, State state, Object source) {
+    banKeyInParent(key, state, source);
+    bannedKeys.add(key, state, source);
+  }
+
+  /**
+   * Similar to {@link #banKey(Key, State, Object)} but we only begin banning the binding at the
+   * parent level. This is used to prevent JIT bindings in the parent injector from overriding
+   * explicit bindings declared in a child injector.
+   */
+  void banKeyInParent(Key<?> key, State state, Object source) {
+    if (parent.isPresent()) {
+      parent.get().banKey(key, state, source);
+    }
+  }
+
+  /**
+   * Returns true if {@code key} is forbidden from being bound in the injector corresponding to this
+   * data object. This indicates that one of the injector's children has bound the key.
+   */
+  boolean isBannedKey(Key<?> key) {
+    return bannedKeys.contains(key);
+  }
+
+  /** Returns the source of a banned key. */
+  Set<Object> getSourcesForBannedKey(Key<?> key) {
+    return bannedKeys.getSources(key);
+  }
+}

--- a/core/src/com/google/inject/internal/InternalInjectorCreator.java
+++ b/core/src/com/google/inject/internal/InternalInjectorCreator.java
@@ -200,7 +200,7 @@ public final class InternalInjectorCreator {
     candidateBindings.addAll(bindingsAtThisLevel);
     synchronized (injector.state.lock()) {
       // jit bindings must be accessed while holding the lock.
-      candidateBindings.addAll(injector.jitBindings.values());
+      candidateBindings.addAll(injector.getJitBindingData().getJitBindings().values());
     }
     InternalContext context = injector.enterContext();
     try {

--- a/core/src/com/google/inject/internal/State.java
+++ b/core/src/com/google/inject/internal/State.java
@@ -177,18 +177,7 @@ interface State {
           return ImmutableList.of();
         }
 
-        @Override
-        public void blacklist(Key<?> key, State state, Object source) {}
 
-        @Override
-        public boolean isBlacklisted(Key<?> key) {
-          return true;
-        }
-
-        @Override
-        public Set<Object> getSourcesForBlacklistedKey(Key<?> key) {
-          throw new UnsupportedOperationException();
-        }
 
         @Override
         public Object lock() {
@@ -285,22 +274,6 @@ interface State {
   List<ModuleAnnotatedMethodScannerBinding> getScannerBindings();
 
   List<ModuleAnnotatedMethodScannerBinding> getScannerBindingsThisLevel();
-
-  /**
-   * Forbids the corresponding injector from creating a binding to {@code key}. Child injectors
-   * blacklist their bound keys on their parent injectors to prevent just-in-time bindings on the
-   * parent injector that would conflict and pass along their state to control the lifetimes.
-   */
-  void blacklist(Key<?> key, State state, Object source);
-
-  /**
-   * Returns true if {@code key} is forbidden from being bound in this injector. This indicates that
-   * one of this injector's descendent's has bound the key.
-   */
-  boolean isBlacklisted(Key<?> key);
-
-  /** Returns the source of a blacklisted key. */
-  Set<Object> getSourcesForBlacklistedKey(Key<?> key);
 
   /**
    * Returns the shared lock for all injector data. This is a low-granularity, high-contention lock

--- a/core/test/com/google/inject/internal/WeakKeySetTest.java
+++ b/core/test/com/google/inject/internal/WeakKeySetTest.java
@@ -135,7 +135,8 @@ public class WeakKeySetTest extends TestCase {
     assertSourceNotInSet(set, key, source1);
     assertInSet(set, key, 1, source2);
 
-    source1 = source2 = null;
+    // Clear source1 and source2 fields so the objects can be GCed.
+    Object unused = source1 = source2 = null;
 
     awaitClear(weakSource1Ref);
     // Key1 will be referenced as the key in the sources backingSet and won't be
@@ -583,19 +584,6 @@ public class WeakKeySetTest extends TestCase {
     @Override
     public List<ModuleAnnotatedMethodScannerBinding> getScannerBindings() {
       return ImmutableList.of();
-    }
-
-    @Override
-    public void blacklist(Key<?> key, State state, Object source) {}
-
-    @Override
-    public boolean isBlacklisted(Key<?> key) {
-      return true;
-    }
-
-    @Override
-    public Set<Object> getSourcesForBlacklistedKey(Key<?> key) {
-      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/core/test/com/google/inject/internal/WeakKeySetUtils.java
+++ b/core/test/com/google/inject/internal/WeakKeySetUtils.java
@@ -81,13 +81,13 @@ public final class WeakKeySetUtils {
     // if we're expecting it to not be blacklisted, loop around and wait for threads to run.
     if (!isBlacklisted) {
       for (int i = 0; i < 10; i++) {
-        if (!((InjectorImpl) injector).state.isBlacklisted(key)) {
+        if (!((InjectorImpl) injector).getJitBindingData().isBannedKey(key)) {
           break;
         }
         sleep();
       }
     }
-    assertEquals(isBlacklisted, ((InjectorImpl) injector).state.isBlacklisted(key));
+    assertEquals(isBlacklisted, ((InjectorImpl) injector).getJitBindingData().isBannedKey(key));
   }
 
   private static void sleep() {
@@ -96,6 +96,7 @@ public final class WeakKeySetUtils {
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }
+    // TODO(b/160912368): fix the ThreadPriorityCheck errorprone warning on this line.
     Thread.yield();
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Aggregate the Guice injector's JIT binding data into an InjectorJitBindingData object.

In particular:
- Move jitBindings and failedJitBindings out of InjectorImpl and into a new InjectorJitBindingData class, which is constructed in parallel with State in the InjectorShell.
- Move blacklistedKeys (and associated methods) out of InheritingState and into InjectorJitBindingData.
- Rename blacklistedKeys methods: blacklist -> banKey; isBlacklisted -> isBannedKey; getSourcesForBlacklistedKey -> getSourcesForBannedKey
- Replace parent().blacklist() with banKeyInParent() since it's the only reason the parent jit binding data is ever accessed.

This should be a refactor only: no change in behavior is expected from this CL.

This is Step 1 of this design doc: https://docs.google.com/document/d/1az6yShBLpN9DKr1uvFlMUQEqj-2eXl0frckmVWDEdkg/edit

dd2b35c204b8bdd035f93f19061754b69a05fbe4