### PR TITLE
Replace Guava's Objects class with java.util.Objects

### DIFF
--- a/core/src/com/google/inject/internal/ConstructorBindingImpl.java
+++ b/core/src/com/google/inject/internal/ConstructorBindingImpl.java
@@ -22,7 +22,6 @@ import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
 import static com.google.inject.spi.Elements.withTrustedSource;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.ConfigurationException;
@@ -39,6 +38,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.aopalliance.intercept.MethodInterceptor;
 
@@ -260,7 +260,7 @@ final class ConstructorBindingImpl<T> extends BindingImpl<T>
       ConstructorBindingImpl<?> o = (ConstructorBindingImpl<?>) obj;
       return getKey().equals(o.getKey())
           && getScoping().equals(o.getScoping())
-          && Objects.equal(constructorInjectionPoint, o.constructorInjectionPoint);
+          && Objects.equals(constructorInjectionPoint, o.constructorInjectionPoint);
     } else {
       return false;
     }
@@ -268,7 +268,7 @@ final class ConstructorBindingImpl<T> extends BindingImpl<T>
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getKey(), getScoping(), constructorInjectionPoint);
+    return Objects.hash(getKey(), getScoping(), constructorInjectionPoint);
   }
 
   private static class Factory<T> implements InternalFactory<T> {

--- a/core/src/com/google/inject/internal/Indexer.java
+++ b/core/src/com/google/inject/internal/Indexer.java
@@ -16,7 +16,6 @@
 
 package com.google.inject.internal;
 
-import com.google.common.base.Objects;
 import com.google.inject.Binding;
 import com.google.inject.Injector;
 import com.google.inject.Scope;
@@ -34,6 +33,7 @@ import com.google.inject.spi.ProviderInstanceBinding;
 import com.google.inject.spi.ProviderKeyBinding;
 import com.google.inject.spi.UntargettedBinding;
 import java.lang.annotation.Annotation;
+import java.util.Objects;
 
 /**
  * Visits bindings to return a {@code IndexedBinding} that can be used to emulate the binding
@@ -83,16 +83,16 @@ class Indexer extends DefaultBindingTargetVisitor<Object, Indexer.IndexedBinding
       }
       IndexedBinding o = (IndexedBinding) obj;
       return type == o.type
-          && Objects.equal(scope, o.scope)
+          && Objects.equals(scope, o.scope)
           && typeLiteral.equals(o.typeLiteral)
           && annotationType == o.annotationType
           && annotationName.equals(o.annotationName)
-          && Objects.equal(extraEquality, o.extraEquality);
+          && Objects.equals(extraEquality, o.extraEquality);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(
+      return Objects.hash(
           type, scope, typeLiteral, annotationType, annotationName, extraEquality);
     }
   }

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.inject.internal.Annotations.findScopeAnnotation;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -60,6 +59,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -430,7 +430,7 @@ final class InjectorImpl implements Injector, Lookups {
         SyntheticProviderBindingImpl<?> o = (SyntheticProviderBindingImpl<?>) obj;
         return getKey().equals(o.getKey())
             && getScoping().equals(o.getScoping())
-            && Objects.equal(providedBinding, o.providedBinding);
+            && Objects.equals(providedBinding, o.providedBinding);
       } else {
         return false;
       }
@@ -438,7 +438,7 @@ final class InjectorImpl implements Injector, Lookups {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(getKey(), getScoping(), providedBinding);
+      return Objects.hash(getKey(), getScoping(), providedBinding);
     }
   }
 
@@ -576,7 +576,7 @@ final class InjectorImpl implements Injector, Lookups {
         ConvertedConstantBindingImpl<?> o = (ConvertedConstantBindingImpl<?>) obj;
         return getKey().equals(o.getKey())
             && getScoping().equals(o.getScoping())
-            && Objects.equal(value, o.value);
+            && Objects.equals(value, o.value);
       } else {
         return false;
       }
@@ -584,7 +584,7 @@ final class InjectorImpl implements Injector, Lookups {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(getKey(), getScoping(), value);
+      return Objects.hash(getKey(), getScoping(), value);
     }
   }
 

--- a/core/src/com/google/inject/internal/InstanceBindingImpl.java
+++ b/core/src/com/google/inject/internal/InstanceBindingImpl.java
@@ -20,7 +20,6 @@ import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
 import static com.google.inject.spi.Elements.withTrustedSource;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.Key;
@@ -29,6 +28,7 @@ import com.google.inject.spi.Dependency;
 import com.google.inject.spi.HasDependencies;
 import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.InstanceBinding;
+import java.util.Objects;
 import java.util.Set;
 
 final class InstanceBindingImpl<T> extends BindingImpl<T> implements InstanceBinding<T> {
@@ -108,7 +108,7 @@ final class InstanceBindingImpl<T> extends BindingImpl<T> implements InstanceBin
       InstanceBindingImpl<?> o = (InstanceBindingImpl<?>) obj;
       return getKey().equals(o.getKey())
           && getScoping().equals(o.getScoping())
-          && Objects.equal(instance, o.instance);
+          && Objects.equals(instance, o.instance);
     } else {
       return false;
     }
@@ -116,6 +116,6 @@ final class InstanceBindingImpl<T> extends BindingImpl<T> implements InstanceBin
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getKey(), getScoping());
+    return Objects.hash(getKey(), getScoping());
   }
 }

--- a/core/src/com/google/inject/internal/LinkedBindingImpl.java
+++ b/core/src/com/google/inject/internal/LinkedBindingImpl.java
@@ -20,7 +20,6 @@ import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
 import static com.google.inject.spi.Elements.withTrustedSource;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.Key;
@@ -28,6 +27,7 @@ import com.google.inject.spi.BindingTargetVisitor;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.HasDependencies;
 import com.google.inject.spi.LinkedKeyBinding;
+import java.util.Objects;
 import java.util.Set;
 
 final class LinkedBindingImpl<T> extends BindingImpl<T>
@@ -101,7 +101,7 @@ final class LinkedBindingImpl<T> extends BindingImpl<T>
       LinkedBindingImpl<?> o = (LinkedBindingImpl<?>) obj;
       return getKey().equals(o.getKey())
           && getScoping().equals(o.getScoping())
-          && Objects.equal(targetKey, o.targetKey);
+          && Objects.equals(targetKey, o.targetKey);
     } else {
       return false;
     }
@@ -109,6 +109,6 @@ final class LinkedBindingImpl<T> extends BindingImpl<T>
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getKey(), getScoping(), targetKey);
+    return Objects.hash(getKey(), getScoping(), targetKey);
   }
 }

--- a/core/src/com/google/inject/internal/LinkedProviderBindingImpl.java
+++ b/core/src/com/google/inject/internal/LinkedProviderBindingImpl.java
@@ -20,7 +20,6 @@ import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
 import static com.google.inject.spi.Elements.withTrustedSource;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.Key;
@@ -28,7 +27,9 @@ import com.google.inject.spi.BindingTargetVisitor;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.HasDependencies;
 import com.google.inject.spi.ProviderKeyBinding;
+import java.util.Objects;
 import java.util.Set;
+
 
 final class LinkedProviderBindingImpl<T> extends BindingImpl<T>
     implements ProviderKeyBinding<T>, HasDependencies, DelayedInitialize {
@@ -138,7 +139,7 @@ final class LinkedProviderBindingImpl<T> extends BindingImpl<T>
       LinkedProviderBindingImpl<?> o = (LinkedProviderBindingImpl<?>) obj;
       return getKey().equals(o.getKey())
           && getScoping().equals(o.getScoping())
-          && Objects.equal(providerKey, o.providerKey);
+          && Objects.equals(providerKey, o.providerKey);
     } else {
       return false;
     }
@@ -146,6 +147,6 @@ final class LinkedProviderBindingImpl<T> extends BindingImpl<T>
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getKey(), getScoping(), providerKey);
+    return Objects.hash(getKey(), getScoping(), providerKey);
   }
 }

--- a/core/src/com/google/inject/internal/Messages.java
+++ b/core/src/com/google/inject/internal/Messages.java
@@ -18,7 +18,6 @@ package com.google.inject.internal;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.base.Equivalence;
-import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
@@ -33,6 +32,7 @@ import java.util.Collection;
 import java.util.Formatter;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /** Utility methods for {@link Message} objects */
@@ -49,7 +49,7 @@ public final class Messages {
     // merging errors.
     if (!sources.isEmpty()
         && !messageSources.isEmpty()
-        && Objects.equal(messageSources.get(0), sources.get(sources.size() - 1))) {
+        && Objects.equals(messageSources.get(0), sources.get(sources.size() - 1))) {
       messageSources = messageSources.subList(1, messageSources.size());
     }
     return message.withSource(
@@ -261,14 +261,14 @@ public final class Messages {
     @Override
     protected boolean doEquivalent(Throwable a, Throwable b) {
       return a.getClass().equals(b.getClass())
-          && Objects.equal(a.getMessage(), b.getMessage())
+          && Objects.equals(a.getMessage(), b.getMessage())
           && Arrays.equals(a.getStackTrace(), b.getStackTrace())
           && equivalent(a.getCause(), b.getCause());
     }
 
     @Override
     protected int doHash(Throwable t) {
-      return Objects.hashCode(t.getClass().hashCode(), t.getMessage(), hash(t.getCause()));
+      return Objects.hash(t.getClass().hashCode(), t.getMessage(), hash(t.getCause()));
     }
   }
 

--- a/core/src/com/google/inject/internal/MissingConstructorError.java
+++ b/core/src/com/google/inject/internal/MissingConstructorError.java
@@ -1,6 +1,5 @@
 package com.google.inject.internal;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.ErrorDetail;
@@ -9,6 +8,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
+import java.util.Objects;
 
 /** Error reported when Guice can't find an useable constructor to create objects. */
 final class MissingConstructorError extends InternalErrorDetail<MissingConstructorError> {
@@ -29,8 +29,8 @@ final class MissingConstructorError extends InternalErrorDetail<MissingConstruct
   public boolean isMergeable(ErrorDetail<?> other) {
     if (other instanceof MissingConstructorError) {
       MissingConstructorError otherMissing = (MissingConstructorError) other;
-      return Objects.equal(type, otherMissing.type)
-          && Objects.equal(atInjectRequired, otherMissing.atInjectRequired);
+      return Objects.equals(type, otherMissing.type)
+          && Objects.equals(atInjectRequired, otherMissing.atInjectRequired);
     }
     return false;
   }

--- a/core/src/com/google/inject/internal/MoreTypes.java
+++ b/core/src/com/google/inject/internal/MoreTypes.java
@@ -19,7 +19,6 @@ package com.google.inject.internal;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.ConfigurationException;
 import com.google.inject.Key;
@@ -35,6 +34,7 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 /**
  * Static methods for working with types that we aren't publishing in the public {@code Types} API.
@@ -224,7 +224,7 @@ public class MoreTypes {
 
       ParameterizedType pa = (ParameterizedType) a;
       ParameterizedType pb = (ParameterizedType) b;
-      return Objects.equal(pa.getOwnerType(), pb.getOwnerType())
+      return Objects.equals(pa.getOwnerType(), pb.getOwnerType())
           && pa.getRawType().equals(pb.getRawType())
           && Arrays.equals(getSharedTypeArguments(pa), getSharedTypeArguments(pb));
 

--- a/core/src/com/google/inject/internal/ProviderInstanceBindingImpl.java
+++ b/core/src/com/google/inject/internal/ProviderInstanceBindingImpl.java
@@ -20,7 +20,6 @@ import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
 import static com.google.inject.spi.Elements.withTrustedSource;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.Key;
@@ -32,6 +31,7 @@ import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.ProviderInstanceBinding;
 import com.google.inject.spi.ProviderWithExtensionVisitor;
 import com.google.inject.util.Providers;
+import java.util.Objects;
 import java.util.Set;
 
 class ProviderInstanceBindingImpl<T> extends BindingImpl<T> implements ProviderInstanceBinding<T> {
@@ -73,6 +73,7 @@ class ProviderInstanceBindingImpl<T> extends BindingImpl<T> implements ProviderI
     }
   }
 
+  @Override
   public Provider<? extends T> getProviderInstance() {
     return Providers.guicify(providerInstance);
   }
@@ -131,7 +132,7 @@ class ProviderInstanceBindingImpl<T> extends BindingImpl<T> implements ProviderI
       ProviderInstanceBindingImpl<?> o = (ProviderInstanceBindingImpl<?>) obj;
       return getKey().equals(o.getKey())
           && getScoping().equals(o.getScoping())
-          && Objects.equal(providerInstance, o.providerInstance);
+          && Objects.equals(providerInstance, o.providerInstance);
     } else {
       return false;
     }
@@ -139,6 +140,6 @@ class ProviderInstanceBindingImpl<T> extends BindingImpl<T> implements ProviderI
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getKey(), getScoping());
+    return Objects.hash(getKey(), getScoping());
   }
 }

--- a/core/src/com/google/inject/internal/ProviderMethod.java
+++ b/core/src/com/google/inject/internal/ProviderMethod.java
@@ -16,7 +16,6 @@
 
 package com.google.inject.internal;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.Exposed;
@@ -36,6 +35,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -218,7 +218,7 @@ public abstract class ProviderMethod<T> extends InternalProviderInstanceBindingI
     if (obj instanceof ProviderMethod) {
       ProviderMethod<?> o = (ProviderMethod<?>) obj;
       return method.equals(o.method)
-          && Objects.equal(instance, o.instance)
+          && Objects.equals(instance, o.instance)
           && annotation.equals(o.annotation);
     } else {
       return false;
@@ -230,7 +230,7 @@ public abstract class ProviderMethod<T> extends InternalProviderInstanceBindingI
     // Avoid calling hashCode on 'instance', which is a user-object
     // that might not be expecting it.
     // (We need to call equals, so we do.  But we can avoid hashCode.)
-    return Objects.hashCode(method, annotation);
+    return Objects.hash(method, annotation);
   }
 
 

--- a/core/src/com/google/inject/internal/ProviderMethodsModule.java
+++ b/core/src/com/google/inject/internal/ProviderMethodsModule.java
@@ -19,7 +19,6 @@ package com.google.inject.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -40,6 +39,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Creates bindings to methods annotated with {@literal @}{@link Provides}. Use the scope and
@@ -346,7 +346,7 @@ public final class ProviderMethodsModule implements Module {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(delegate, scanner);
+    return Objects.hash(delegate, scanner);
   }
 
   /** Is it scanning the built-in @Provides* methods. */

--- a/core/src/com/google/inject/internal/RealMapBinder.java
+++ b/core/src/com/google/inject/internal/RealMapBinder.java
@@ -7,7 +7,6 @@ import static com.google.inject.internal.RealMultibinder.setOf;
 import static com.google.inject.util.Types.newParameterizedType;
 import static com.google.inject.util.Types.newParameterizedTypeWithOwner;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -43,6 +42,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -1254,7 +1254,7 @@ public final class RealMapBinder<K, V> implements Module {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(key, valueKey);
+      return Objects.hash(key, valueKey);
     }
 
     @Override

--- a/core/src/com/google/inject/internal/Scoping.java
+++ b/core/src/com/google/inject/internal/Scoping.java
@@ -16,7 +16,6 @@
 
 package com.google.inject.internal;
 
-import com.google.common.base.Objects;
 import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.Scope;
@@ -27,6 +26,7 @@ import com.google.inject.binder.ScopedBindingBuilder;
 import com.google.inject.spi.BindingScopingVisitor;
 import com.google.inject.spi.ScopeBinding;
 import java.lang.annotation.Annotation;
+import java.util.Objects;
 
 /**
  * References a scope, either directly (as a scope instance), or indirectly (as a scope annotation).
@@ -261,8 +261,8 @@ public abstract class Scoping {
   public boolean equals(Object obj) {
     if (obj instanceof Scoping) {
       Scoping o = (Scoping) obj;
-      return Objects.equal(getScopeAnnotation(), o.getScopeAnnotation())
-          && Objects.equal(getScopeInstance(), o.getScopeInstance());
+      return Objects.equals(getScopeAnnotation(), o.getScopeAnnotation())
+          && Objects.equals(getScopeInstance(), o.getScopeInstance());
     } else {
       return false;
     }
@@ -270,7 +270,7 @@ public abstract class Scoping {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getScopeAnnotation(), getScopeInstance());
+    return Objects.hash(getScopeAnnotation(), getScopeInstance());
   }
 
   public abstract <V> V acceptVisitor(BindingScopingVisitor<V> visitor);

--- a/core/src/com/google/inject/internal/UntargettedBindingImpl.java
+++ b/core/src/com/google/inject/internal/UntargettedBindingImpl.java
@@ -20,12 +20,12 @@ import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
 import static com.google.inject.spi.Elements.withTrustedSource;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.spi.BindingTargetVisitor;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.UntargettedBinding;
+import java.util.Objects;
 
 final class UntargettedBindingImpl<T> extends BindingImpl<T> implements UntargettedBinding<T> {
 
@@ -87,6 +87,6 @@ final class UntargettedBindingImpl<T> extends BindingImpl<T> implements Untarget
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getKey(), getScoping());
+    return Objects.hash(getKey(), getScoping());
   }
 }

--- a/core/src/com/google/inject/internal/WeakKeySet.java
+++ b/core/src/com/google/inject/internal/WeakKeySet.java
@@ -16,7 +16,6 @@
 
 package com.google.inject.internal;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -29,6 +28,7 @@ import com.google.common.collect.Sets;
 import com.google.inject.Key;
 import com.google.inject.internal.util.SourceProvider;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -120,7 +120,7 @@ final class WeakKeySet {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(key, source);
+      return Objects.hash(key, source);
     }
 
     @Override
@@ -134,7 +134,7 @@ final class WeakKeySet {
       }
 
       KeyAndSource other = (KeyAndSource) obj;
-      return Objects.equal(key, other.key) && Objects.equal(source, other.source);
+      return Objects.equals(key, other.key) && Objects.equals(source, other.source);
     }
   }
 }

--- a/core/src/com/google/inject/spi/Dependency.java
+++ b/core/src/com/google/inject/spi/Dependency.java
@@ -18,12 +18,12 @@ package com.google.inject.spi;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.inject.Key;
 import com.google.inject.internal.MoreTypes;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -95,14 +95,14 @@ public final class Dependency<T> {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(injectionPoint, parameterIndex, key);
+    return Objects.hash(injectionPoint, parameterIndex, key);
   }
 
   @Override
   public boolean equals(Object o) {
     if (o instanceof Dependency) {
       Dependency<?> dependency = (Dependency<?>) o;
-      return Objects.equal(injectionPoint, dependency.injectionPoint)
+      return Objects.equals(injectionPoint, dependency.injectionPoint)
           && parameterIndex == dependency.parameterIndex
           && key.equals(dependency.key);
     } else {

--- a/core/src/com/google/inject/spi/ErrorDetail.java
+++ b/core/src/com/google/inject/spi/ErrorDetail.java
@@ -1,11 +1,11 @@
 package com.google.inject.spi;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.internal.Messages;
 import java.io.Serializable;
 import java.util.Formatter;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -111,7 +111,7 @@ public abstract class ErrorDetail<SelfT extends ErrorDetail<SelfT>> implements S
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(message, cause, sources);
+    return Objects.hash(message, cause, sources);
   }
 
   @Override
@@ -120,7 +120,7 @@ public abstract class ErrorDetail<SelfT extends ErrorDetail<SelfT>> implements S
       return false;
     }
     ErrorDetail<?> e = (ErrorDetail<?>) o;
-    return message.equals(e.message) && Objects.equal(cause, e.cause) && sources.equals(e.sources);
+    return message.equals(e.message) && Objects.equals(cause, e.cause) && sources.equals(e.sources);
   }
 
   /** Returns a new instance of the same {@link ErrorDetail} with updated sources. */

--- a/core/src/com/google/inject/spi/InjectionRequest.java
+++ b/core/src/com/google/inject/spi/InjectionRequest.java
@@ -18,10 +18,10 @@ package com.google.inject.spi;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Objects;
 import com.google.inject.Binder;
 import com.google.inject.ConfigurationException;
 import com.google.inject.TypeLiteral;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -93,13 +93,13 @@ public final class InjectionRequest<T> implements Element {
   @Override
   public boolean equals(Object obj) {
     return obj instanceof InjectionRequest
-        && Objects.equal(((InjectionRequest<?>) obj).instance, instance)
+        && Objects.equals(((InjectionRequest<?>) obj).instance, instance)
         && ((InjectionRequest<?>) obj).type.equals(type)
         && ((InjectionRequest<?>) obj).source.equals(source);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(type, source);
+    return Objects.hash(type, source);
   }
 }

--- a/core/src/com/google/inject/spi/MembersInjectorLookup.java
+++ b/core/src/com/google/inject/spi/MembersInjectorLookup.java
@@ -19,11 +19,11 @@ package com.google.inject.spi;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.common.base.Objects;
 import com.google.inject.Binder;
 import com.google.inject.ConfigurationException;
 import com.google.inject.MembersInjector;
 import com.google.inject.TypeLiteral;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -136,6 +136,6 @@ public final class MembersInjectorLookup<T> implements Element {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(type, source);
+    return Objects.hash(type, source);
   }
 }

--- a/core/src/com/google/inject/spi/ProviderLookup.java
+++ b/core/src/com/google/inject/spi/ProviderLookup.java
@@ -20,13 +20,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.internal.Errors;
 import com.google.inject.util.Types;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -146,6 +146,6 @@ public final class ProviderLookup<T> implements Element {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(dependency, source);
+    return Objects.hash(dependency, source);
   }
 }

--- a/core/src/com/google/inject/spi/StaticInjectionRequest.java
+++ b/core/src/com/google/inject/spi/StaticInjectionRequest.java
@@ -18,9 +18,9 @@ package com.google.inject.spi;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Objects;
 import com.google.inject.Binder;
 import com.google.inject.ConfigurationException;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -87,6 +87,6 @@ public final class StaticInjectionRequest implements Element {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(source, type);
+    return Objects.hash(source, type);
   }
 }

--- a/core/src/com/google/inject/util/Providers.java
+++ b/core/src/com/google/inject/util/Providers.java
@@ -19,7 +19,6 @@ package com.google.inject.util;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.inject.Inject;
@@ -28,6 +27,7 @@ import com.google.inject.Provider;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.ProviderWithDependencies;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -73,7 +73,7 @@ public final class Providers {
     @Override
     public boolean equals(Object obj) {
       return (obj instanceof ConstantProvider)
-          && Objects.equal(instance, ((ConstantProvider<?>) obj).instance);
+          && Objects.equals(instance, ((ConstantProvider<?>) obj).instance);
     }
 
     @Override
@@ -143,7 +143,7 @@ public final class Providers {
     @Override
     public boolean equals(Object obj) {
       return (obj instanceof GuicifiedJakartaProvider)
-          && Objects.equal(delegate, ((GuicifiedJakartaProvider<?>) obj).delegate);
+          && Objects.equals(delegate, ((GuicifiedJakartaProvider<?>) obj).delegate);
     }
 
     @Override

--- a/core/test/com/google/inject/DuplicateBindingsTest.java
+++ b/core/test/com/google/inject/DuplicateBindingsTest.java
@@ -19,7 +19,6 @@ package com.google.inject;
 import static com.google.inject.Asserts.*;
 import static com.google.inject.name.Names.named;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.google.inject.internal.Annotations;
 import com.google.inject.name.Named;
@@ -32,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
 import junit.framework.TestCase;
 
@@ -632,7 +632,7 @@ public class DuplicateBindingsTest extends TestCase {
         if (equality == null && o.equality == null) {
           return this == o;
         } else {
-          return Objects.equal(equality, o.equality);
+          return Objects.equals(equality, o.equality);
         }
       } else {
         return false;

--- a/core/test/com/google/inject/internal/SpiUtils.java
+++ b/core/test/com/google/inject/internal/SpiUtils.java
@@ -45,7 +45,6 @@ import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -79,6 +78,7 @@ import com.google.inject.util.Types;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -1287,7 +1287,7 @@ public class SpiUtils {
         break;
       case PROVIDER_INSTANCE:
         if (item instanceof ProviderInstanceBinding
-            && Objects.equal(
+            && Objects.equals(
                 ((ProviderInstanceBinding) item).getUserSuppliedProvider().get(),
                 result.instance)) {
           return true;

--- a/core/test/com/google/inject/util/OverrideModuleTest.java
+++ b/core/test/com/google/inject/util/OverrideModuleTest.java
@@ -23,7 +23,6 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Binder;
@@ -49,6 +48,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.Date;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import junit.framework.TestCase;
@@ -755,7 +755,7 @@ public class OverrideModuleTest extends TestCase {
         if (equality == null && o.equality == null) {
           return this == o;
         } else {
-          return Objects.equal(equality, o.equality);
+          return Objects.equals(equality, o.equality);
         }
       } else {
         return false;

--- a/core/test/com/google/inject/util/ProvidersTest.java
+++ b/core/test/com/google/inject/util/ProvidersTest.java
@@ -16,7 +16,6 @@
 
 package com.google.inject.util;
 
-import com.google.common.base.Objects;
 import com.google.common.testing.EqualsTester;
 import com.google.inject.Provider;
 import jakarta.inject.Inject;
@@ -74,7 +73,7 @@ public class ProvidersTest extends TestCase {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(value);
+      return Integer.hashCode(value);
     }
 
     @Override

--- a/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider.java
+++ b/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider.java
@@ -18,7 +18,6 @@ package com.google.inject.assistedinject;
 
 import static com.google.inject.internal.Annotations.getKey;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -42,6 +41,7 @@ import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -406,7 +406,7 @@ public class FactoryProvider<F> implements Provider<F>, HasDependencies {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(factoryType, implementationType);
+    return Objects.hash(factoryType, implementationType);
   }
 
   @Override

--- a/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
+++ b/extensions/assistedinject/src/com/google/inject/assistedinject/FactoryProvider2.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -71,6 +70,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -928,7 +928,7 @@ final class FactoryProvider2<F>
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(factoryKey, collector);
+    return Objects.hash(factoryKey, collector);
   }
 
   @Override
@@ -937,7 +937,7 @@ final class FactoryProvider2<F>
       return false;
     }
     FactoryProvider2<?> other = (FactoryProvider2<?>) obj;
-    return factoryKey.equals(other.factoryKey) && Objects.equal(collector, other.collector);
+    return factoryKey.equals(other.factoryKey) && Objects.equals(collector, other.collector);
   }
 
   /** Returns true if {@code thrown} can be thrown by {@code invoked} without wrapping. */

--- a/extensions/grapher/src/com/google/inject/grapher/BindingEdge.java
+++ b/extensions/grapher/src/com/google/inject/grapher/BindingEdge.java
@@ -16,7 +16,7 @@
 
 package com.google.inject.grapher;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 /**
  * Edge that connects an interface to the type or instance that is bound to implement it.
@@ -52,7 +52,7 @@ public class BindingEdge extends Edge {
       return false;
     }
     BindingEdge other = (BindingEdge) obj;
-    return super.equals(other) && Objects.equal(type, other.type);
+    return super.equals(other) && Objects.equals(type, other.type);
   }
 
   @Override

--- a/extensions/grapher/src/com/google/inject/grapher/DependencyEdge.java
+++ b/extensions/grapher/src/com/google/inject/grapher/DependencyEdge.java
@@ -16,8 +16,8 @@
 
 package com.google.inject.grapher;
 
-import com.google.common.base.Objects;
 import com.google.inject.spi.InjectionPoint;
+import java.util.Objects;
 
 /**
  * Edge from a class or {@link InjectionPoint} to the interface node that will satisfy the
@@ -48,7 +48,7 @@ public class DependencyEdge extends Edge {
       return false;
     }
     DependencyEdge other = (DependencyEdge) obj;
-    return super.equals(other) && Objects.equal(injectionPoint, other.injectionPoint);
+    return super.equals(other) && Objects.equals(injectionPoint, other.injectionPoint);
   }
 
   @Override

--- a/extensions/grapher/src/com/google/inject/grapher/Edge.java
+++ b/extensions/grapher/src/com/google/inject/grapher/Edge.java
@@ -16,7 +16,7 @@
 
 package com.google.inject.grapher;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 /**
  * Edge in a guice dependency graph.
@@ -47,12 +47,12 @@ public abstract class Edge {
       return false;
     }
     Edge other = (Edge) obj;
-    return Objects.equal(fromId, other.fromId) && Objects.equal(toId, other.toId);
+    return Objects.equals(fromId, other.fromId) && Objects.equals(toId, other.toId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(fromId, toId);
+    return Objects.hash(fromId, toId);
   }
 
   /**

--- a/extensions/grapher/src/com/google/inject/grapher/ImplementationNode.java
+++ b/extensions/grapher/src/com/google/inject/grapher/ImplementationNode.java
@@ -16,9 +16,9 @@
 
 package com.google.inject.grapher;
 
-import com.google.common.base.Objects;
 import java.lang.reflect.Member;
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * Node for types that have {@link com.google.inject.spi.Dependency}s and are bound to {@link
@@ -47,7 +47,7 @@ public class ImplementationNode extends Node {
       return false;
     }
     ImplementationNode other = (ImplementationNode) obj;
-    return super.equals(other) && Objects.equal(members, other.members);
+    return super.equals(other) && Objects.equals(members, other.members);
   }
 
   @Override

--- a/extensions/grapher/src/com/google/inject/grapher/InstanceNode.java
+++ b/extensions/grapher/src/com/google/inject/grapher/InstanceNode.java
@@ -16,8 +16,8 @@
 
 package com.google.inject.grapher;
 
-import com.google.common.base.Objects;
 import java.lang.reflect.Member;
+import java.util.Objects;
 
 /**
  * Node for instances. Used when a type is bound to an instance.
@@ -50,13 +50,13 @@ public class InstanceNode extends Node {
     }
     InstanceNode other = (InstanceNode) obj;
     return super.equals(other)
-        && Objects.equal(instance, other.instance)
-        && Objects.equal(members, other.members);
+        && Objects.equals(instance, other.instance)
+        && Objects.equals(members, other.members);
   }
 
   @Override
   public int hashCode() {
-    return 31 * super.hashCode() + Objects.hashCode(instance, members);
+    return 31 * super.hashCode() + Objects.hash(instance, members);
   }
 
   @Override

--- a/extensions/grapher/src/com/google/inject/grapher/Node.java
+++ b/extensions/grapher/src/com/google/inject/grapher/Node.java
@@ -16,7 +16,7 @@
 
 package com.google.inject.grapher;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 /**
  * Node in a guice dependency graph.
@@ -53,13 +53,13 @@ public abstract class Node {
       return false;
     }
     Node other = (Node) obj;
-    return Objects.equal(id, other.id)
-        && (ignoreSourceInComparisons || Objects.equal(source, other.source));
+    return Objects.equals(id, other.id)
+        && (ignoreSourceInComparisons || Objects.equals(source, other.source));
   }
 
   @Override
   public int hashCode() {
-    return ignoreSourceInComparisons ? id.hashCode() : Objects.hashCode(id, source);
+    return ignoreSourceInComparisons ? id.hashCode() : Objects.hash(id, source);
   }
 
   /**

--- a/extensions/grapher/src/com/google/inject/grapher/NodeId.java
+++ b/extensions/grapher/src/com/google/inject/grapher/NodeId.java
@@ -16,8 +16,8 @@
 
 package com.google.inject.grapher;
 
-import com.google.common.base.Objects;
 import com.google.inject.Key;
+import java.util.Objects;
 
 /**
  * ID of a node in the graph. An ID is given by a {@link Key} and a node type, which is used to
@@ -65,7 +65,7 @@ public final class NodeId {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(key, nodeType);
+    return Objects.hash(key, nodeType);
   }
 
   @Override
@@ -74,7 +74,7 @@ public final class NodeId {
       return false;
     }
     NodeId other = (NodeId) obj;
-    return Objects.equal(key, other.key) && Objects.equal(nodeType, other.nodeType);
+    return Objects.equals(key, other.key) && Objects.equals(nodeType, other.nodeType);
   }
 
   @Override

--- a/extensions/servlet/test/com/google/inject/servlet/ServletSpiVisitor.java
+++ b/extensions/servlet/test/com/google/inject/servlet/ServletSpiVisitor.java
@@ -17,7 +17,6 @@
 package com.google.inject.servlet;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.inject.Binding;
@@ -26,6 +25,7 @@ import com.google.inject.Stage;
 import com.google.inject.spi.DefaultBindingTargetVisitor;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Logger;
 import jakarta.servlet.Filter;
@@ -139,10 +139,10 @@ class ServletSpiVisitor extends DefaultBindingTargetVisitor<Object, Integer>
     public boolean equals(Object obj) {
       if (obj instanceof Params) {
         Params o = (Params) obj;
-        return Objects.equal(pattern, o.pattern)
-            && Objects.equal(keyOrInstance, o.keyOrInstance)
-            && Objects.equal(params, o.params)
-            && Objects.equal(patternType, o.patternType);
+        return Objects.equals(pattern, o.pattern)
+            && Objects.equals(keyOrInstance, o.keyOrInstance)
+            && Objects.equals(params, o.params)
+            && Objects.equals(patternType, o.patternType);
       } else {
         return false;
       }
@@ -150,7 +150,7 @@ class ServletSpiVisitor extends DefaultBindingTargetVisitor<Object, Integer>
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(pattern, keyOrInstance, params, patternType);
+      return Objects.hash(pattern, keyOrInstance, params, patternType);
     }
 
     @Override


### PR DESCRIPTION
Additionally use `Objects.hashCode()` instead of `Objects.hash()` for single arguments. This changes the resulting `hashCode()` value but saves the creation of a singleton array.

Part of https://github.com/google/guice/issues/1785