### PR TITLE
Completely remove OSGi Import-Package 'javax.annotation'

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -149,7 +149,7 @@
         <configuration>
           <instructions>
             <Bundle-Name>${project.artifactId}</Bundle-Name>
-            <Import-Package>!org.objectweb.asm.*,!com.google.inject.*,*</Import-Package>
+            <Import-Package>!org.objectweb.asm.*,!com.google.inject.*,!javax.annotation,*</Import-Package>
             <Eclipse-ExtensibleAPI>true</Eclipse-ExtensibleAPI>
           </instructions>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -344,9 +344,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>5.1.2</version>
+          <version>5.1.8</version>
           <configuration>
-            <excludeDependencies>jsr305</excludeDependencies>
             <instructions>
               <module>com.google.inject</module>
               <_include>-${project.basedir}/build.properties</_include>
@@ -355,7 +354,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
               <Bundle-Name>${project.artifactId}</Bundle-Name>
               <Bundle-SymbolicName>$(module)</Bundle-SymbolicName>
               <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
-              <Import-Package>!com.google.inject.*,*</Import-Package>
+              <Import-Package>!com.google.inject.*,!javax.annotation,*</Import-Package>
               <_exportcontents>!*.internal.*,$(module).*;version=${guice.api.version}</_exportcontents>
               <_consumer-policy>$(version;==;$(@))</_consumer-policy>
               <_nouses>true</_nouses>


### PR DESCRIPTION
As suggested (and I assume also intended) in https://github.com/google/guice/pull/1173 this PR changes the configuration of the maven-bundle-plugin to completely remove the import of the package `javax.annotation`, which seems not to be required at runtime.

With PR https://github.com/google/guice/pull/1173 respectively https://github.com/google/guice/pull/1697 the OSGi package import of `javax.annotation;version="[3.0,4)"` was only changed to `javax.annotation`, i.e. the version range was removed.

@mcculls do you want to have a look at this?

Additionally update to latest maven-bundle-plugin 5.1.8.

