### PR TITLE
MOE Sync 2020-08-20

### DIFF
--- a/core/src/com/google/inject/internal/BindingAlreadySetError.java
+++ b/core/src/com/google/inject/internal/BindingAlreadySetError.java
@@ -39,7 +39,7 @@ final class BindingAlreadySetError extends InternalErrorDetail<BindingAlreadySet
             .map(e -> ((BindingAlreadySetError) e).binding.getSource())
             .map(ImmutableList::of)
             .collect(Collectors.toList()));
-    formatter.format("Bound at the following %s locations:%n", sourcesList.size());
+    formatter.format("%s%n", Messages.bold("Bound at:"));
     for (int i = 0; i < sourcesList.size(); i++) {
       ErrorFormatter.formatSources(i + 1, sourcesList.get(i), formatter);
     }

--- a/core/src/com/google/inject/internal/Errors.java
+++ b/core/src/com/google/inject/internal/Errors.java
@@ -388,6 +388,13 @@ public final class Errors implements Serializable {
   }
 
   public Errors scopeNotFound(Class<? extends Annotation> scopeAnnotation) {
+    if (InternalFlags.enableExperimentalErrorMessages()) {
+      return addMessage(
+          new Message(
+              GuiceInternal.GUICE_INTERNAL,
+              ErrorId.SCOPE_NOT_FOUND,
+              new ScopeNotFoundError(scopeAnnotation, getSources())));
+    }
     return addMessage(ErrorId.SCOPE_NOT_FOUND, "No scope is bound to %s.", scopeAnnotation);
   }
 

--- a/core/src/com/google/inject/internal/GenericErrorDetail.java
+++ b/core/src/com/google/inject/internal/GenericErrorDetail.java
@@ -22,7 +22,11 @@ public final class GenericErrorDetail extends InternalErrorDetail<GenericErrorDe
     Preconditions.checkArgument(mergeableErrors.isEmpty(), "Unexpected mergeable errors");
     List<Object> dependencies = getSources();
     for (Object source : Lists.reverse(dependencies)) {
-      Messages.formatSource(formatter, source);
+      if (InternalFlags.enableExperimentalErrorMessages()) {
+        new SourceFormatter(source, formatter).format();
+      } else {
+        Messages.formatSource(formatter, source);
+      }
     }
   }
 

