### PR TITLE
Make PrivateModule#binder() non-final to allow binder customization in subclasses

### DIFF
--- a/core/src/com/google/inject/PrivateModule.java
+++ b/core/src/com/google/inject/PrivateModule.java
@@ -137,7 +137,7 @@ public abstract class PrivateModule implements Module {
   // everything below is copied from AbstractModule
 
   /** Returns the current binder. */
-  protected final PrivateBinder binder() {
+  protected PrivateBinder binder() {
     checkState(binder != null, "The binder can only be used inside configure()");
     return binder;
   }


### PR DESCRIPTION
One of the cases for overriding `#binder()` would be calling `Binder#skipSources(...)`

fixes #1525