### PR TITLE
MOE Sync 2020-08-17

### DIFF
--- a/core/src/com/google/inject/internal/InternalErrorDetail.java
+++ b/core/src/com/google/inject/internal/InternalErrorDetail.java
@@ -1,6 +1,7 @@
 package com.google.inject.internal;
 
 import com.google.common.base.CaseFormat;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.spi.ErrorDetail;
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +11,27 @@ import java.util.Optional;
  * application code.
  */
 abstract class InternalErrorDetail<T extends ErrorDetail<T>> extends ErrorDetail<T> {
+  // A list of errors that have help documentation.
+  private static final ImmutableSet<ErrorId> DOCUMENTED_ERRORS =
+      ImmutableSet.<ErrorId>builder()
+          .add(ErrorId.BINDING_ALREADY_SET)
+          .add(ErrorId.CAN_NOT_PROXY_CLASS)
+          .add(ErrorId.CIRCULAR_PROXY_DISABLED)
+          .add(ErrorId.DUPLICATE_BINDING_ANNOTATIONS)
+          .add(ErrorId.DUPLICATE_ELEMENT)
+          .add(ErrorId.DUPLICATE_SCOPES)
+          .add(ErrorId.ERROR_INJECTING_CONSTRUCTOR)
+          .add(ErrorId.ERROR_INJECTING_METHOD)
+          .add(ErrorId.ERROR_IN_CUSTOM_PROVIDER)
+          .add(ErrorId.INJECT_INNER_CLASS)
+          .add(ErrorId.MISSING_CONSTRUCTOR)
+          .add(ErrorId.MISSING_IMPLEMENTATION)
+          .add(ErrorId.NULL_INJECTED_INTO_NON_NULLABLE)
+          .add(ErrorId.NULL_VALUE_IN_MAP)
+          .add(ErrorId.SCOPE_NOT_FOUND)
+          .add(ErrorId.TOO_MANY_CONSTRUCTORS)
+          .build();
+
   private static final String DOC_BASE_URL = "https://github.com/googel/guice/wiki";
 
   protected final ErrorId errorId;
@@ -27,6 +49,9 @@ abstract class InternalErrorDetail<T extends ErrorDetail<T>> extends ErrorDetail
 
   @Override
   protected final Optional<String> getLearnMoreLink() {
-    return Optional.of(String.format("%s/%s", DOC_BASE_URL, errorId.name()));
+    if (DOCUMENTED_ERRORS.contains(errorId)) {
+      return Optional.of(String.format("%s/%s", DOC_BASE_URL, errorId.name()));
+    }
+    return Optional.empty();
   }
 }

--- a/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
+++ b/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
@@ -545,11 +545,8 @@ final class FactoryProvider2<F>
     }
 
     if (!anyAssistedInjectConstructors) {
-      // If none existed, use @Inject.
+      // If none existed, use @Inject or a no-arg constructor.
       try {
-        // TODO(b/151482394): Change this to enforce that there is a @Inject annotated cosntructor
-        // since it doesn't make sense to use assisted inject with a no-arg constructor, regardless
-        // if the injector is configured to require @Inject annotation or not.
         return InjectionPoint.forConstructorOf(implementation);
       } catch (ConfigurationException e) {
         errors.merge(e.getErrorMessages());


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Delete TODO to make `@Inject` required to use assisted inject.

Since it's actually possible to use assisted inject with field or method injection, an `@Inject` annotated constructor is not necessary.

This does mean that assisted injection does not respect the `binder().requireAtInjectOnConstructors()` requirement and it is non-trivial to propagate the injector option down to enforce this because the injection point is looked up at module configuration time.

67eea5fe1572fdb908aabb7ecf01ed5e15eb09ae

-------

<p> Only display learn more link for documented error id.

3c5e88f102dd8fd9d19bdca8983bdcacc9213a8c