### PR TITLE
MOE Sync 2020-07-13

### DIFF
--- a/core/src/com/google/inject/internal/BindingProcessor.java
+++ b/core/src/com/google/inject/internal/BindingProcessor.java
@@ -43,8 +43,9 @@ final class BindingProcessor extends AbstractBindingProcessor {
 
   private final Initializer initializer;
 
-  BindingProcessor(Errors errors, Initializer initializer, ProcessedBindingData bindingData) {
-    super(errors, bindingData);
+  BindingProcessor(
+      Errors errors, Initializer initializer, ProcessedBindingData processedBindingData) {
+    super(errors, processedBindingData);
     this.initializer = initializer;
   }
 
@@ -153,7 +154,7 @@ final class BindingProcessor extends AbstractBindingProcessor {
                     providerKey,
                     source,
                     injector.provisionListenerStore.get((ProviderKeyBinding<T>) binding));
-            bindingData.addCreationListener(boundProviderFactory);
+            processedBindingData.addCreationListener(boundProviderFactory);
             InternalFactory<? extends T> scopedFactory =
                 Scoping.scope(
                     key,
@@ -176,7 +177,7 @@ final class BindingProcessor extends AbstractBindingProcessor {
             }
 
             FactoryProxy<T> factory = new FactoryProxy<>(injector, key, linkedKey, source);
-            bindingData.addCreationListener(factory);
+            processedBindingData.addCreationListener(factory);
             InternalFactory<? extends T> scopedFactory =
                 Scoping.scope(key, injector, factory, source, scoping);
             putBinding(
@@ -246,7 +247,7 @@ final class BindingProcessor extends AbstractBindingProcessor {
 
   private <T> void bindExposed(PrivateElements privateElements, Key<T> key) {
     ExposedKeyFactory<T> exposedKeyFactory = new ExposedKeyFactory<>(key, privateElements);
-    bindingData.addCreationListener(exposedKeyFactory);
+    processedBindingData.addCreationListener(exposedKeyFactory);
     putBinding(
         new ExposedBindingImpl<T>(
             injector,

--- a/core/src/com/google/inject/internal/ConstructorInjectorStore.java
+++ b/core/src/com/google/inject/internal/ConstructorInjectorStore.java
@@ -75,7 +75,7 @@ final class ConstructorInjectorStore {
             injector.membersInjectorStore.get(injectionPoint.getDeclaringType(), errors);
 
     /*if[AOP]*/
-    ImmutableList<MethodAspect> injectorAspects = injector.state.getMethodAspects();
+    ImmutableList<MethodAspect> injectorAspects = injector.getBindingData().getMethodAspects();
     ImmutableList<MethodAspect> methodAspects =
         membersInjector.getAddedAspects().isEmpty()
             ? injectorAspects

--- a/core/src/com/google/inject/internal/ExposedKeyFactory.java
+++ b/core/src/com/google/inject/internal/ExposedKeyFactory.java
@@ -37,7 +37,7 @@ final class ExposedKeyFactory<T> implements InternalFactory<T>, CreationListener
   @Override
   public void notify(Errors errors) {
     InjectorImpl privateInjector = (InjectorImpl) privateElements.getInjector();
-    BindingImpl<T> explicitBinding = privateInjector.state.getExplicitBinding(key);
+    BindingImpl<T> explicitBinding = privateInjector.getBindingData().getExplicitBinding(key);
 
     // validate that the child injector has its own factory. If the getInternalFactory() returns
     // this, then that child injector doesn't have a factory (and getExplicitBinding has returned

--- a/core/src/com/google/inject/internal/InjectionRequestProcessor.java
+++ b/core/src/com/google/inject/internal/InjectionRequestProcessor.java
@@ -47,7 +47,7 @@ final class InjectionRequestProcessor extends AbstractProcessor {
   @Override
   public Boolean visit(StaticInjectionRequest request) {
     staticInjections.add(new StaticInjection(injector, request));
-    injector.state.putStaticInjectionRequest(request);
+    injector.getBindingData().putStaticInjectionRequest(request);
     return true;
   }
 
@@ -68,11 +68,13 @@ final class InjectionRequestProcessor extends AbstractProcessor {
     // when determining the types for members injection.
     // If/when this is fixed, we can report the exact type back to the user.
     // (Otherwise the injection points exposed from the request may be wrong.)
-    injector.state.putInjectionRequest(
-        new InjectionRequest<>(
-            request.getSource(),
-            TypeLiteral.get(request.getInstance().getClass()),
-            /* instance= */ null));
+    injector
+        .getBindingData()
+        .putInjectionRequest(
+            new InjectionRequest<>(
+                request.getSource(),
+                TypeLiteral.get(request.getInstance().getClass()),
+                /* instance= */ null));
     return true;
   }
 

--- a/core/src/com/google/inject/internal/InterceptorBindingProcessor.java
+++ b/core/src/com/google/inject/internal/InterceptorBindingProcessor.java
@@ -32,9 +32,11 @@ final class InterceptorBindingProcessor extends AbstractProcessor {
 
   @Override
   public Boolean visit(InterceptorBinding command) {
-    injector.state.addMethodAspect(
-        new MethodAspect(
-            command.getClassMatcher(), command.getMethodMatcher(), command.getInterceptors()));
+    injector
+        .getBindingData()
+        .addMethodAspect(
+            new MethodAspect(
+                command.getClassMatcher(), command.getMethodMatcher(), command.getInterceptors()));
     return true;
   }
 }

--- a/core/src/com/google/inject/internal/ListenerBindingProcessor.java
+++ b/core/src/com/google/inject/internal/ListenerBindingProcessor.java
@@ -32,13 +32,13 @@ final class ListenerBindingProcessor extends AbstractProcessor {
 
   @Override
   public Boolean visit(TypeListenerBinding binding) {
-    injector.state.addTypeListener(binding);
+    injector.getBindingData().addTypeListener(binding);
     return true;
   }
 
   @Override
   public Boolean visit(ProvisionListenerBinding binding) {
-    injector.state.addProvisionListener(binding);
+    injector.getBindingData().addProvisionListener(binding);
     return true;
   }
 }

--- a/core/src/com/google/inject/internal/LookupProcessor.java
+++ b/core/src/com/google/inject/internal/LookupProcessor.java
@@ -39,7 +39,7 @@ final class LookupProcessor extends AbstractProcessor {
       MembersInjector<T> membersInjector =
           injector.membersInjectorStore.get(lookup.getType(), errors);
       lookup.initializeDelegate(membersInjector);
-      injector.state.putMembersInjectorLookup(lookup);
+      injector.getBindingData().putMembersInjectorLookup(lookup);
     } catch (ErrorsException e) {
       errors.merge(e.getErrors()); // TODO: source
     }
@@ -53,7 +53,7 @@ final class LookupProcessor extends AbstractProcessor {
     try {
       Provider<T> provider = injector.getProviderOrThrow(lookup.getDependency(), errors);
       lookup.initializeDelegate(provider);
-      injector.state.putProviderLookup(lookup);
+      injector.getBindingData().putProviderLookup(lookup);
     } catch (ErrorsException e) {
       errors.merge(e.getErrors()); // TODO: source
     }

--- a/core/src/com/google/inject/internal/ModuleAnnotatedMethodScannerProcessor.java
+++ b/core/src/com/google/inject/internal/ModuleAnnotatedMethodScannerProcessor.java
@@ -31,7 +31,7 @@ final class ModuleAnnotatedMethodScannerProcessor extends AbstractProcessor {
 
   @Override
   public Boolean visit(ModuleAnnotatedMethodScannerBinding command) {
-    injector.state.addScanner(command);
+    injector.getBindingData().addScanner(command);
     return true;
   }
 }

--- a/core/src/com/google/inject/internal/ScopeBindingProcessor.java
+++ b/core/src/com/google/inject/internal/ScopeBindingProcessor.java
@@ -50,13 +50,13 @@ final class ScopeBindingProcessor extends AbstractProcessor {
       // Go ahead and bind anyway so we don't get collateral errors.
     }
 
-    ScopeBinding existing = injector.state.getScopeBinding(annotationType);
+    ScopeBinding existing = injector.getBindingData().getScopeBinding(annotationType);
     if (existing != null) {
       if (!scope.equals(existing.getScope())) {
         errors.duplicateScopes(existing, annotationType, scope);
       }
     } else {
-      injector.state.putScopeBinding(annotationType, command);
+      injector.getBindingData().putScopeBinding(annotationType, command);
     }
 
     return true;

--- a/core/src/com/google/inject/internal/Scoping.java
+++ b/core/src/com/google/inject/internal/Scoping.java
@@ -311,7 +311,7 @@ public abstract class Scoping {
       return scoping;
     }
 
-    ScopeBinding scope = injector.state.getScopeBinding(scopeAnnotation);
+    ScopeBinding scope = injector.getBindingData().getScopeBinding(scopeAnnotation);
     if (scope != null) {
       return forInstance(scope.getScope());
     }

--- a/core/src/com/google/inject/internal/TypeConverterBindingProcessor.java
+++ b/core/src/com/google/inject/internal/TypeConverterBindingProcessor.java
@@ -178,15 +178,19 @@ final class TypeConverterBindingProcessor extends AbstractProcessor {
 
   private static void internalConvertToTypes(
       InjectorImpl injector, Matcher<? super TypeLiteral<?>> typeMatcher, TypeConverter converter) {
-    injector.state.addConverter(
-        new TypeConverterBinding(SourceProvider.UNKNOWN_SOURCE, typeMatcher, converter));
+    injector
+        .getBindingData()
+        .addConverter(
+            new TypeConverterBinding(SourceProvider.UNKNOWN_SOURCE, typeMatcher, converter));
   }
 
   @Override
   public Boolean visit(TypeConverterBinding command) {
-    injector.state.addConverter(
-        new TypeConverterBinding(
-            command.getSource(), command.getTypeMatcher(), command.getTypeConverter()));
+    injector
+        .getBindingData()
+        .addConverter(
+            new TypeConverterBinding(
+                command.getSource(), command.getTypeMatcher(), command.getTypeConverter()));
     return true;
   }
 

--- a/core/src/com/google/inject/internal/UntargettedBindingProcessor.java
+++ b/core/src/com/google/inject/internal/UntargettedBindingProcessor.java
@@ -26,8 +26,8 @@ import com.google.inject.spi.UntargettedBinding;
  */
 class UntargettedBindingProcessor extends AbstractBindingProcessor {
 
-  UntargettedBindingProcessor(Errors errors, ProcessedBindingData bindingData) {
-    super(errors, bindingData);
+  UntargettedBindingProcessor(Errors errors, ProcessedBindingData processedBindingData) {
+    super(errors, processedBindingData);
   }
 
   @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> InjectorImpl: rename state -> bindingData and make it a private field.
Rename ProcessedBindingData bindingData -> processedBindingData in the processors, so that the two kinds of binding data are distinct.

This is a refactor only. No changes in behavior expected from this CL.

9bc5016948b4b734c4a4aa381d148aee4a5ebd8f

-------

<p> Enable logging warnings on RestrictedBindingSource violations (ie. the restrictionLevel knob).

ebdfb4c8cef922c905e834a67c048a30a274f3ce