### PR TITLE
Use try-with-resources when interacting with InternalContext

### DIFF
--- a/core/src/com/google/inject/internal/InjectionRequestProcessor.java
+++ b/core/src/com/google/inject/internal/InjectionRequestProcessor.java
@@ -137,8 +137,7 @@ final class InjectionRequestProcessor extends AbstractProcessor {
     }
 
     void injectMembers() {
-      InternalContext context = injector.enterContext();
-      try {
+      try (InternalContext context = injector.enterContext()) {
         boolean isStageTool = injector.options.stage == Stage.TOOL;
         for (SingleMemberInjector memberInjector : memberInjectors) {
           // Run injections if we're not in tool stage (ie, PRODUCTION or DEV),
@@ -151,8 +150,6 @@ final class InjectionRequestProcessor extends AbstractProcessor {
             }
           }
         }
-      } finally {
-        context.close();
       }
     }
   }

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -1143,14 +1143,11 @@ final class InjectorImpl implements Injector, Lookups {
     return new Provider<T>() {
       @Override
       public T get() {
-        InternalContext currentContext = enterContext();
-        try {
+        try (InternalContext currentContext = enterContext()) {
           T t = internalFactory.get(currentContext, dependency, false);
           return t;
         } catch (InternalProvisionException e) {
           throw e.addSource(dependency).toProvisionException();
-        } finally {
-          currentContext.close();
         }
       }
 

--- a/core/src/com/google/inject/internal/InternalInjectorCreator.java
+++ b/core/src/com/google/inject/internal/InternalInjectorCreator.java
@@ -204,8 +204,8 @@ public final class InternalInjectorCreator {
       // jit bindings must be accessed while holding the lock.
       candidateBindings.addAll(injector.getJitBindingData().getJitBindings().values());
     }
-    InternalContext context = injector.enterContext();
-    try {
+
+    try (InternalContext context = injector.enterContext()) {
       for (BindingImpl<?> binding : candidateBindings) {
         if (isEagerSingleton(injector, binding, stage)) {
           Dependency<?> dependency = Dependency.get(binding.getKey());
@@ -216,8 +216,6 @@ public final class InternalInjectorCreator {
           }
         }
       }
-    } finally {
-      context.close();
     }
   }
 

--- a/core/src/com/google/inject/internal/MembersInjectorImpl.java
+++ b/core/src/com/google/inject/internal/MembersInjectorImpl.java
@@ -85,8 +85,7 @@ final class MembersInjectorImpl<T> implements MembersInjector<T> {
     if (instance == null) {
       return;
     }
-    final InternalContext context = injector.enterContext();
-    try {
+    try (InternalContext context = injector.enterContext()) {
       if (provisionCallback != null && provisionCallback.hasListeners()) {
         provisionCallback.provision(
             context,
@@ -100,8 +99,6 @@ final class MembersInjectorImpl<T> implements MembersInjector<T> {
       } else {
         injectMembers(instance, context, toolableOnly);
       }
-    } finally {
-      context.close();
     }
 
     // TODO: We *could* notify listeners too here,

--- a/core/src/com/google/inject/internal/ProviderToInternalFactoryAdapter.java
+++ b/core/src/com/google/inject/internal/ProviderToInternalFactoryAdapter.java
@@ -32,8 +32,7 @@ final class ProviderToInternalFactoryAdapter<T> implements Provider<T> {
 
   @Override
   public T get() {
-    InternalContext context = injector.enterContext();
-    try {
+    try (InternalContext context = injector.enterContext()) {
       // Always pretend that we are a linked binding, to support
       // scoping implicit bindings.  If we are not actually a linked
       // binding, we'll fail properly elsewhere in the chain.
@@ -41,8 +40,6 @@ final class ProviderToInternalFactoryAdapter<T> implements Provider<T> {
       return t;
     } catch (InternalProvisionException e) {
       throw e.toProvisionException();
-    } finally {
-      context.close();
     }
   }
 


### PR DESCRIPTION
Here when interacting with InternalContext we can use a better construction with automatic closing of try-with-resources, which is a good practice