### PR TITLE
Create a new multibinder alternate for Set<? extends T>

### DIFF
--- a/core/src/com/google/inject/internal/RealMultibinder.java
+++ b/core/src/com/google/inject/internal/RealMultibinder.java
@@ -81,6 +81,13 @@ public final class RealMultibinder<T> implements Module {
     return (TypeLiteral<Collection<javax.inject.Provider<T>>>) TypeLiteral.get(type);
   }
 
+  @SuppressWarnings("unchecked")
+  static <T> TypeLiteral<Set<? extends T>> setOfExtendsOf(TypeLiteral<T> elementType) {
+    Type extendsType = Types.subtypeOf(elementType.getType());
+    Type setOfExtendsType = Types.setOf(extendsType);
+    return (TypeLiteral<Set<? extends T>>) TypeLiteral.get(setOfExtendsType);
+  }
+
   private final BindingSelection<T> bindingSelection;
   private final Binder binder;
 
@@ -100,6 +107,9 @@ public final class RealMultibinder<T> implements Module {
     binder
         .bind(bindingSelection.getCollectionOfProvidersKey())
         .toProvider(collectionOfProvidersProvider);
+    binder
+        .bind(bindingSelection.getSetOfExtendsKey())
+        .to(bindingSelection.getSetKey());
 
     // The collection this exposes is internally an ImmutableList, so it's OK to massage
     // the guice Provider to javax Provider in the value (since the guice Provider implements
@@ -296,7 +306,8 @@ public final class RealMultibinder<T> implements Module {
     public Set<Key<?>> getAlternateSetKeys() {
       return ImmutableSet.of(
           (Key<?>) bindingSelection.getCollectionOfProvidersKey(),
-          (Key<?>) bindingSelection.getCollectionOfJavaxProvidersKey());
+          (Key<?>) bindingSelection.getCollectionOfJavaxProvidersKey(),
+          (Key<?>) bindingSelection.getSetOfExtendsKey());
     }
 
     @Override
@@ -332,6 +343,7 @@ public final class RealMultibinder<T> implements Module {
     private String setName;
     private Key<Collection<Provider<T>>> collectionOfProvidersKey;
     private Key<Collection<javax.inject.Provider<T>>> collectionOfJavaxProvidersKey;
+    private Key<Set<? extends T>> setOfExtendsKey;
     private Key<Boolean> permitDuplicatesKey;
 
     private boolean isInitialized;
@@ -457,6 +469,15 @@ public final class RealMultibinder<T> implements Module {
       return local;
     }
 
+    Key<Set<? extends T>> getSetOfExtendsKey() {
+      Key<Set<? extends T>> local = setOfExtendsKey;
+      if (local == null) {
+        local =
+            setOfExtendsKey = setKey.ofType(setOfExtendsOf(elementType));
+      }
+      return local;
+    }
+
     boolean isInitialized() {
       return isInitialized;
     }
@@ -496,7 +517,8 @@ public final class RealMultibinder<T> implements Module {
             || binding.getKey().equals(getPermitDuplicatesKey())
             || binding.getKey().equals(setKey)
             || binding.getKey().equals(collectionOfProvidersKey)
-            || binding.getKey().equals(collectionOfJavaxProvidersKey);
+            || binding.getKey().equals(collectionOfJavaxProvidersKey)
+            || binding.getKey().equals(setOfExtendsKey);
       } else {
         return false;
       }

--- a/core/src/com/google/inject/multibindings/MultibinderBinding.java
+++ b/core/src/com/google/inject/multibindings/MultibinderBinding.java
@@ -27,12 +27,12 @@ import java.util.Set;
 /**
  * A binding for a Multibinder.
  *
- * <p>Although Multibinders may be injected through a variety of generic types ({@code Set<V>} and
- * {@code Collection<Provider<V>>}), a MultibinderBinding exists only on the Binding associated with
- * the {@code Set<V>} key. Injectable types can be discovered using {@link #getSetKey} (which will
- * return the {@code Set<V>} key), or{@link #getAlternateSetKeys} (which will return the other keys
- * that can inject this data). Other bindings can be validated to be derived from this
- * MultibinderBinding using {@link #containsElement(Element)}.
+ * <p>Although Multibinders may be injected through a variety of generic types ({@code Set<V>},
+ * {@code Collection<Provider<V>>}, and {@code Set<? extends V>} ), a MultibinderBinding exists only
+ * on the Binding associated with the {@code Set<V>} key. Injectable types can be discovered using
+ * {@link #getSetKey} (which will return the {@code Set<V>} key), or {@link #getAlternateSetKeys}
+ * (which will return the other keys that can inject this data). Other bindings can be validated to
+ * be derived from this MultibinderBinding using {@link #containsElement(Element)}.
  *
  * @param <T> The fully qualified type of the set, including Set. For example: {@code
  *     MultibinderBinding<Set<Boolean>>}
@@ -46,8 +46,9 @@ public interface MultibinderBinding<T> {
 
   /**
    * Returns the keys of other bindings that represent this set. This will return an entry for
-   * {@code Collection<com.google.inject.Provider<V>>} and {@code
-   * Collection<javax.inject.Provider<V>>}.
+   * {@code Collection<com.google.inject.Provider<V>>},
+   * {@code Collection<javax.inject.Provider<V>>}, and
+   * {@code Set<? extends V>}.
    *
    * @since 4.2.3
    */

--- a/core/test/com/google/inject/internal/MapBinderTest.java
+++ b/core/test/com/google/inject/internal/MapBinderTest.java
@@ -163,6 +163,11 @@ public class MapBinderTest extends TestCase {
                     collectionOf(
                         Types.javaxProviderOf(
                             mapEntryOf(String.class, Types.providerOf(String.class))))),
+                // Set<? extends Map.Entry<K, Provider<V>>>
+                Key.get(
+                    Types.setOf(
+                        Types.subtypeOf(
+                            mapEntryOf(String.class, Types.providerOf(String.class))))),
                 // @Named(...) Boolean
                 Key.get(
                     Boolean.class,

--- a/core/test/com/google/inject/internal/MultibinderTest.java
+++ b/core/test/com/google/inject/internal/MultibinderTest.java
@@ -1530,6 +1530,86 @@ public class MultibinderTest extends TestCase {
         });
   }
 
+  public void testMultibinderWithWildcard() {
+    Module module = new AbstractModule() {
+      @Override
+      protected void configure() {
+        Multibinder<String> multibinder = Multibinder.newSetBinder(binder(), String.class);
+        multibinder.addBinding().toInstance("a");
+        multibinder.addBinding().toInstance("b");
+        multibinder.addBinding().toInstance("c");
+      }
+    };
+    Injector injector = Guice.createInjector(module);
+
+    Set<String> set = injector.getInstance(new Key<Set<String>>() {});
+    assertEquals(ImmutableSet.of("a", "b", "c"), set);
+
+    Set<? extends String> setOfWildcard = injector.getInstance(new Key<Set<? extends String>>() {});
+    assertEquals(ImmutableSet.of("a", "b", "c"), setOfWildcard);
+  }
+
+  /**
+   * Injection of {@code Set<? extends T>} wasn't added until 2020-07. It's possible that
+   * applications already have a binding to that type. If they do, confirm that Guice fails fast
+   * with a duplicate binding error.
+   */
+  public void testMultibinderConflictsWithExistingWildcard() {
+    Module module = new AbstractModule() {
+      @Override
+      protected void configure() {
+        Multibinder<String> multibinder = Multibinder.newSetBinder(binder(), String.class);
+        multibinder.addBinding().toInstance("a");
+        multibinder.addBinding().toInstance("b");
+        multibinder.addBinding().toInstance("c");
+      }
+
+      @Provides
+      public Set<? extends String> provideStrings() {
+        return ImmutableSet.of("d", "e", "f");
+      }
+    };
+
+    try {
+      Guice.createInjector(module);
+      fail();
+    } catch (CreationException e) {
+      assertTrue(e.getMessage().contains(
+          "A binding to java.util.Set<? extends java.lang.String> was already configured"));
+    }
+  }
+
+  /**
+   * This is the same as the previous test, but it gets at the conflicting set through a multibinder
+   * rather than through a regular binding. It's unlikely that application developers would do this
+   * in practice, but if they do we want to make sure it is detected and fails fast.
+   */
+  public void testMultibinderConflictsWithExistingMultibinder() {
+    Module module = new AbstractModule() {
+      @Override
+      protected void configure() {
+        Multibinder<String> multibinder = Multibinder.newSetBinder(binder(), String.class);
+        multibinder.addBinding().toInstance("a");
+        multibinder.addBinding().toInstance("b");
+        multibinder.addBinding().toInstance("c");
+
+        Multibinder<String> multibinder2 = Multibinder.newSetBinder(binder(),
+            (TypeLiteral<String>) TypeLiteral.get(Types.subtypeOf(String.class)));
+        multibinder2.addBinding().toInstance("d");
+        multibinder2.addBinding().toInstance("e");
+        multibinder2.addBinding().toInstance("f");
+      }
+    };
+
+    try {
+      Guice.createInjector(module);
+      fail();
+    } catch (CreationException e) {
+      assertTrue(e.getMessage().contains(
+          "A binding to java.util.Set<? extends java.lang.String> was already configured"));
+    }
+  }
+
   private <T> Collection<T> collectValues(
       Collection<? extends javax.inject.Provider<T>> providers) {
     Collection<T> values = Lists.newArrayList();

--- a/core/test/com/google/inject/internal/SpiUtils.java
+++ b/core/test/com/google/inject/internal/SpiUtils.java
@@ -28,6 +28,7 @@ import static com.google.inject.internal.RealMapBinder.mapOfSetOfProviderOf;
 import static com.google.inject.internal.RealMultibinder.collectionOfJavaxProvidersOf;
 import static com.google.inject.internal.RealMultibinder.collectionOfProvidersOf;
 import static com.google.inject.internal.RealMultibinder.setOf;
+import static com.google.inject.internal.RealMultibinder.setOfExtendsOf;
 import static com.google.inject.internal.SpiUtils.BindType.INSTANCE;
 import static com.google.inject.internal.SpiUtils.BindType.LINKED;
 import static com.google.inject.internal.SpiUtils.BindType.PROVIDER_INSTANCE;
@@ -194,6 +195,8 @@ public class SpiUtils {
         mapKey.ofType(collectionOfProvidersOf(entryOfProviderOf(keyType, valueType)));
     Key<?> collectionOfJavaxProvidersOfEntryOfProvider =
         mapKey.ofType(collectionOfJavaxProvidersOf(entryOfProviderOf(keyType, valueType)));
+    Key<?> setOfExtendsOfEntryOfProvider =
+        mapKey.ofType(setOfExtendsOf(entryOfProviderOf(keyType, valueType)));
     assertEquals(
         ImmutableSet.of(
             mapOfJavaxProvider,
@@ -216,6 +219,7 @@ public class SpiUtils {
     boolean mapCollectionJavaxProviderMatch = false;
     boolean collectionOfProvidersOfEntryOfProviderMatch = false;
     boolean collectionOfJavaxProvidersOfEntryOfProviderMatch = false;
+    boolean setOfExtendsOfEntryOfProviderMatch = false;
     List<Object> otherMapBindings = Lists.newArrayList();
     List<Binding> otherMatches = Lists.newArrayList();
     Multimap<Object, IndexedBinding> indexedEntries =
@@ -266,6 +270,9 @@ public class SpiUtils {
       } else if (b.getKey().equals(collectionOfJavaxProvidersOfEntryOfProvider)) {
         assertTrue(contains);
         collectionOfJavaxProvidersOfEntryOfProviderMatch = true;
+      } else if (b.getKey().equals(setOfExtendsOfEntryOfProvider)) {
+        assertTrue(contains);
+        setOfExtendsOfEntryOfProviderMatch = true;
       } else if (contains) {
         if (b instanceof ProviderInstanceBinding) {
           ProviderInstanceBinding<?> pib = (ProviderInstanceBinding<?>) b;
@@ -300,6 +307,7 @@ public class SpiUtils {
     assertTrue(mapJavaxProviderMatch);
     assertTrue(collectionOfProvidersOfEntryOfProviderMatch);
     assertTrue(collectionOfJavaxProvidersOfEntryOfProviderMatch);
+    assertTrue(setOfExtendsOfEntryOfProviderMatch);
     assertEquals(allowDuplicates, mapSetMatch);
     assertEquals(allowDuplicates, mapSetProviderMatch);
     assertEquals(allowDuplicates, mapSetJavaxProviderMatch);
@@ -383,6 +391,8 @@ public class SpiUtils {
         mapKey.ofType(collectionOfProvidersOf(entryOfProviderOf(keyType, valueType)));
     Key<?> collectionOfJavaxProvidersOfEntryOfProvider =
         mapKey.ofType(collectionOfJavaxProvidersOf(entryOfProviderOf(keyType, valueType)));
+    Key<?> setOfExtendsOfEntryOfProvider =
+        mapKey.ofType(setOfExtendsOf(entryOfProviderOf(keyType, valueType)));
     assertEquals(
         ImmutableSet.of(
             mapOfProvider,
@@ -405,6 +415,7 @@ public class SpiUtils {
     boolean mapCollectionJavaxProviderMatch = false;
     boolean collectionOfProvidersOfEntryOfProviderMatch = false;
     boolean collectionOfJavaxProvidersOfEntryOfProviderMatch = false;
+    boolean setOfExtendsOfEntryOfProviderMatch = false;
     List<Object> otherMapBindings = Lists.newArrayList();
     List<Element> otherMatches = Lists.newArrayList();
     List<Element> otherElements = Lists.newArrayList();
@@ -499,6 +510,10 @@ public class SpiUtils {
           matched = true;
           assertTrue(contains);
           collectionOfJavaxProvidersOfEntryOfProviderMatch = true;
+        } else if (key.equals(setOfExtendsOfEntryOfProvider)) {
+          matched = true;
+          assertTrue(contains);
+          setOfExtendsOfEntryOfProviderMatch = true;
         }
       }
 
@@ -524,6 +539,7 @@ public class SpiUtils {
     assertTrue(mapJavaxProviderMatch);
     assertTrue(collectionOfProvidersOfEntryOfProviderMatch);
     assertTrue(collectionOfJavaxProvidersOfEntryOfProviderMatch);
+    assertTrue(setOfExtendsOfEntryOfProviderMatch);
     assertEquals(allowDuplicates, mapSetMatch);
     assertEquals(allowDuplicates, mapSetProviderMatch);
     assertEquals(allowDuplicates, mapSetJavaxProviderMatch);
@@ -583,6 +599,7 @@ public class SpiUtils {
       BindResult... results) {
     Key<?> collectionOfProvidersKey = setKey.ofType(collectionOfProvidersOf(elementType));
     Key<?> collectionOfJavaxProvidersKey = setKey.ofType(collectionOfJavaxProvidersOf(elementType));
+    Key<?> setOfExtendsKey = setKey.ofType(setOfExtendsOf(elementType));
     Injector injector = Guice.createInjector(modules);
     Visitor<Set<T>> visitor = new Visitor<>();
     Binding<Set<T>> binding = injector.getBinding(setKey);
@@ -593,7 +610,7 @@ public class SpiUtils {
     assertEquals(elementType, multibinder.getElementTypeLiteral());
     assertEquals(allowDuplicates, multibinder.permitsDuplicates());
     assertEquals(
-        ImmutableSet.of(collectionOfProvidersKey, collectionOfJavaxProvidersKey),
+        ImmutableSet.of(collectionOfProvidersKey, collectionOfJavaxProvidersKey, setOfExtendsKey),
         multibinder.getAlternateSetKeys());
     List<Binding<?>> elements = Lists.newArrayList(multibinder.getElements());
     List<BindResult> bindResults = Lists.newArrayList(results);
@@ -632,6 +649,7 @@ public class SpiUtils {
     List<Binding> otherContains = Lists.newArrayList();
     boolean collectionOfProvidersMatch = false;
     boolean collectionOfJavaxProvidersMatch = false;
+    boolean setOfExtendsKeyMatch = false;
     for (Binding b : injector.getAllBindings().values()) {
       boolean contains = multibinder.containsElement(b);
       Key key = b.getKey();
@@ -650,6 +668,9 @@ public class SpiUtils {
       } else if (key.equals(collectionOfJavaxProvidersKey)) {
         assertTrue(contains);
         collectionOfJavaxProvidersMatch = true;
+      } else if (key.equals(setOfExtendsKey)) {
+        assertTrue(contains);
+        setOfExtendsKeyMatch = true;
       } else if (contains) {
         if (!indexer.isIndexable(b) || !setOfIndexed.contains(b.acceptTargetVisitor(indexer))) {
           otherContains.add(b);
@@ -659,6 +680,7 @@ public class SpiUtils {
 
     assertTrue(collectionOfProvidersMatch);
     assertTrue(collectionOfJavaxProvidersMatch);
+    assertTrue(setOfExtendsKeyMatch);
 
     if (allowDuplicates) {
       assertEquals("contained more than it should: " + otherContains, 1, otherContains.size());
@@ -681,6 +703,7 @@ public class SpiUtils {
       BindResult... results) {
     Key<?> collectionOfProvidersKey = setKey.ofType(collectionOfProvidersOf(elementType));
     Key<?> collectionOfJavaxProvidersKey = setKey.ofType(collectionOfJavaxProvidersOf(elementType));
+    Key<?> setOfExtendsKey = setKey.ofType(setOfExtendsOf(elementType));
     List<BindResult> bindResults = Lists.newArrayList(results);
     List<Element> elements = Elements.getElements(modules);
     Visitor<T> visitor = new Visitor<>();
@@ -696,7 +719,7 @@ public class SpiUtils {
     assertEquals(setKey, multibinder.getSetKey());
     assertEquals(elementType, multibinder.getElementTypeLiteral());
     assertEquals(
-        ImmutableSet.of(collectionOfProvidersKey, collectionOfJavaxProvidersKey),
+        ImmutableSet.of(collectionOfProvidersKey, collectionOfJavaxProvidersKey, setOfExtendsKey),
         multibinder.getAlternateSetKeys());
     List<Object> otherMultibinders = Lists.newArrayList();
     Set<Element> otherContains = new HashSet<>();
@@ -706,6 +729,7 @@ public class SpiUtils {
     Indexer indexer = new Indexer(null);
     boolean collectionOfProvidersMatch = false;
     boolean collectionOfJavaxProvidersMatch = false;
+    boolean setOfExtendsMatch = false;
     for (Element element : elements) {
       boolean contains = multibinder.containsElement(element);
       if (!contains) {
@@ -739,6 +763,10 @@ public class SpiUtils {
         assertTrue(contains);
         assertFalse(matched);
         collectionOfJavaxProvidersMatch = true;
+      } else if (setOfExtendsKey.equals(key)) {
+        assertTrue(contains);
+        assertFalse(matched);
+        setOfExtendsMatch = true;
       } else if (!matched && contains) {
         otherContains.add(element);
       }
@@ -762,6 +790,7 @@ public class SpiUtils {
         otherMultibinders.size());
     assertTrue(collectionOfProvidersMatch);
     assertTrue(collectionOfJavaxProvidersMatch);
+    assertTrue(setOfExtendsMatch);
 
     // Validate that we can construct an injector out of the remaining bindings.
     Guice.createInjector(Elements.getModule(otherElements));


### PR DESCRIPTION
This is a simple linked binding to the original multibinder set. This is
safe because 'Set<? extends T>' is assignable from 'Set<T>'.

This is useful for projects integrating Guice and Kotlin. In Kotlin there
are different types for read-only vs. read-write Sets. When declaring a
read-only Set, the bytecode includes a wildcard.

In particular, this Kotlin:

    var setA: Set<Runnable>
    var setB: MutableSet<Runnable>

is equivalent to this Java:

    Set<? extends Runnable> setA;
    Set<Runnable> setB;

Using Kotlin with Guice multibindings is quite annoying because the binding
to `Set<Runnable>` is typically provided, but `Set<? extends Runnable>` is
needed.

The typical Kotlin workaround is also ugly:

    var setA: Set<@JvmSuppressWildcards Runnable>

With this fix, Guice multibindings and Guice should just work.

I expect this may be backwards-incompatible with a very small number of Kotlin
applications that implement a different workaround to the above problem:

    @Provides
    Set<? extends Runnable> provideRunnables(Set<Runnable> set) {
      return set;
    }

I don't expect backwards incompatibility with Java programs. In such programs
the behavior change will result in a fast failure (injector fails to create)
which is easy to diagnose and fix.

Closes: https://github.com/google/guice/issues/1282