### PR TITLE
issue #1655: prevent NullPointerException if contextPath is null

### DIFF
--- a/extensions/servlet/src/com/google/inject/servlet/ServletDefinition.java
+++ b/extensions/servlet/src/com/google/inject/servlet/ServletDefinition.java
@@ -212,7 +212,9 @@ class ServletDefinition implements ProviderWithExtensionVisitor<ServletDefinitio
               String servletPath = getServletPath();
               int servletPathLength = servletPath.length();
               String requestUri = getRequestURI();
-              pathInfo = requestUri.substring(getContextPath().length()).replaceAll("[/]{2,}", "/");
+              String contextPath = getContextPath();
+              int contextPathLength = contextPath != null ? contextPath.length() : 0;
+              pathInfo = requestUri.substring(contextPathLength).replaceAll("[/]{2,}", "/");
               // See: https://github.com/google/guice/issues/372
               if (pathInfo.startsWith(servletPath)) {
                 pathInfo = pathInfo.substring(servletPathLength);

--- a/extensions/servlet/test/com/google/inject/servlet/ServletDefinitionPathsTest.java
+++ b/extensions/servlet/test/com/google/inject/servlet/ServletDefinitionPathsTest.java
@@ -113,6 +113,7 @@ public class ServletDefinitionPathsTest extends TestCase {
   // Data-driven test.
   public final void testPathInfoWithServletStyleMatching() throws IOException, ServletException {
     pathInfoWithServletStyleMatching("/path/index.html", "/path", "/*", "/index.html", "");
+    pathInfoWithServletStyleMatching("/index.html", null, "/*", "/index.html", "");
     pathInfoWithServletStyleMatching(
         "/path//hulaboo///index.html", "/path", "/*", "/hulaboo/index.html", "");
     pathInfoWithServletStyleMatching("/path/", "/path", "/*", "/", "");


### PR DESCRIPTION
This prevents a NPE as described in issue https://github.com/google/guice/issues/1655