### PR TITLE
Upgrade ASM from 9.1 to 9.5 to support Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>9.2</version>
+        <version>9.5</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
24 March 2023: ASM 9.5 (tag ASM_9_5)

- new Opcodes.V21 constant for Java 21
- new readBytecodeInstructionOffset hook in ClassReader
- more detailed exception messages
- bug fixes:
  - 317989: Silent removal of zero-valued entries from the line-number table

Tested with Eclipse Sisu Inject project and Java 19, 20 and 21-ea