### PR TITLE
Update ASM to version 9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>9.0</version>
+        <version>9.1</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
ASM 9.1 was released yesterday with a couple of bugfixes and also already unlocks Java 17:
https://asm.ow2.io/versions.html