### PR TITLE
Upgrade hibernate version to support JPA 3.0

### DIFF
--- a/extensions/persist/pom.xml
+++ b/extensions/persist/pom.xml
@@ -15,10 +15,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
-      <version>1.0.0.Final</version>
-      <scope>provided</scope>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core-jakarta</artifactId>
+      <version>5.5.7.Final</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -35,7 +34,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
-      <version>4.1.7.Final</version>
+      <version>5.5.6.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions/persist/src/com/google/inject/persist/jpa/JpaFinderProxy.java
+++ b/extensions/persist/src/com/google/inject/persist/jpa/JpaFinderProxy.java
@@ -31,8 +31,8 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import javax.persistence.EntityManager;
-import javax.persistence.Query;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 

--- a/extensions/persist/src/com/google/inject/persist/jpa/JpaLocalTxnInterceptor.java
+++ b/extensions/persist/src/com/google/inject/persist/jpa/JpaLocalTxnInterceptor.java
@@ -20,8 +20,8 @@ import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 import com.google.inject.persist.UnitOfWork;
 import java.lang.reflect.Method;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 

--- a/extensions/persist/src/com/google/inject/persist/jpa/JpaPersistModule.java
+++ b/extensions/persist/src/com/google/inject/persist/jpa/JpaPersistModule.java
@@ -32,8 +32,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.List;
 import java.util.Map;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 

--- a/extensions/persist/src/com/google/inject/persist/jpa/JpaPersistService.java
+++ b/extensions/persist/src/com/google/inject/persist/jpa/JpaPersistService.java
@@ -29,9 +29,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Map;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
 
 /** @author Dhanji R. Prasanna (dhanji@gmail.com) */
 @Singleton

--- a/extensions/persist/test/com/google/inject/persist/jpa/ClassLevelManagedLocalTransactionsTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/ClassLevelManagedLocalTransactionsTest.java
@@ -25,7 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.EntityManager;
+import jakarta.persistence.EntityManager;
 import junit.framework.TestCase;
 
 /**

--- a/extensions/persist/test/com/google/inject/persist/jpa/CustomPropsEntityManagerFactoryProvisionTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/CustomPropsEntityManagerFactoryProvisionTest.java
@@ -21,8 +21,8 @@ import com.google.inject.Injector;
 import com.google.inject.persist.PersistService;
 import com.google.inject.persist.UnitOfWork;
 import java.util.Properties;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import junit.framework.TestCase;
 
 /** @author Dhanji R. Prasanna (dhanji@gmail.com) */

--- a/extensions/persist/test/com/google/inject/persist/jpa/DynamicFinderTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/DynamicFinderTest.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import javax.persistence.EntityManager;
+import jakarta.persistence.EntityManager;
 import junit.framework.TestCase;
 
 /**

--- a/extensions/persist/test/com/google/inject/persist/jpa/EnsureJpaCanTakeObjectsInPropertiesTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/EnsureJpaCanTakeObjectsInPropertiesTest.java
@@ -23,14 +23,14 @@ import com.google.inject.persist.UnitOfWork;
 import junit.framework.TestCase;
 
 import org.hibernate.cfg.Environment;
-import org.hibernate.ejb.connection.InjectedDataSourceConnectionProvider;
+import org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl;
 import org.hsqldb.jdbc.JDBCDataSource;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.PersistenceException;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceException;
 import javax.sql.DataSource;
 
 public class EnsureJpaCanTakeObjectsInPropertiesTest extends TestCase {
@@ -51,7 +51,7 @@ public class EnsureJpaCanTakeObjectsInPropertiesTest extends TestCase {
     protected void configure() {
       Map<String, Object> p = new HashMap<>();
 
-      p.put(Environment.CONNECTION_PROVIDER, InjectedDataSourceConnectionProvider.class.getName());
+      p.put(Environment.CONNECTION_PROVIDER, DatasourceConnectionProviderImpl.class.getName());
       if (passDataSource) {
         p.put(Environment.DATASOURCE, ds);
       }

--- a/extensions/persist/test/com/google/inject/persist/jpa/EntityManagerFactoryProvisionTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/EntityManagerFactoryProvisionTest.java
@@ -20,8 +20,8 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.persist.PersistService;
 import com.google.inject.persist.UnitOfWork;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import junit.framework.TestCase;
 
 /** @author Dhanji R. Prasanna (dhanji@gmail.com) */

