### PR TITLE
Make error_prone_annotations dependency optional

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,6 +29,7 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
+      <optional>true</optional>
     </dependency>
     <!--
      | ASM is embedded by default by the JarJar build profile


### PR DESCRIPTION
At the moment the error_prone_annotations are a mandatory requirement. But annotations with retention policy 'runtime' are ignored if they cannot be loaded at runtime (at least according to [Stack-Overvflow](https://stackoverflow.com/questions/3567413/why-doesnt-a-missing-annotation-cause-a-classnotfoundexception-at-runtime)). This PR aims to make the dependency optional to not enforce the presence of error_prone_annotations in a java runtime if those annotations are not used at all.

This is especially useful for OSGi-runtimes where you cannot exclude error_prone_annotations because the corresponding package is specified as mandatory requirement in the MANIFEST.MF. Marking the Maven dependency as optional will also result in the error-prone package requirement being marked as optional.

At the moment error_prone_annotations does not come with a OSGi compliant Manifest, which makes it harder to include it in OSGi applications like Eclipse.
I already created a PR at error-prone to include the required OSGi headers (see https://github.com/google/error-prone/pull/3903), but not requiring the annotations at all would make it even simpler to use guice within OSGi.

Alternatively the dependency could only be marked as optional in the OSGi metadata.