### PR TITLE
MOE Sync 2020-08-03

### DIFF
--- a/core/src/com/google/inject/internal/BindingAlreadySetError.java
+++ b/core/src/com/google/inject/internal/BindingAlreadySetError.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /** Error reported by Guice when a key is bound at multiple places the injector. */
-final class BindingAlreadySetError extends ErrorDetail<BindingAlreadySetError> {
+final class BindingAlreadySetError extends InternalErrorDetail<BindingAlreadySetError> {
   private final Binding<?> binding;
   private final Binding<?> original;
 

--- a/core/src/com/google/inject/internal/GenericErrorDetail.java
+++ b/core/src/com/google/inject/internal/GenericErrorDetail.java
@@ -9,8 +9,8 @@ import java.io.Serializable;
 import java.util.Formatter;
 import java.util.List;
 
-/** Generic error message representing a Guice error. */
-public final class GenericErrorDetail extends ErrorDetail<GenericErrorDetail>
+/** Generic error message representing a Guice internal error. */
+public final class GenericErrorDetail extends InternalErrorDetail<GenericErrorDetail>
     implements Serializable {
   public GenericErrorDetail(
       ErrorId errorId, String message, List<Object> sources, Throwable cause) {

--- a/core/src/com/google/inject/internal/InjectorShell.java
+++ b/core/src/com/google/inject/internal/InjectorShell.java
@@ -30,8 +30,8 @@ import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.Stage;
 import com.google.inject.internal.InjectorImpl.InjectorOptions;
+import com.google.inject.internal.util.ContinuousStopwatch;
 import com.google.inject.internal.util.SourceProvider;
-import com.google.inject.internal.util.Stopwatch;
 import com.google.inject.spi.BindingSourceRestriction;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.Element;
@@ -133,7 +133,7 @@ final class InjectorShell {
     List<InjectorShell> build(
         Initializer initializer,
         ProcessedBindingData processedBindingData,
-        Stopwatch stopwatch,
+        ContinuousStopwatch stopwatch,
         Errors errors) {
       checkState(stage != null, "Stage not initialized");
       checkState(privateElements == null || parent != null, "PrivateElements with no parent");

--- a/core/src/com/google/inject/internal/InternalErrorDetail.java
+++ b/core/src/com/google/inject/internal/InternalErrorDetail.java
@@ -1,0 +1,32 @@
+package com.google.inject.internal;
+
+import com.google.common.base.CaseFormat;
+import com.google.inject.spi.ErrorDetail;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Represents an error created by Guice as opposed to custom error added to the binder from
+ * application code.
+ */
+abstract class InternalErrorDetail<T extends ErrorDetail<T>> extends ErrorDetail<T> {
+  private static final String DOC_BASE_URL = "https://github.com/googel/guice/wiki";
+
+  protected final ErrorId errorId;
+
+  protected InternalErrorDetail(
+      ErrorId errorId, String message, List<Object> sources, Throwable cause) {
+    super(
+        String.format(
+            "Guice/%s", CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, errorId.name())),
+        message,
+        sources,
+        cause);
+    this.errorId = errorId;
+  }
+
+  @Override
+  protected final Optional<String> getLearnMoreLink() {
+    return Optional.of(String.format("%s/%s", DOC_BASE_URL, errorId.name()));
+  }
+}

--- a/core/src/com/google/inject/internal/InternalInjectorCreator.java
+++ b/core/src/com/google/inject/internal/InternalInjectorCreator.java
@@ -16,6 +16,7 @@
 
 package com.google.inject.internal;
 
+import com.google.common.base.Stopwatch;
 import com.google.inject.Binding;
 import com.google.inject.Injector;
 import com.google.inject.Key;
@@ -25,7 +26,7 @@ import com.google.inject.Provider;
 import com.google.inject.Scope;
 import com.google.inject.Stage;
 import com.google.inject.TypeLiteral;
-import com.google.inject.internal.util.Stopwatch;
+import com.google.inject.internal.util.ContinuousStopwatch;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.Element;
 import com.google.inject.spi.InjectionPoint;
@@ -59,7 +60,8 @@ import java.util.Set;
  */
 public final class InternalInjectorCreator {
 
-  private final Stopwatch stopwatch = new Stopwatch();
+  private final ContinuousStopwatch stopwatch =
+      new ContinuousStopwatch(Stopwatch.createUnstarted());
   private final Errors errors = new Errors();
 
   private final Initializer initializer = new Initializer();

--- a/core/src/com/google/inject/internal/MissingImplementationError.java
+++ b/core/src/com/google/inject/internal/MissingImplementationError.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /** Error reported by Guice when a key is not bound in the injector. */
-final class MissingImplementationError extends ErrorDetail<MissingImplementationError> {
+final class MissingImplementationError extends InternalErrorDetail<MissingImplementationError> {
   private final Key<?> key;
 
   public MissingImplementationError(Key<?> key, List<Object> sources) {

--- a/core/src/com/google/inject/internal/util/ContinuousStopwatch.java
+++ b/core/src/com/google/inject/internal/util/ContinuousStopwatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Google Inc.
+ * Copyright (C) 2020 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,26 +16,38 @@
 
 package com.google.inject.internal.util;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import com.google.common.base.Stopwatch;
 import java.util.logging.Logger;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * Enables simple performance monitoring.
+ * A continuously timing stopwatch that is used for simple performance monitoring.
  *
  * @author crazybob@google.com (Bob Lee)
  */
-public final class Stopwatch {
-  private static final Logger logger = Logger.getLogger(Stopwatch.class.getName());
+@NotThreadSafe
+public final class ContinuousStopwatch {
+  private final Logger logger = Logger.getLogger(ContinuousStopwatch.class.getName());
+  private final Stopwatch stopwatch;
 
-  private long start = System.currentTimeMillis();
+  /**
+   * Constructs a ContinuousStopwatch, which will start timing immediately after construction.
+   *
+   * @param stopwatch the internal stopwatch used by ContinuousStopwatch
+   */
+  public ContinuousStopwatch(Stopwatch stopwatch) {
+    this.stopwatch = stopwatch;
+    reset();
+  }
 
   /** Resets and returns elapsed time in milliseconds. */
   public long reset() {
-    long now = System.currentTimeMillis();
-    try {
-      return now - start;
-    } finally {
-      start = now;
-    }
+    long elapsedTimeMs = stopwatch.elapsed(MILLISECONDS);
+    stopwatch.reset();
+    stopwatch.start();
+    return elapsedTimeMs;
   }
 
   /** Resets and logs elapsed time in milliseconds. */

--- a/core/test/com/google/inject/internal/MessagesTest.java
+++ b/core/test/com/google/inject/internal/MessagesTest.java
@@ -18,7 +18,7 @@ import org.junit.runners.JUnit4;
 public final class MessagesTest {
   static class ExampleErrorDetail extends ErrorDetail<ExampleErrorDetail> {
     ExampleErrorDetail(String message) {
-      super(ErrorId.OTHER, message, ImmutableList.of(), null);
+      super("Example", message, ImmutableList.of(), null);
     }
 
     @Override

--- a/core/test/com/google/inject/internal/util/ContinuousStopwatchTest.java
+++ b/core/test/com/google/inject/internal/util/ContinuousStopwatchTest.java
@@ -1,0 +1,68 @@
+package com.google.inject.internal.util;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.testing.FakeTicker;
+import com.google.common.testing.TestLogHandler;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ContinuousStopwatchTest {
+  private static final Logger logger = Logger.getLogger(ContinuousStopwatch.class.getName());
+  // Records ContinuousStopwatch logs.
+  private TestLogHandler testLogHandler;
+  // Used to reset the log level after this test is over.
+  private Level savedLogLevel;
+
+  @Before
+  public void addLogHandler() {
+    savedLogLevel = logger.getLevel();
+    logger.setLevel(Level.FINE);
+    testLogHandler = new TestLogHandler();
+    logger.addHandler(testLogHandler);
+  }
+
+  @After
+  public void removeLogHandler() {
+    Logger.getLogger(ContinuousStopwatch.class.getName()).removeHandler(testLogHandler);
+    logger.setLevel(savedLogLevel);
+  }
+
+  @Test
+  public void multipleReset() throws Exception {
+    FakeTicker fakeTicker = new FakeTicker();
+    ContinuousStopwatch continuousStopwatch =
+        new ContinuousStopwatch(Stopwatch.createUnstarted(fakeTicker));
+
+    fakeTicker.advance(1, MILLISECONDS);
+    assertThat(continuousStopwatch.reset()).isEqualTo(1);
+    fakeTicker.advance(2, MILLISECONDS);
+    assertThat(continuousStopwatch.reset()).isEqualTo(2);
+  }
+
+  @Test
+  public void multipleResetAndLog() throws Exception {
+    FakeTicker fakeTicker = new FakeTicker();
+    ContinuousStopwatch continuousStopwatch =
+        new ContinuousStopwatch(Stopwatch.createUnstarted(fakeTicker));
+
+    fakeTicker.advance(1, MILLISECONDS);
+    continuousStopwatch.resetAndLog("label one");
+    fakeTicker.advance(2, MILLISECONDS);
+    continuousStopwatch.resetAndLog("label two");
+    List<LogRecord> logs = testLogHandler.getStoredLogRecords();
+    assertThat(logs).hasSize(2);
+    assertThat(logs.get(0).getMessage()).isEqualTo("label one: 1ms");
+    assertThat(logs.get(1).getMessage()).isEqualTo("label two: 2ms");
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Rewrite the Guice Stopwatch class to make it testable. Rename this Stopwatch to ContinuousStopwatch to avoid a naming collision with its internal Stopwatch.

Automated g4 rollback of changelist 324101718.

*** Reason for rollback ***

Roll forward of [] with fix: Stopwatch's Duration elapsed() method cannot be used here. Possibly related to b/156759807.

*** Original change description ***

Automated g4 rollback of changelist 324072869.

*** Reason for rollback ***

Broke a bunch of things.

*** Original change description ***

Rewrite the Guice Stopwatch class to make it testable. Rename this Stopwatch to ContinuousStopwatch to avoid a naming collision with its internal Stopwatch.

***

***

298ba14d7c15cbe280a92710a956db57a81b66bd

-------

<p> Allow custom error to include their own id and learn more links.

bd2b3f8bbaffbab199a466ac4db8a5c3deffb0cc