--- a/extensions/persist/test/com/google/inject/persist/jpa/EntityManagerPerRequestProvisionTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/EntityManagerPerRequestProvisionTest.java
@@ -22,8 +22,8 @@ import com.google.inject.Injector;
 import com.google.inject.persist.PersistService;
 import com.google.inject.persist.Transactional;
 import com.google.inject.persist.UnitOfWork;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import junit.framework.TestCase;
 
 /**

--- a/extensions/persist/test/com/google/inject/persist/jpa/EntityManagerProvisionTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/EntityManagerProvisionTest.java
@@ -22,8 +22,8 @@ import com.google.inject.Injector;
 import com.google.inject.Provider;
 import com.google.inject.persist.PersistService;
 import com.google.inject.persist.Transactional;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import junit.framework.TestCase;
 
 /**

--- a/extensions/persist/test/com/google/inject/persist/jpa/JoiningLocalTransactionsTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/JoiningLocalTransactionsTest.java
@@ -24,9 +24,9 @@ import com.google.inject.persist.Transactional;
 import com.google.inject.persist.UnitOfWork;
 import java.io.IOException;
 import java.util.Date;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.NoResultException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.NoResultException;
 import junit.framework.TestCase;
 
 /** @author Dhanji R. Prasanna (dhanji@gmail.com) */

--- a/extensions/persist/test/com/google/inject/persist/jpa/JpaParentTestEntity.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/JpaParentTestEntity.java
@@ -18,10 +18,10 @@ package com.google.inject.persist.jpa;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 
 /**
  * Created with IntelliJ IDEA. On: 2/06/2007

--- a/extensions/persist/test/com/google/inject/persist/jpa/JpaPersistServiceTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/JpaPersistServiceTest.java
@@ -23,9 +23,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Properties;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.spi.PersistenceProvider;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.spi.PersistenceProvider;
 import junit.framework.TestCase;
 
 public class JpaPersistServiceTest extends TestCase {

--- a/extensions/persist/test/com/google/inject/persist/jpa/JpaTestEntity.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/JpaTestEntity.java
@@ -16,9 +16,9 @@
 
 package com.google.inject.persist.jpa;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 
 /** @author Dhanji R. Prasanna (dhanji@gmail.com) */
 @Entity

--- a/extensions/persist/test/com/google/inject/persist/jpa/JpaWorkManagerTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/JpaWorkManagerTest.java
@@ -23,9 +23,9 @@ import com.google.inject.persist.PersistService;
 import com.google.inject.persist.Transactional;
 import com.google.inject.persist.UnitOfWork;
 import java.util.Date;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Query;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Query;
 import junit.framework.TestCase;
 import org.hibernate.HibernateException;
 

--- a/extensions/persist/test/com/google/inject/persist/jpa/ManagedLocalTransactionsAcrossRequestTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/ManagedLocalTransactionsAcrossRequestTest.java
@@ -26,9 +26,9 @@ import com.google.inject.persist.UnitOfWork;
 import com.google.inject.persist.finder.Finder;
 import java.io.IOException;
 import java.util.Date;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.NoResultException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.NoResultException;
 import junit.framework.TestCase;
 
 /** @author Dhanji R. Prasanna (dhanji@gmail.com) */

--- a/extensions/persist/test/com/google/inject/persist/jpa/ManagedLocalTransactionsTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/ManagedLocalTransactionsTest.java
@@ -24,9 +24,9 @@ import com.google.inject.persist.Transactional;
 import com.google.inject.persist.UnitOfWork;
 import java.io.IOException;
 import java.util.Date;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.NoResultException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.NoResultException;
 import junit.framework.TestCase;
 
 /** @author Dhanji R. Prasanna (dhanji@gmail.com) */

--- a/extensions/persist/test/com/google/inject/persist/jpa/ManualLocalTransactionsConfidenceTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/ManualLocalTransactionsConfidenceTest.java
@@ -22,8 +22,8 @@ import com.google.inject.Injector;
 import com.google.inject.persist.PersistService;
 import com.google.inject.persist.Transactional;
 import java.util.Date;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
 import junit.framework.TestCase;
 
 /** @author Dhanji R. Prasanna (dhanji@gmail.com) */

--- a/extensions/persist/test/com/google/inject/persist/jpa/ManualLocalTransactionsTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/ManualLocalTransactionsTest.java
@@ -23,8 +23,8 @@ import com.google.inject.persist.PersistService;
 import com.google.inject.persist.Transactional;
 import com.google.inject.persist.UnitOfWork;
 import java.util.Date;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import junit.framework.TestCase;
 
 /**

--- a/extensions/persist/test/com/google/inject/persist/jpa/ManualLocalTransactionsWithCustomMatcherTest.java
+++ b/extensions/persist/test/com/google/inject/persist/jpa/ManualLocalTransactionsWithCustomMatcherTest.java
@@ -23,8 +23,8 @@ import com.google.inject.persist.PersistService;
 import com.google.inject.persist.Transactional;
 import com.google.inject.persist.UnitOfWork;
 import java.util.Date;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import junit.framework.TestCase;
 
 /**


### PR DESCRIPTION
Sort of related to "jakarta" naming issues in https://github.com/google/guice/issues/1490 and https://github.com/google/guice/issues/1383. Upgrading the hibernate library - which uses the `jakarta.persistence` namespace - in the persistence extension seems to work fine on its own. 

This PR might not be accepted as it leaves a mix of `jakarta.persistence` and `javax.*` in the guice library but thought I'd give it a try. At least it was pretty low effort to do!