### PR TITLE
fix ci's settings. lack of java version in publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 11
           distribution: 'zulu'
           server-id: google-snapshots
           server-username: MAVEN_USERNAME


### PR DESCRIPTION
CI failed `publish` job, the reason is  lacking of Java version setting , maybe.
(a `matrix.*` value can be used every task. the value was set in `test` job, but don't set in `publish` job)

Add java version to `java-version param` in `publish` job. Java11 is stable version.