--- a/core/src/com/google/inject/internal/InternalFlags.java
+++ b/core/src/com/google/inject/internal/InternalFlags.java
@@ -35,10 +35,10 @@ public class InternalFlags {
   private static final NullableProvidesOption NULLABLE_PROVIDES
       = parseNullableProvidesOption(NullableProvidesOption.ERROR);
 
+  private static final ColorizeOption COLORIZE_OPTION = parseColorizeOption();
 
-  /**
-   * The options for Guice stack trace collection.
-   */
+
+  /** The options for Guice stack trace collection. */
   public enum IncludeStackTraceOption {
     /** No stack trace collection */
     OFF,
@@ -94,6 +94,30 @@ public class InternalFlags {
     ENABLED,
   }
 
+  /** Options for enable or disable using ansi color in error messages. */
+  public enum ColorizeOption {
+    AUTO {
+      @Override
+      boolean enabled() {
+        return System.console() != null && System.getenv("TERM") != null;
+      }
+    },
+    ON {
+      @Override
+      boolean enabled() {
+        return true;
+      }
+    },
+    OFF {
+      @Override
+      boolean enabled() {
+        return false;
+      }
+    };
+
+    abstract boolean enabled();
+  }
+
   public static IncludeStackTraceOption getIncludeStackTraceOption() {
     return INCLUDE_STACK_TRACES;
   }
@@ -111,6 +135,10 @@ public class InternalFlags {
     return false;
   }
 
+  public static boolean enableColorizeErrorMessages() {
+    return COLORIZE_OPTION.enabled();
+  }
+
   private static IncludeStackTraceOption parseIncludeStackTraceOption() {
     return getSystemOption("guice_include_stack_traces",
         IncludeStackTraceOption.ONLY_FOR_DECLARING_SOURCE);
@@ -124,6 +152,10 @@ public class InternalFlags {
   private static NullableProvidesOption parseNullableProvidesOption(
       NullableProvidesOption defaultValue) {
     return getSystemOption("guice_check_nullable_provides_params", defaultValue);
+  }
+
+  private static ColorizeOption parseColorizeOption() {
+    return getSystemOption("guice_colorize_error_messages", ColorizeOption.OFF);
   }
 
   /**

--- a/core/src/com/google/inject/internal/Messages.java
+++ b/core/src/com/google/inject/internal/Messages.java
@@ -16,6 +16,7 @@
 package com.google.inject.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.stream.Collectors.joining;
 
 import com.google.common.base.Equivalence;
 import com.google.common.base.Objects;
@@ -414,5 +415,47 @@ public final class Messages {
     protected int doHash(Throwable t) {
       return Objects.hashCode(t.getClass().hashCode(), t.getMessage(), hash(t.getCause()));
     }
+  }
+
+  private enum FormatOptions {
+    RED("\u001B[31m"),
+    BOLD("\u001B[1m"),
+    FAINT("\u001B[2m"),
+    ITALIC("\u001B[3m"),
+    UNDERLINE("\u001B[4m"),
+    RESET("\u001B[0m");
+
+    private final String ansiCode;
+
+    FormatOptions(String ansiCode) {
+      this.ansiCode = ansiCode;
+    }
+  }
+
+  private static final String formatText(String text, FormatOptions... options) {
+    if (!InternalFlags.enableColorizeErrorMessages()) {
+      return text;
+    }
+    return String.format(
+        "%s%s%s",
+        Arrays.stream(options).map(option -> option.ansiCode).collect(joining()),
+        text,
+        FormatOptions.RESET.ansiCode);
+  }
+
+  public static final String bold(String text) {
+    return formatText(text, FormatOptions.BOLD);
+  }
+
+  public static final String redBold(String text) {
+    return formatText(text, FormatOptions.RED, FormatOptions.BOLD);
+  }
+
+  public static final String underline(String text) {
+    return formatText(text, FormatOptions.UNDERLINE);
+  }
+
+  public static final String faint(String text) {
+    return formatText(text, FormatOptions.FAINT);
   }
 }

--- a/core/src/com/google/inject/internal/MissingConstructorError.java
+++ b/core/src/com/google/inject/internal/MissingConstructorError.java
@@ -67,7 +67,7 @@ final class MissingConstructorError extends InternalErrorDetail<MissingConstruct
     sourcesList.add(getSources());
     mergeableErrors.forEach(error -> sourcesList.add(error.getSources()));
 
-    formatter.format("%s%n", "Requested by:");
+    formatter.format("%s%n", Messages.bold("Requested by:"));
     int sourceListIndex = 1;
     for (List<Object> sources : sourcesList) {
       ErrorFormatter.formatSources(sourceListIndex++, Lists.reverse(sources), formatter);

--- a/core/src/com/google/inject/internal/MissingImplementationError.java
+++ b/core/src/com/google/inject/internal/MissingImplementationError.java
@@ -41,7 +41,7 @@ final class MissingImplementationError extends InternalErrorDetail<MissingImplem
             .collect(Collectors.toList());
 
     if (!filteredSourcesList.isEmpty()) {
-      formatter.format("%s%n", "Requested by:");
+      formatter.format("%s%n", Messages.bold("Requested by:"));
       int sourceListIndex = 1;
       for (List<Object> sources : filteredSourcesList) {
         ErrorFormatter.formatSources(sourceListIndex++, Lists.reverse(sources), formatter);

--- a/core/src/com/google/inject/internal/PackageNameCompressor.java
+++ b/core/src/com/google/inject/internal/PackageNameCompressor.java
@@ -117,8 +117,12 @@ final class PackageNameCompressor {
           .append("\n");
     }
 
-    return legendBuilder.length() == 0 ? replacedString
-        : replacedString + LEGEND_HEADER + legendBuilder + LEGEND_FOOTER;
+    return legendBuilder.length() == 0
+        ? replacedString
+        : replacedString
+            + Messages.bold(LEGEND_HEADER)
+            + Messages.faint(legendBuilder.toString())
+            + Messages.bold(LEGEND_FOOTER);
   }
 
   /**

--- a/core/src/com/google/inject/internal/ScopeNotFoundError.java
+++ b/core/src/com/google/inject/internal/ScopeNotFoundError.java
@@ -1,0 +1,47 @@
+package com.google.inject.internal;
+
+import com.google.common.collect.Lists;
+import com.google.inject.spi.ErrorDetail;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.List;
+
+/** Error reported by Guice when a scope annotation is not bound to any scope implementation. */
+final class ScopeNotFoundError extends InternalErrorDetail<ScopeNotFoundError> {
+
+  private final Class<? extends Annotation> scopeAnnotation;
+
+  ScopeNotFoundError(Class<? extends Annotation> scopeAnnotation, List<Object> sources) {
+    super(
+        ErrorId.SCOPE_NOT_FOUND,
+        String.format("No scope is bound to %s.", Messages.convert(scopeAnnotation)),
+        sources,
+        null);
+    this.scopeAnnotation = scopeAnnotation;
+  }
+
+  @Override
+  public boolean isMergeable(ErrorDetail<?> other) {
+    return other instanceof ScopeNotFoundError
+        && ((ScopeNotFoundError) other).scopeAnnotation.equals(scopeAnnotation);
+  }
+
+  @Override
+  protected void formatDetail(List<ErrorDetail<?>> mergeableErrors, Formatter formatter) {
+    List<List<Object>> sourcesSet = new ArrayList<>();
+    sourcesSet.add(getSources());
+    mergeableErrors.stream().map(ErrorDetail::getSources).forEach(sourcesSet::add);
+
+    formatter.format("%s%n", "Used at:");
+    int sourceListIndex = 1;
+    for (List<Object> sources : sourcesSet) {
+      ErrorFormatter.formatSources(sourceListIndex++, Lists.reverse(sources), formatter);
+    }
+  }
+
+  @Override
+  public ScopeNotFoundError withSources(List<Object> newSources) {
+    return new ScopeNotFoundError(scopeAnnotation, newSources);
+  }
+}

--- a/core/src/com/google/inject/internal/SourceFormatter.java
+++ b/core/src/com/google/inject/internal/SourceFormatter.java
@@ -38,6 +38,7 @@ final class SourceFormatter {
   }
 
   void format() {
+    // TODO(b/151482394): Omit the prepositions for first source in the list.
     boolean appendModuleSource = !moduleStack.isEmpty();
     if (source instanceof Dependency) {
       formatDependency((Dependency<?>) source);
@@ -85,13 +86,13 @@ final class SourceFormatter {
     Class<? extends Member> memberType = Classes.memberType(member);
     formatMember(injectionPoint.getMember());
     if (memberType == Field.class) {
-      formatter.format("%s \\_ for field %s%n", INDENT, member.getName());
+      formatter.format("%s \\_ for field %s%n", INDENT, Messages.redBold(member.getName()));
     } else if (dependency != null) {
       int ordinal = dependency.getParameterIndex() + 1;
       Optional<String> name = getParameterName(member, dependency.getParameterIndex());
       formatter.format(
           "%s \\_ for %s parameter %s%n",
-          INDENT, ordinal + Messages.getOrdinalSuffix(ordinal), name.orElse(""));
+          INDENT, ordinal + Messages.getOrdinalSuffix(ordinal), Messages.redBold(name.orElse("")));
     }
   }
 

--- a/core/src/com/google/inject/spi/ErrorDetail.java
+++ b/core/src/com/google/inject/spi/ErrorDetail.java
@@ -3,6 +3,7 @@ package com.google.inject.spi;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.internal.InternalFlags;
+import com.google.inject.internal.Messages;
 import java.io.Serializable;
 import java.util.Formatter;
 import java.util.List;
@@ -60,14 +61,14 @@ public abstract class ErrorDetail<SelfT extends ErrorDetail<SelfT>> implements S
    */
   public final void format(int index, List<ErrorDetail<?>> mergeableErrors, Formatter formatter) {
     if (InternalFlags.enableExperimentalErrorMessages()) {
-      formatter.format("%s) [%s]: %s%n%n", index, errorIdentifier, getMessage());
+      formatter.format("%s) [%s]: %s%n%n", index, Messages.redBold(errorIdentifier), getMessage());
       formatDetail(mergeableErrors, formatter);
       formatter.format("%n");
       // TODO(b/151482394): Output potiential fixes for the error
       Optional<String> learnMoreLink = getLearnMoreLink();
       if (learnMoreLink.isPresent()) {
-        formatter.format("Learn more:%n");
-        formatter.format("  %s%n", learnMoreLink.get());
+        formatter.format("%s%n", Messages.bold("Learn more:"));
+        formatter.format("  %s%n", Messages.underline(learnMoreLink.get()));
       }
     } else {
       // TODO(b/151482394): Remove this once the new error messages are enabled.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Implement ScopeNotFoundError.

10af17ef92244f8698b85879fd17523e6db33a1b

-------

<p> Apply formatting to the error message.

- add an option to enable or disable the formatting in error messages
- minor update on BindingAlreadySet error to be more concise

Note that the tests in errors directory currently are not exported since there is no way to turn on the new error message in opensource version. Those tests will be included once the new error messages are enabled.

1c9d384bb8ffa23a86a11214cd2939c95fc0b10f