### PR TITLE
Fix old google doc Users guide link in javadoc

### DIFF
--- a/core/src/com/google/inject/package-info.java
+++ b/core/src/com/google/inject/package-info.java
@@ -16,7 +16,7 @@
 
 /**
  * <i>Google Guice</i> (pronounced "juice") is an ultra-lightweight dependency injection framework.
- * Please refer to the Guice <a href="http://docs.google.com/Doc?id=dd2fhx4z_5df5hw8">User's
+ * Please refer to the Guice <a href="https://github.com/google/guice/wiki/Motivation">User's
  * Guide</a> for a gentle introduction.
  *
  * <p>The principal public APIs in this package are:


### PR DESCRIPTION
The javadoc package info for the Inject package is currently pointing to [this](http://docs.google.com/Doc?id=dd2fhx4z_5df5hw8) link, which is a protected google doc. The linked reference to "User's guide" in the README.md points to the "Motivation" wiki [here](https://github.com/google/guice/wiki/Motivation).

This PR updates the javadoc for the Inject package to be consistent with this project's README link to the User's guide

Please let me know if I need to do anything else 👍 