### PR TITLE
MOE Sync 2020-08-12

### DIFF
--- a/core/src/com/google/inject/internal/ConstructorBindingImpl.java
+++ b/core/src/com/google/inject/internal/ConstructorBindingImpl.java
@@ -26,7 +26,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.ConfigurationException;
-import com.google.inject.Inject;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.internal.util.Classes;
@@ -89,7 +88,7 @@ final class ConstructorBindingImpl<T> extends BindingImpl<T>
       Scoping scoping,
       Errors errors,
       boolean failIfNotLinked,
-      boolean failIfNotExplicit)
+      boolean atInjectRequired)
       throws ErrorsException {
     int numErrors = errors.size();
 
@@ -113,10 +112,8 @@ final class ConstructorBindingImpl<T> extends BindingImpl<T>
     // Find a constructor annotated @Inject
     if (constructorInjector == null) {
       try {
-        constructorInjector = InjectionPoint.forConstructorOf(key.getTypeLiteral());
-        if (failIfNotExplicit && !hasAtInject((Constructor) constructorInjector.getMember())) {
-          errors.atInjectRequired(rawType);
-        }
+        constructorInjector =
+            InjectionPoint.forConstructorOf(key.getTypeLiteral(), atInjectRequired);
       } catch (ConfigurationException e) {
         throw errors.merge(e.getErrorMessages()).toException();
       }
@@ -141,12 +138,6 @@ final class ConstructorBindingImpl<T> extends BindingImpl<T>
 
     return new ConstructorBindingImpl<T>(
         injector, key, source, scopedFactory, scoping, factoryFactory, constructorInjector);
-  }
-
-  /** Returns true if the inject annotation is on the constructor. */
-  private static boolean hasAtInject(Constructor<?> cxtor) {
-    return cxtor.isAnnotationPresent(Inject.class)
-        || cxtor.isAnnotationPresent(javax.inject.Inject.class);
   }
 
   @Override

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -260,12 +260,19 @@ public final class Errors implements Serializable {
         key);
   }
 
