### PR TITLE
Allow access to InterceptorBindings from SPI

### DIFF
--- a/core/src/com/google/inject/internal/ConstructorInjectorStore.java
+++ b/core/src/com/google/inject/internal/ConstructorInjectorStore.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.spi.InjectionPoint;
+import com.google.inject.spi.InterceptorBinding;
 import java.util.stream.Stream;
 
 /**
@@ -75,12 +76,11 @@ final class ConstructorInjectorStore {
             injector.membersInjectorStore.get(injectionPoint.getDeclaringType(), errors);
     ConstructionProxyFactory<T> factory = null;
     if (InternalFlags.isBytecodeGenEnabled()) {
-      ImmutableList<MethodAspect> injectorAspects = injector.getBindingData().getMethodAspects();
+      ImmutableList<InterceptorBinding> injectorBindings = injector.getBindingData().getInterceptorBindings();
       ImmutableList<MethodAspect> methodAspects =
-          membersInjector.getAddedAspects().isEmpty()
-              ? injectorAspects
-              : Stream.concat(injectorAspects.stream(), membersInjector.getAddedAspects().stream())
-                  .collect(toImmutableList());
+          Stream.concat(injectorBindings.stream().map(MethodAspect::fromBinding),
+            membersInjector.getAddedAspects().stream())
+              .collect(toImmutableList());
       factory = new ProxyFactory<>(injectionPoint, methodAspects);
     } else {
       factory = new DefaultConstructionProxyFactory<>(injectionPoint);

--- a/core/src/com/google/inject/internal/InjectorBindingData.java
+++ b/core/src/com/google/inject/internal/InjectorBindingData.java
@@ -28,6 +28,7 @@ import com.google.inject.Key;
 import com.google.inject.Scope;
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.InjectionRequest;
+import com.google.inject.spi.InterceptorBinding;
 import com.google.inject.spi.MembersInjectorLookup;
 import com.google.inject.spi.ModuleAnnotatedMethodScannerBinding;
 import com.google.inject.spi.ProviderLookup;
@@ -65,7 +66,7 @@ class InjectorBindingData {
   private final Set<MembersInjectorLookup<?>> membersInjectorLookups = Sets.newLinkedHashSet();
   private final Set<InjectionRequest<?>> injectionRequests = Sets.newLinkedHashSet();
   private final List<TypeConverterBinding> converters = Lists.newArrayList();
-  private final List<MethodAspect> methodAspects = Lists.newArrayList();
+  private final List<InterceptorBinding> interceptorBindings = Lists.newArrayList();
   private final List<TypeListenerBinding> typeListenerBindings = Lists.newArrayList();
   private final List<ProvisionListenerBinding> provisionListenerBindings = Lists.newArrayList();
   private final List<ModuleAnnotatedMethodScannerBinding> scannerBindings = Lists.newArrayList();
@@ -172,18 +173,22 @@ class InjectorBindingData {
     return matchingConverter;
   }
 
-  public void addMethodAspect(MethodAspect methodAspect) {
-    methodAspects.add(methodAspect);
+  public void addInterceptorBinding(InterceptorBinding interceptorBinding) {
+    interceptorBindings.add(interceptorBinding);
   }
 
-  public ImmutableList<MethodAspect> getMethodAspects() {
+  public ImmutableList<InterceptorBinding> getInterceptorBindings() {
     if (parent.isPresent()) {
-      return new ImmutableList.Builder<MethodAspect>()
-          .addAll(parent.get().getMethodAspects())
-          .addAll(methodAspects)
+      return new ImmutableList.Builder<InterceptorBinding>()
+          .addAll(parent.get().getInterceptorBindings())
+          .addAll(interceptorBindings)
           .build();
     }
-    return ImmutableList.copyOf(methodAspects);
+    return ImmutableList.copyOf(interceptorBindings);
+  }
+
+  public ImmutableList<InterceptorBinding> getInterceptorBindingsThisLevel() {
+    return ImmutableList.copyOf(interceptorBindings);
   }
 
   public void addTypeListener(TypeListenerBinding listenerBinding) {

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -987,6 +987,7 @@ final class InjectorImpl implements Injector, Lookups {
     elements.addAll(bindingData.getStaticInjectionRequestsThisLevel());
     elements.addAll(bindingData.getMembersInjectorLookupsThisLevel());
     elements.addAll(bindingData.getInjectionRequestsThisLevel());
+    elements.addAll(bindingData.getInterceptorBindingsThisLevel());
 
     return elements.build();
   }

--- a/core/src/com/google/inject/internal/InterceptorBindingProcessor.java
+++ b/core/src/com/google/inject/internal/InterceptorBindingProcessor.java
@@ -35,11 +35,7 @@ final class InterceptorBindingProcessor extends AbstractProcessor {
     if (InternalFlags.isBytecodeGenEnabled()) {
       injector
           .getBindingData()
-          .addMethodAspect(
-              new MethodAspect(
-                  command.getClassMatcher(),
-                  command.getMethodMatcher(),
-                  command.getInterceptors()));
+          .addInterceptorBinding(command);
     } else {
       errors.aopDisabled(command);
     }

--- a/core/src/com/google/inject/internal/MethodAspect.java
+++ b/core/src/com/google/inject/internal/MethodAspect.java
@@ -19,6 +19,7 @@ package com.google.inject.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.inject.matcher.Matcher;
+import com.google.inject.spi.InterceptorBinding;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -34,6 +35,10 @@ final class MethodAspect {
   private final Matcher<? super Class<?>> classMatcher;
   private final Matcher<? super Method> methodMatcher;
   private final List<MethodInterceptor> interceptors;
+
+  static MethodAspect fromBinding(InterceptorBinding binding) {
+    return new MethodAspect(binding.getClassMatcher(), binding.getMethodMatcher(), binding.getInterceptors());
+  }
 
   /**
    * @param classMatcher matches classes the interceptor should apply to. For example: {@code

--- a/core/test/com/google/inject/internal/WeakKeySetTest.java
+++ b/core/test/com/google/inject/internal/WeakKeySetTest.java
@@ -35,6 +35,7 @@ import com.google.inject.Key;
 import com.google.inject.Scope;
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.InjectionRequest;
+import com.google.inject.spi.InterceptorBinding;
 import com.google.inject.spi.MembersInjectorLookup;
 import com.google.inject.spi.ModuleAnnotatedMethodScannerBinding;
 import com.google.inject.spi.ProviderLookup;
@@ -551,12 +552,12 @@ public class WeakKeySetTest extends TestCase {
     }
 
     @Override
-    public void addMethodAspect(MethodAspect methodAspect) {
+    public void addInterceptorBinding(InterceptorBinding interceptorBinding) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public ImmutableList<MethodAspect> getMethodAspects() {
+    public ImmutableList<InterceptorBinding> getInterceptorBindings() {
       return ImmutableList.of();
     }
 


### PR DESCRIPTION
This PR allows calls to Injector SPI to get configured `InterceptorBinding` when asking for `getElements`. This will allow tools to extract aspects applied on created instances.

No major changes beside returning those interceptor bindings were made. Now, the `InterceptorBinding` list is kept within `InjectorBindingData` and transformed into `MethodAspect`s when creating constructor.

There are no API changes here. `Injector#getElements` does specify that some elements are not returned, but doesn't specify which. As I understand that means that it can return those interceptor bindings now, and this change isn't breaking the contract of this method. Tools that extract those elements should search for specific ones anyway.