### PR TITLE
MOE Sync 2020-07-22

### DIFF
--- a/core/src/com/google/inject/internal/InjectorBindingData.java
+++ b/core/src/com/google/inject/internal/InjectorBindingData.java
@@ -75,11 +75,8 @@ class InjectorBindingData {
   private final ListMultimap<TypeLiteral<?>, Binding<?>> indexedExplicitBindings =
       ArrayListMultimap.create();
 
-  private final Object lock;
-
   InjectorBindingData(Optional<InjectorBindingData> parent) {
     this.parent = parent;
-    this.lock = parent.isPresent() ? parent.get().lock() : this;
   }
 
   public Optional<InjectorBindingData> parent() {
@@ -245,10 +242,6 @@ class InjectorBindingData {
 
   public ImmutableList<ModuleAnnotatedMethodScannerBinding> getScannerBindingsThisLevel() {
     return ImmutableList.copyOf(scannerBindings);
-  }
-
-  public Object lock() {
-    return lock;
   }
 
   public Map<Class<? extends Annotation>, Scope> getScopes() {

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -171,7 +171,7 @@ final class InjectorImpl implements Injector, Lookups {
     if (explicitBinding != null) {
       return explicitBinding;
     }
-    synchronized (bindingData.lock()) {
+    synchronized (jitBindingData.lock()) {
       // See if any jit bindings have been created for this key.
       for (InjectorImpl injector = this; injector != null; injector = injector.parent) {
         @SuppressWarnings("unchecked")
@@ -257,7 +257,7 @@ final class InjectorImpl implements Injector, Lookups {
       throws ErrorsException {
 
     boolean jitOverride = isProvider(key) || isTypeLiteral(key) || isMembersInjector(key);
-    synchronized (bindingData.lock()) {
+    synchronized (jitBindingData.lock()) {
       // first try to find a JIT binding that we've already created
       for (InjectorImpl injector = this; injector != null; injector = injector.parent) {
         @SuppressWarnings("unchecked") // we only store bindings that match their key
@@ -295,7 +295,7 @@ final class InjectorImpl implements Injector, Lookups {
         throw errors.toException();
       }
       return createJustInTimeBindingRecursive(key, errors, options.jitDisabled, jitType);
-    } // end synchronized(state.lock())
+    } // end synchronized(jitBindingData.lock())
   }
 
   /** Returns true if the key type is Provider (but not a subclass of Provider). */
@@ -593,7 +593,7 @@ final class InjectorImpl implements Injector, Lookups {
   <T> void initializeJitBinding(BindingImpl<T> binding, Errors errors) throws ErrorsException {
     // Put the partially constructed binding in the map a little early. This enables us to handle
     // circular dependencies. Example: FooImpl -> BarImpl -> FooImpl.
-    // Note: We don't need to synchronize on state.lock() during injector creation.
+    // Note: We don't need to synchronize on jitBindingData.lock() during injector creation.
     if (binding instanceof DelayedInitialize) {
       Key<T> key = binding.getKey();
       jitBindingData.getJitBindings().put(key, binding);
@@ -954,7 +954,7 @@ final class InjectorImpl implements Injector, Lookups {
 
   @Override
   public Map<Key<?>, Binding<?>> getAllBindings() {
-    synchronized (bindingData.lock()) {
+    synchronized (jitBindingData.lock()) {
       return new ImmutableMap.Builder<Key<?>, Binding<?>>()
           .putAll(bindingData.getExplicitBindingsThisLevel())
           .putAll(jitBindingData.getJitBindings())

--- a/core/src/com/google/inject/internal/InternalInjectorCreator.java
+++ b/core/src/com/google/inject/internal/InternalInjectorCreator.java
@@ -198,7 +198,7 @@ public final class InternalInjectorCreator {
     Collection<BindingImpl<?>> bindingsAtThisLevel =
         (Collection) injector.getBindingData().getExplicitBindingsThisLevel().values();
     candidateBindings.addAll(bindingsAtThisLevel);
-    synchronized (injector.getBindingData().lock()) {
+    synchronized (injector.getJitBindingData().lock()) {
       // jit bindings must be accessed while holding the lock.
       candidateBindings.addAll(injector.getJitBindingData().getJitBindings().values());
     }

--- a/core/test/com/google/inject/internal/WeakKeySetTest.java
+++ b/core/test/com/google/inject/internal/WeakKeySetTest.java
@@ -593,11 +593,6 @@ public class WeakKeySetTest extends TestCase {
     }
 
     @Override
-    public Object lock() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Map<Class<? extends Annotation>, Scope> getScopes() {
       return ImmutableMap.of();
     }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Move the lock from being InjectorBindingData -> InjectorJitBindingData.
This is a better place for the lock, since it is needed for JIT bindings.
Also inline InjectorShell's getBindingData(): it's only called from one place.

44ddb5c994f4829479c707893cb4dce0e7984bbf