### PR TITLE
Optimize memory allocation in InternalContext by lazy initialization

### DIFF
--- a/core/src/com/google/inject/internal/InternalContext.java
+++ b/core/src/com/google/inject/internal/InternalContext.java
@@ -29,8 +29,7 @@ final class InternalContext implements AutoCloseable {
 
   private final InjectorOptions options;
 
-  private final IdentityHashMap<Object, ConstructionContext<?>> constructionContexts =
-      new IdentityHashMap<>();
+  private IdentityHashMap<Object, ConstructionContext<?>> constructionContexts;
 
   /** Keeps track of the type that is currently being requested for injection. */
   private Dependency<?> dependency;
@@ -77,11 +76,17 @@ final class InternalContext implements AutoCloseable {
 
   @SuppressWarnings("unchecked")
   <T> ConstructionContext<T> getConstructionContext(Object key) {
+
+    /** Lazily initialize the constructionContexts map. */
+    if (constructionContexts == null) {
+        constructionContexts = new IdentityHashMap<>();
+    }
+
     ConstructionContext<T> constructionContext =
-        (ConstructionContext<T>) constructionContexts.get(key);
+            (ConstructionContext<T>) constructionContexts.get(key);
     if (constructionContext == null) {
-      constructionContext = new ConstructionContext<>();
-      constructionContexts.put(key, constructionContext);
+        constructionContext = new ConstructionContext<>();
+        constructionContexts.put(key, constructionContext);
     }
     return constructionContext;
   }


### PR DESCRIPTION
**perf(InternalContext): Optimize memory allocation by lazy initializing constructionContexts**

The current implementation of InternalContext eagerly initializes the constructionContexts map,
leading to unnecessary memory allocation when retrieving singleton instances via Injector#getInstance(...)
or Provider#get(). This commit lazily initializes the constructionContexts map in the getConstructionContext
method, avoiding the creation of the IdentityHashMap and associated Object array when not needed.

This optimization should significantly reduce memory overhead in scenarios where singleton instances
are accessed frequently, improving the overall memory footprint of applications using Guice.

Resolves: #1802 