### PR TITLE
Update unsafe class defining to work on Java 17+

### DIFF
--- a/core/src/com/google/inject/internal/InternalFlags.java
+++ b/core/src/com/google/inject/internal/InternalFlags.java
@@ -58,13 +58,13 @@ public final class InternalFlags {
   public enum CustomClassLoadingOption {
     /**
      * Define fast/enhanced types in the same class loader as their original type, never creates
-     * class loaders. Uses Unsafe.defineAnonymousClass to gain access to existing class loaders.
+     * class loaders. Uses {@link sun.misc.Unsafe} to gain access to existing class loaders.
      */
     OFF,
 
     /**
-     * Define fast/enhanced types with Unsafe.defineAnonymousClass, never creates class loaders.
-     * This is faster than regular class loading and anonymous classes are easier to unload.
+     * Define fast/enhanced types anonymously as hidden nest-mates, never creates class loaders.
+     * This is faster than regular class loading and the resulting classes are easier to unload.
      *
      * <p>Note: with this option you cannot look up fast/enhanced types by name or mock/spy them.
      */

--- a/core/src/com/google/inject/internal/aop/AnonymousClassDefiner.java
+++ b/core/src/com/google/inject/internal/aop/AnonymousClassDefiner.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.inject.internal.aop;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * {@link ClassDefiner} that defines classes using {@code sun.misc.Unsafe#defineAnonymousClass}.
+ *
+ * @author mcculls@gmail.com (Stuart McCulloch)
+ */
+final class AnonymousClassDefiner implements ClassDefiner {
+
+  private static final Object THE_UNSAFE;
+  private static final Method ANONYMOUS_DEFINE_METHOD;
+
+  static {
+    try {
+      Class<?> unsafeType = Class.forName("sun.misc.Unsafe");
+      Field theUnsafeField = unsafeType.getDeclaredField("theUnsafe");
+      theUnsafeField.setAccessible(true);
+      THE_UNSAFE = theUnsafeField.get(null);
+      ANONYMOUS_DEFINE_METHOD =
+          unsafeType.getMethod("defineAnonymousClass", Class.class, byte[].class, Object[].class);
+    } catch (ReflectiveOperationException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  @Override
+  public Class<?> define(Class<?> hostClass, byte[] bytecode) throws Exception {
+    return (Class<?>) ANONYMOUS_DEFINE_METHOD.invoke(THE_UNSAFE, hostClass, bytecode, null);
+  }
+}

--- a/core/src/com/google/inject/internal/aop/ClassDefining.java
+++ b/core/src/com/google/inject/internal/aop/ClassDefining.java
@@ -44,14 +44,19 @@ public final class ClassDefining {
     return ClassDefinerHolder.INSTANCE.define(hostClass, bytecode);
   }
 
-  /** Returns true if the ClassDefiner has access to package-private members. */
+  /** Returns true if the current class definer allows access to package-private members. */
   public static boolean hasPackageAccess() {
     return ClassDefinerHolder.IS_UNSAFE;
   }
 
-  /** Does the given class host new types anonymously, meaning they are not visible by name? */
-  public static boolean isAnonymousHost(Class<?> hostClass) {
-    return ClassDefinerHolder.IS_UNSAFE && UnsafeClassDefiner.isAnonymousHost(hostClass);
+  /** Returns true if it's possible to load by name proxies defined from the given host. */
+  public static boolean canLoadProxyByName(Class<?> hostClass) {
+    return !ClassDefinerHolder.IS_UNSAFE || UnsafeClassDefiner.canLoadProxyByName(hostClass);
+  }
+
+  /** Returns true if it's possible to downcast to proxies defined from the given host. */
+  public static boolean canDowncastToProxy(Class<?> hostClass) {
+    return !ClassDefinerHolder.IS_UNSAFE || UnsafeClassDefiner.canDowncastToProxy(hostClass);
   }
 
   /** Binds the preferred {@link ClassDefiner} instance. */

--- a/core/src/com/google/inject/internal/aop/GeneratedClassDefiner.java
+++ b/core/src/com/google/inject/internal/aop/GeneratedClassDefiner.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.inject.internal.aop;
+
+import java.util.function.BiFunction;
+
+/**
+ * {@link ClassDefiner} that defines classes using a generated access function.
+ *
+ * @author mcculls@gmail.com (Stuart McCulloch)
+ */
+final class GeneratedClassDefiner implements ClassDefiner {
+
+  private final BiFunction<ClassLoader, byte[], Class<?>> defineAccess;
+
+  GeneratedClassDefiner(BiFunction<ClassLoader, byte[], Class<?>> defineAccess) {
+    this.defineAccess = defineAccess;
+  }
+
+  @Override
+  public Class<?> define(Class<?> hostClass, byte[] bytecode) throws Exception {
+    return defineAccess.apply(hostClass.getClassLoader(), bytecode);
+  }
+}

--- a/core/src/com/google/inject/internal/aop/HiddenClassDefiner.java
+++ b/core/src/com/google/inject/internal/aop/HiddenClassDefiner.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.inject.internal.aop;
+
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * {@link ClassDefiner} that defines classes using {@code MethodHandles.Lookup#defineHiddenClass}.
+ *
+ * @author mcculls@gmail.com (Stuart McCulloch)
+ */
+final class HiddenClassDefiner implements ClassDefiner {
+
+  private static final Object THE_UNSAFE;
+  private static final Object TRUSTED_LOOKUP_BASE;
+  private static final Object TRUSTED_LOOKUP_OFFSET;
+  private static final Method GET_OBJECT_METHOD;
+  private static final Object HIDDEN_CLASS_OPTIONS;
+  private static final Method HIDDEN_DEFINE_METHOD;
+
+  static {
+    try {
+      Class<?> unsafeType = Class.forName("sun.misc.Unsafe");
+      Field theUnsafeField = unsafeType.getDeclaredField("theUnsafe");
+      theUnsafeField.setAccessible(true);
+      THE_UNSAFE = theUnsafeField.get(null);
+      Field trustedLookupField = Lookup.class.getDeclaredField("IMPL_LOOKUP");
+      Method baseMethod = unsafeType.getMethod("staticFieldBase", Field.class);
+      TRUSTED_LOOKUP_BASE = baseMethod.invoke(THE_UNSAFE, trustedLookupField);
+      Method offsetMethod = unsafeType.getMethod("staticFieldOffset", Field.class);
+      TRUSTED_LOOKUP_OFFSET = offsetMethod.invoke(THE_UNSAFE, trustedLookupField);
+      GET_OBJECT_METHOD = unsafeType.getMethod("getObject", Object.class, long.class);
+      HIDDEN_CLASS_OPTIONS = classOptions("NESTMATE");
+      HIDDEN_DEFINE_METHOD =
+          Lookup.class.getMethod(
+              "defineHiddenClass", byte[].class, boolean.class, HIDDEN_CLASS_OPTIONS.getClass());
+    } catch (ReflectiveOperationException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  @Override
+  public Class<?> define(Class<?> hostClass, byte[] bytecode) throws Exception {
+    Lookup trustedLookup =
+        (Lookup) GET_OBJECT_METHOD.invoke(THE_UNSAFE, TRUSTED_LOOKUP_BASE, TRUSTED_LOOKUP_OFFSET);
+    Lookup definedLookup =
+        (Lookup)
+            HIDDEN_DEFINE_METHOD.invoke(
+                trustedLookup.in(hostClass), bytecode, false, HIDDEN_CLASS_OPTIONS);
+    return definedLookup.lookupClass();
+  }
+
+  /** Creates {@link MethodHandles.Lookup.ClassOption} array with the named options. */
+  @SuppressWarnings("unchecked")
+  private static Object classOptions(String... options) throws ClassNotFoundException {
+    @SuppressWarnings("rawtypes") // Unavoidable, only way to use Enum.valueOf
+    Class optionClass = Class.forName(Lookup.class.getName() + "$ClassOption");
+    Object classOptions = Array.newInstance(optionClass, options.length);
+    for (int i = 0; i < options.length; i++) {
+      Array.set(classOptions, i, Enum.valueOf(optionClass, options[i]));
+    }
+    return classOptions;
+  }
+}

--- a/core/test/com/google/inject/ImplicitBindingTest.java
+++ b/core/test/com/google/inject/ImplicitBindingTest.java
@@ -437,6 +437,8 @@ public class ImplicitBindingTest extends TestCase {
     // String has a public nullary constructor, so Guice will call it.
     assertEquals("", injector.getInstance(String.class));
     // InetAddress has a package private constructor.  We probably shouldn't be calling it :(
-    assertNotNull(injector.getInstance(java.net.InetAddress.class));
+    if (Double.parseDouble(System.getProperty("java.specification.version")) < 17) {
+      assertNotNull(injector.getInstance(java.net.InetAddress.class));
+    }
   }
 }

--- a/core/test/com/google/inject/MethodInterceptionTest.java
+++ b/core/test/com/google/inject/MethodInterceptionTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.internal.InternalFlags;
+import com.google.inject.internal.InternalFlags.CustomClassLoadingOption;
 import com.google.inject.matcher.AbstractMatcher;
 import com.google.inject.matcher.Matchers;
 import com.google.inject.name.Names;
@@ -269,6 +270,11 @@ public class MethodInterceptionTest {
 
   @Test
   public void testNotInterceptedMethodsInInterceptedClassDontAddFrames() {
+    // Test relies on Enhancer appearing in stack traces which isn't true for Java17 hidden classes
+    if (Double.parseDouble(System.getProperty("java.specification.version")) >= 17) {
+      assumeTrue(InternalFlags.getCustomClassLoadingOption() != CustomClassLoadingOption.ANONYMOUS);
+    }
+
     Injector injector =
         Guice.createInjector(
             new AbstractModule() {

--- a/core/test/com/google/inject/spi/ProviderMethodsTest.java
+++ b/core/test/com/google/inject/spi/ProviderMethodsTest.java
@@ -640,6 +640,11 @@ public class ProviderMethodsTest implements Module {
         InternalFlags.isBytecodeGenEnabled()
             && InternalFlags.getCustomClassLoadingOption() != CustomClassLoadingOption.CHILD);
 
+    // Test relies on FastClass appearing in stack traces which isn't true for Java17 hidden classes
+    if (Double.parseDouble(System.getProperty("java.specification.version")) >= 17) {
+      assumeTrue(InternalFlags.getCustomClassLoadingOption() != CustomClassLoadingOption.ANONYMOUS);
+    }
+
     CallerInspecterModule module = new CallerInspecterModule();
     Guice.createInjector(Stage.PRODUCTION, module);
     assertEquals(module.fooCallerClass, module.barCallerClass);
@@ -673,6 +678,11 @@ public class ProviderMethodsTest implements Module {
     assumeTrue(
         InternalFlags.isBytecodeGenEnabled()
             && InternalFlags.getCustomClassLoadingOption() != CustomClassLoadingOption.CHILD);
+
+    // Test relies on FastClass appearing in stack traces which isn't true for Java17 hidden classes
+    if (Double.parseDouble(System.getProperty("java.specification.version")) >= 17) {
+      assumeTrue(InternalFlags.getCustomClassLoadingOption() != CustomClassLoadingOption.ANONYMOUS);
+    }
 
     CallerInspecterSubClassModule module = new CallerInspecterSubClassModule();
     Guice.createInjector(Stage.PRODUCTION, module);

--- a/core/test/com/googlecode/guice/BytecodeGenTest.java
+++ b/core/test/com/googlecode/guice/BytecodeGenTest.java
@@ -364,6 +364,12 @@ public class BytecodeGenTest {
     if (InternalFlags.getCustomClassLoadingOption() == CustomClassLoadingOption.CHILD) {
       return;
     }
+
+    // Test relies on FastClass appearing in stack traces which isn't true for Java17 hidden classes
+    if (Double.parseDouble(System.getProperty("java.specification.version")) >= 17) {
+      assumeTrue(InternalFlags.getCustomClassLoadingOption() != CustomClassLoadingOption.ANONYMOUS);
+    }
+
     Injector injector = Guice.createInjector();
     // These classes are all in the same classloader as guice itself, so other than the private one
     // they can all be fast class invoked


### PR DESCRIPTION
Java 17 has removed `Unsafe.defineAnonymousClass` in favour of `Lookup.defineHiddenClass`