-  public Errors atInjectRequired(Class<?> clazz) {
+  public Errors atInjectRequired(TypeLiteral<?> type) {
+    if (InternalFlags.enableExperimentalErrorMessages()) {
+      return addMessage(
+          new Message(
+              GuiceInternal.GUICE_INTERNAL,
+              ErrorId.MISSING_CONSTRUCTOR,
+              new MissingConstructorError(type, /* atInjectRequired= */ true, getSources())));
+    }
     return addMessage(
         ErrorId.AT_INJECT_REQUIRED,
         "Explicit @Inject annotations are required on constructors,"
             + " but %s has no constructors annotated with @Inject.",
-        clazz);
+        type.getRawType());
   }
 
   public Errors converterReturnedNull(
@@ -410,6 +417,13 @@ public final class Errors implements Serializable {
           + " or a zero-argument constructor that is not private.";
 
   public Errors missingConstructor(TypeLiteral<?> type) {
+    if (InternalFlags.enableExperimentalErrorMessages()) {
+      return addMessage(
+          new Message(
+              GuiceInternal.GUICE_INTERNAL,
+              ErrorId.MISSING_CONSTRUCTOR,
+              new MissingConstructorError(type, /* atInjectRequired= */ false, getSources())));
+    }
     // Don't bother including the type in the message twice, unless the type is generic (i.e. the
     // type has generics that the raw class loses)
     String typeString = type.toString();

--- a/core/src/com/google/inject/internal/MissingConstructorError.java
+++ b/core/src/com/google/inject/internal/MissingConstructorError.java
@@ -1,0 +1,81 @@
+package com.google.inject.internal;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Lists;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.ErrorDetail;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.List;
+
+/** Error reported when Guice can't find an useable constructor to create objects. */
+final class MissingConstructorError extends InternalErrorDetail<MissingConstructorError> {
+  private final TypeLiteral<?> type;
+  private final boolean atInjectRequired;
+
+  MissingConstructorError(TypeLiteral<?> type, boolean atInjectRequired, List<Object> sources) {
+    super(
+        ErrorId.MISSING_CONSTRUCTOR,
+        "No injectable constructor for type " + type + ".",
+        sources,
+        null);
+    this.type = type;
+    this.atInjectRequired = atInjectRequired;
+  }
+
+  @Override
+  public boolean isMergeable(ErrorDetail<?> other) {
+    if (other instanceof MissingConstructorError) {
+      MissingConstructorError otherMissing = (MissingConstructorError) other;
+      return Objects.equal(type, otherMissing.type)
+          && Objects.equal(atInjectRequired, otherMissing.atInjectRequired);
+    }
+    return false;
+  }
+
+  @Override
+  protected void formatDetail(List<ErrorDetail<?>> mergeableErrors, Formatter formatter) {
+    Class<?> rawType = type.getRawType();
+    if (atInjectRequired) {
+      formatter.format(
+          "Injector is configured to require @Inject constructors but %s does not have a @Inject"
+              + " annotated constructor.%n",
+          rawType);
+    } else {
+      Constructor<?> noArgConstructor = null;
+      try {
+        noArgConstructor = type.getRawType().getDeclaredConstructor();
+      } catch (NoSuchMethodException e) {
+        // Ignore
+      }
+      if (noArgConstructor == null) {
+        formatter.format(
+            "%s does not have a @Inject annotated constructor or a no-arg constructor.%n", rawType);
+      } else if (Modifier.isPrivate(noArgConstructor.getModifiers())
+          && !Modifier.isPrivate(rawType.getModifiers())) {
+        formatter.format(
+            "%s has a private no-arg constructor but it's not private. Guice can only use private"
+                + " no-arg constructor if it is defined in a private class.%n",
+            rawType);
+      }
+    }
+    formatter.format("%n");
+
+    List<List<Object>> sourcesList = new ArrayList<>();
+    sourcesList.add(getSources());
+    mergeableErrors.forEach(error -> sourcesList.add(error.getSources()));
+
+    formatter.format("%s%n", "Requested by:");
+    int sourceListIndex = 1;
+    for (List<Object> sources : sourcesList) {
+      ErrorFormatter.formatSources(sourceListIndex++, Lists.reverse(sources), formatter);
+    }
+  }
+
+  @Override
+  public MissingConstructorError withSources(List<Object> newSources) {
+    return new MissingConstructorError(type, atInjectRequired, newSources);
+  }
+}

--- a/core/src/com/google/inject/spi/InjectionPoint.java
+++ b/core/src/com/google/inject/spi/InjectionPoint.java
@@ -20,6 +20,7 @@ import static com.google.inject.internal.MoreTypes.getRawType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.ConfigurationException;
 import com.google.inject.Inject;
@@ -39,6 +40,7 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -47,6 +49,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * A constructor, field or method that can receive injections. Typically this is a member with the
@@ -229,6 +232,9 @@ public final class InjectionPoint {
   /**
    * Returns a new injection point for the injectable constructor of {@code type}.
    *
+   * <p>Either a {@code @Inject} annotated constructor or a non-private no arg constructor is
+   * required to be defined by the class corresponding to {@code type}.
+   *
    * @param type a concrete type with exactly one constructor annotated {@literal @}{@link Inject},
    *     or a no-arguments constructor that is not private.
    * @throws ConfigurationException if there is no injectable constructor, more than one injectable
@@ -236,36 +242,53 @@ public final class InjectionPoint {
    *     parameter with multiple binding annotations.
    */
   public static InjectionPoint forConstructorOf(TypeLiteral<?> type) {
+    return forConstructorOf(type, false);
+  }
+
+  /**
+   * Returns a new injection point for the injectable constructor of {@code type}.
+   *
+   * <p>If {@code atInjectRequired} is true, the constructor must be annotated with {@code @Inject}.
+   * If {@code atInjectRequired} is false, either a {@code @Inject} annotated constructor or a
+   * non-private no arg constructor is required to be defined by the class corresponding to {@code
+   * type}.
+   *
+   * @param type a concrete type with exactly one constructor annotated {@code @Inject}, or a
+   *     no-arguments constructor that is not private.
+   * @param atInjectRequired whether the constructor must be annotated with {@code Inject}.
+   * @throws ConfigurationException if there is no injectable constructor, more than one injectable
+   *     constructor, or if parameters of the injectable constructor are malformed, such as a
+   *     parameter with multiple binding annotations.
+   */
+  public static InjectionPoint forConstructorOf(TypeLiteral<?> type, boolean atInjectRequired) {
     Class<?> rawType = getRawType(type.getType());
     Errors errors = new Errors(rawType);
 
+    List<Constructor<?>> atInjectConstructors =
+        Arrays.stream(rawType.getDeclaredConstructors())
+            .filter(
+                constructor ->
+                    constructor.isAnnotationPresent(Inject.class)
+                        || constructor.isAnnotationPresent(javax.inject.Inject.class))
+            .collect(Collectors.toList());
+
     Constructor<?> injectableConstructor = null;
-    for (Constructor<?> constructor : rawType.getDeclaredConstructors()) {
+    atInjectConstructors.stream()
+        .filter(constructor -> constructor.isAnnotationPresent(Inject.class))
+        .filter(constructor -> constructor.getAnnotation(Inject.class).optional())
+        .forEach(errors::optionalConstructor);
 
-      boolean optional;
-      Inject guiceInject = constructor.getAnnotation(Inject.class);
-      if (guiceInject == null) {
-        javax.inject.Inject javaxInject = constructor.getAnnotation(javax.inject.Inject.class);
-        if (javaxInject == null) {
-          continue;
-        }
-        optional = false;
-      } else {
-        optional = guiceInject.optional();
-      }
-
-      if (optional) {
-        errors.optionalConstructor(constructor);
-      }
-
+    if (atInjectConstructors.size() > 1) {
+      errors.tooManyConstructors(rawType);
+    } else {
+      injectableConstructor = Iterables.getOnlyElement(atInjectConstructors, null);
       if (injectableConstructor != null) {
-        errors.tooManyConstructors(rawType);
+        checkForMisplacedBindingAnnotations(injectableConstructor, errors);
       }
-
-      injectableConstructor = constructor;
-      checkForMisplacedBindingAnnotations(injectableConstructor, errors);
     }
-
+    if (atInjectRequired && injectableConstructor == null) {
+      errors.atInjectRequired(type);
+    }
     errors.throwConfigurationExceptionIfErrorsExist();
 
     if (injectableConstructor != null) {

--- a/core/test/com/google/inject/RequireAtInjectOnConstructorsTest.java
+++ b/core/test/com/google/inject/RequireAtInjectOnConstructorsTest.java
@@ -139,12 +139,12 @@ public class RequireAtInjectOnConstructorsTest extends TestCase {
       Asserts.assertContains(
           ce.getMessage(),
           "1) Explicit @Inject annotations are required on constructors, but "
-              + NoCxtors.class.getName()
+              + AnotherNoCxtors.class.getName()
               + " has no constructors annotated with @Inject",
           "at " + RequireAtInjectOnConstructorsTest.class.getName() + "$",
           "configure",
           "2) Explicit @Inject annotations are required on constructors, but "
-              + AnotherNoCxtors.class.getName()
+              + NoCxtors.class.getName()
               + " has no constructors annotated with @Inject",
           "at " + RequireAtInjectOnConstructorsTest.class.getName() + "$",
           "configure");

--- a/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
+++ b/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
@@ -547,6 +547,9 @@ final class FactoryProvider2<F>
     if (!anyAssistedInjectConstructors) {
       // If none existed, use @Inject.
       try {
+        // TODO(b/151482394): Change this to enforce that there is a @Inject annotated cosntructor
+        // since it doesn't make sense to use assisted inject with a no-arg constructor, regardless
+        // if the injector is configured to require @Inject annotation or not.
         return InjectionPoint.forConstructorOf(implementation);
       } catch (ConfigurationException e) {
         errors.merge(e.getErrorMessages());


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Implement MissingConstructor error in the new format.

This also merge MISSING_CONSTRUCTOR with AT_INJECT_REQUIRED into a single error since they are essentially about the same issue.

f88bde42d099101fea41c6fb02320f43c7f38229