### PR TITLE
Finish the experimental method handle support

### DIFF
--- a/core/src/com/google/inject/internal/BoundProviderFactory.java
+++ b/core/src/com/google/inject/internal/BoundProviderFactory.java
@@ -19,7 +19,6 @@ package com.google.inject.internal;
 import com.google.inject.Key;
 import com.google.inject.internal.InjectorImpl.JitLimitation;
 import com.google.inject.spi.Dependency;
-import java.lang.invoke.MethodHandle;
 
 /** Delegates to a custom factory which is also bound in the injector. */
 final class BoundProviderFactory<T> extends ProviderInternalFactory<T> implements CreationListener {
@@ -64,11 +63,12 @@ final class BoundProviderFactory<T> extends ProviderInternalFactory<T> implement
   }
 
   @Override
-  MethodHandle makeHandle(LinkageContext context, boolean linked) {
-    return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-        circularGetHandle(
-            providerFactory.getHandle(context, /* linked= */ true), provisionCallback),
-        providerKey);
+  MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+    return makeCachable(
+        InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
+            circularGetHandle(
+                providerFactory.getHandle(context, /* linked= */ true), provisionCallback),
+            providerKey));
   }
 
   @Override

--- a/core/src/com/google/inject/internal/BoundProviderFactory.java
+++ b/core/src/com/google/inject/internal/BoundProviderFactory.java
@@ -64,15 +64,13 @@ final class BoundProviderFactory<T> extends ProviderInternalFactory<T> implement
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, Dependency<?> dependency, boolean linked) {
+  public MethodHandle getHandle(LinkageContext context, boolean linked) {
     return context.makeHandle(
         this,
         () ->
             InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
                 circularGetHandle(
-                    providerFactory.getHandle(context, PROVIDER_DEPENDENCY, /* linked= */ true),
-                    dependency,
-                    provisionCallback),
+                    providerFactory.getHandle(context, /* linked= */ true), provisionCallback),
                 providerKey));
   }
 

--- a/core/src/com/google/inject/internal/BoundProviderFactory.java
+++ b/core/src/com/google/inject/internal/BoundProviderFactory.java
@@ -64,14 +64,11 @@ final class BoundProviderFactory<T> extends ProviderInternalFactory<T> implement
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, boolean linked) {
-    return context.makeHandle(
-        this,
-        () ->
-            InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-                circularGetHandle(
-                    providerFactory.getHandle(context, /* linked= */ true), provisionCallback),
-                providerKey));
+  MethodHandle makeHandle(LinkageContext context, boolean linked) {
+    return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
+        circularGetHandle(
+            providerFactory.getHandle(context, /* linked= */ true), provisionCallback),
+        providerKey);
   }
 
   @Override

--- a/core/src/com/google/inject/internal/ConstantFactory.java
+++ b/core/src/com/google/inject/internal/ConstantFactory.java
@@ -16,23 +16,15 @@
 
 package com.google.inject.internal;
 
-import static java.lang.invoke.MethodType.methodType;
-
 import com.google.common.base.MoreObjects;
 import com.google.inject.Provider;
 import com.google.inject.spi.Dependency;
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
 
 /**
  * @author crazybob@google.com (Bob Lee)
  */
 final class ConstantFactory<T> implements InternalFactory<T> {
-  private static final MethodHandle ON_NULL_INJECTED_INTO_NON_NULLABLE_DEPENDENCY_MH =
-      InternalMethodHandles.findStaticOrDie(
-          InternalProvisionException.class,
-          "onNullInjectedIntoNonNullableDependency",
-          methodType(void.class, Object.class, Dependency.class));
 
   private static <T> InternalFactory<T> nullFactory(Object source) {
     return new InternalFactory<T>() {
@@ -51,19 +43,9 @@ final class ConstantFactory<T> implements InternalFactory<T> {
       }
 
       @Override
-      public MethodHandle getHandle(
-          LinkageContext context, Dependency<?> dependency, boolean linked) {
+      public MethodHandle getHandle(LinkageContext context, boolean linked) {
         var returnNull = InternalMethodHandles.constantFactoryGetHandle(null);
-        if (dependency.isNullable()) {
-          // Just return a constant null handle.
-          return returnNull;
-        }
-        // We need to call onNullInjectedIntoNonNullableDependency and then return null.  It is
-        // possible that the former will throw but that depends on some runtime conditions.
-        var onNull =
-            MethodHandles.insertArguments(
-                ON_NULL_INJECTED_INTO_NON_NULLABLE_DEPENDENCY_MH, 0, source, dependency);
-        return MethodHandles.foldArguments(returnNull, onNull);
+        return InternalMethodHandles.nullCheckResult(returnNull, source);
       }
     };
   }
@@ -92,7 +74,7 @@ final class ConstantFactory<T> implements InternalFactory<T> {
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, Dependency<?> dependency, boolean linked) {
+  public MethodHandle getHandle(LinkageContext context, boolean linked) {
     return InternalMethodHandles.constantFactoryGetHandle(instance);
   }
 

--- a/core/src/com/google/inject/internal/ConstantFactory.java
+++ b/core/src/com/google/inject/internal/ConstantFactory.java
@@ -43,7 +43,7 @@ final class ConstantFactory<T> extends InternalFactory<T> {
       }
 
       @Override
-      public MethodHandle getHandle(LinkageContext context, boolean linked) {
+      MethodHandle makeHandle(LinkageContext context, boolean linked) {
         var returnNull = InternalMethodHandles.constantFactoryGetHandle(null);
         return InternalMethodHandles.nullCheckResult(returnNull, source);
       }
@@ -74,7 +74,7 @@ final class ConstantFactory<T> extends InternalFactory<T> {
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, boolean linked) {
+  MethodHandle makeHandle(LinkageContext context, boolean linked) {
     return InternalMethodHandles.constantFactoryGetHandle(instance);
   }
 

--- a/core/src/com/google/inject/internal/ConstantFactory.java
+++ b/core/src/com/google/inject/internal/ConstantFactory.java
@@ -19,7 +19,6 @@ package com.google.inject.internal;
 import com.google.common.base.MoreObjects;
 import com.google.inject.Provider;
 import com.google.inject.spi.Dependency;
-import java.lang.invoke.MethodHandle;
 
 /**
  * @author crazybob@google.com (Bob Lee)
@@ -43,9 +42,9 @@ final class ConstantFactory<T> extends InternalFactory<T> {
       }
 
       @Override
-      MethodHandle makeHandle(LinkageContext context, boolean linked) {
+      MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
         var returnNull = InternalMethodHandles.constantFactoryGetHandle(null);
-        return InternalMethodHandles.nullCheckResult(returnNull, source);
+        return makeCachable(InternalMethodHandles.nullCheckResult(returnNull, source));
       }
     };
   }
@@ -74,8 +73,8 @@ final class ConstantFactory<T> extends InternalFactory<T> {
   }
 
   @Override
-  MethodHandle makeHandle(LinkageContext context, boolean linked) {
-    return InternalMethodHandles.constantFactoryGetHandle(instance);
+  MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+    return makeCachable(InternalMethodHandles.constantFactoryGetHandle(instance));
   }
 
   @Override

--- a/core/src/com/google/inject/internal/ConstantFactory.java
+++ b/core/src/com/google/inject/internal/ConstantFactory.java
@@ -24,7 +24,7 @@ import java.lang.invoke.MethodHandle;
 /**
  * @author crazybob@google.com (Bob Lee)
  */
-final class ConstantFactory<T> implements InternalFactory<T> {
+final class ConstantFactory<T> extends InternalFactory<T> {
 
   private static <T> InternalFactory<T> nullFactory(Object source) {
     return new InternalFactory<T>() {

--- a/core/src/com/google/inject/internal/ConstantProviderInternalFactory.java
+++ b/core/src/com/google/inject/internal/ConstantProviderInternalFactory.java
@@ -19,9 +19,8 @@ package com.google.inject.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.inject.spi.Dependency;
-import java.lang.invoke.MethodHandle;
-import javax.annotation.Nullable;
 import jakarta.inject.Provider;
+import javax.annotation.Nullable;
 
 /** An InternalFactory that delegates to a constant provider. */
 final class ConstantProviderInternalFactory<T> extends ProviderInternalFactory<T> {
@@ -45,8 +44,9 @@ final class ConstantProviderInternalFactory<T> extends ProviderInternalFactory<T
   }
 
   @Override
-  MethodHandle makeHandle(LinkageContext context, boolean linked) {
-    return circularGetHandleImmediate(
-        InternalMethodHandles.constantFactoryGetHandle(provider), provisionCallback);
+  MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+    return makeCachable(
+        circularGetHandleImmediate(
+            InternalMethodHandles.constantFactoryGetHandle(provider), provisionCallback));
   }
 }

--- a/core/src/com/google/inject/internal/ConstantProviderInternalFactory.java
+++ b/core/src/com/google/inject/internal/ConstantProviderInternalFactory.java
@@ -45,8 +45,8 @@ final class ConstantProviderInternalFactory<T> extends ProviderInternalFactory<T
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, Dependency<?> dependency, boolean linked) {
+  public MethodHandle getHandle(LinkageContext context, boolean linked) {
     return circularGetHandleImmediate(
-        InternalMethodHandles.constantFactoryGetHandle(provider), dependency, provisionCallback);
+        InternalMethodHandles.constantFactoryGetHandle(provider), provisionCallback);
   }
 }

--- a/core/src/com/google/inject/internal/ConstantProviderInternalFactory.java
+++ b/core/src/com/google/inject/internal/ConstantProviderInternalFactory.java
@@ -45,7 +45,7 @@ final class ConstantProviderInternalFactory<T> extends ProviderInternalFactory<T
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, boolean linked) {
+  MethodHandle makeHandle(LinkageContext context, boolean linked) {
     return circularGetHandleImmediate(
         InternalMethodHandles.constantFactoryGetHandle(provider), provisionCallback);
   }

--- a/core/src/com/google/inject/internal/ConstructionProxy.java
+++ b/core/src/com/google/inject/internal/ConstructionProxy.java
@@ -39,7 +39,7 @@ interface ConstructionProxy<T> {
    * Returns the method handle for the constructor, using the supplied handles to provide
    * parameters.
    *
-   * <p>The returned handle has {@link InternalMethodHandles#FACTORY_TYPE} as its signature.
+   * <p>The returned handle has {@link InternalMethodHandles#ELEMENT_FACTORY_TYPE} as its signature.
    */
   MethodHandle getConstructHandle(MethodHandle[] parameterHandles);
 

--- a/core/src/com/google/inject/internal/ConstructorBindingImpl.java
+++ b/core/src/com/google/inject/internal/ConstructorBindingImpl.java
@@ -279,7 +279,7 @@ final class ConstructorBindingImpl<T> extends BindingImpl<T>
     return Objects.hashCode(getKey(), getScoping(), constructorInjectionPoint);
   }
 
-  private static class Factory<T> implements InternalFactory<T> {
+  private static class Factory<T> extends InternalFactory<T> {
     private final boolean failIfNotLinked;
     private final Key<?> key;
     private ConstructorInjector<T> constructorInjector;

--- a/core/src/com/google/inject/internal/ConstructorBindingImpl.java
+++ b/core/src/com/google/inject/internal/ConstructorBindingImpl.java
@@ -309,20 +309,16 @@ final class ConstructorBindingImpl<T> extends BindingImpl<T>
     }
 
     @Override
-    public MethodHandle getHandle(
-        LinkageContext context, Dependency<?> dependency, boolean linked) {
+    public MethodHandle getHandle(LinkageContext context, boolean linked) {
       if (!linked && failIfNotLinked) {
         var throwHandle =
             MethodHandles.foldArguments(
-                MethodHandles.throwException(
-                    dependency.getKey().getTypeLiteral().getRawType(),
-                    InternalProvisionException.class),
+                MethodHandles.throwException(Object.class, InternalProvisionException.class),
                 MethodHandles.insertArguments(JIT_DISABLED_HANDLE, 0, key));
-        return MethodHandles.dropArguments(throwHandle, 0, InternalContext.class);
+        return MethodHandles.dropArguments(throwHandle, 0, InternalContext.class, Dependency.class);
       }
       return context.makeHandle(
-          this,
-          () -> constructorInjector.getConstructHandle(context, dependency, provisionCallback));
+          this, () -> constructorInjector.getConstructHandle(context, provisionCallback));
     }
 
     private static final MethodHandle JIT_DISABLED_HANDLE =

--- a/core/src/com/google/inject/internal/ConstructorBindingImpl.java
+++ b/core/src/com/google/inject/internal/ConstructorBindingImpl.java
@@ -309,7 +309,7 @@ final class ConstructorBindingImpl<T> extends BindingImpl<T>
     }
 
     @Override
-    public MethodHandle getHandle(LinkageContext context, boolean linked) {
+    MethodHandle makeHandle(LinkageContext context, boolean linked) {
       if (!linked && failIfNotLinked) {
         var throwHandle =
             MethodHandles.foldArguments(
@@ -317,8 +317,7 @@ final class ConstructorBindingImpl<T> extends BindingImpl<T>
                 MethodHandles.insertArguments(JIT_DISABLED_HANDLE, 0, key));
         return MethodHandles.dropArguments(throwHandle, 0, InternalContext.class, Dependency.class);
       }
-      return context.makeHandle(
-          this, () -> constructorInjector.getConstructHandle(context, provisionCallback));
+      return constructorInjector.getConstructHandle(context, provisionCallback);
     }
 
     private static final MethodHandle JIT_DISABLED_HANDLE =

--- a/core/src/com/google/inject/internal/ConstructorInjector.java
+++ b/core/src/com/google/inject/internal/ConstructorInjector.java
@@ -127,9 +127,6 @@ final class ConstructorInjector<T> implements ProvisionCallback<T> {
       handle = InternalMethodHandles.finishConstruction(handle, circularFactoryId);
     }
 
-    handle =
-        InternalMethodHandles.catchErrorInConstructorAndRethrowWithSource(
-            handle, constructionProxy.getInjectionPoint());
     if (membersInjector != null) {
       // If we called finishConstructionAndSetReference, we need to clear the reference here.
       handle = InternalMethodHandles.clearReference(handle, circularFactoryId);

--- a/core/src/com/google/inject/internal/ConstructorInjector.java
+++ b/core/src/com/google/inject/internal/ConstructorInjector.java
@@ -19,6 +19,7 @@ package com.google.inject.internal;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.internal.MembersInjectorImpl.MethodHandleMembersInjectorImpl;
 import com.google.inject.internal.ProvisionListenerStackCallback.ProvisionCallback;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.InjectionPoint;
@@ -111,7 +112,7 @@ final class ConstructorInjector<T> implements ProvisionCallback<T> {
     if (membersInjector != null) {
       handle = InternalMethodHandles.finishConstructionAndSetReference(handle, circularFactoryId);
       // Members injectors have the signature `(Object, InternalContext)->void`
-      var membersHandle = membersInjector.getInjectMembersAndNotifyListenersHandle(linkageContext);
+      var membersHandle = ((MethodHandleMembersInjectorImpl<?>)membersInjector).getInjectMembersAndNotifyListenersHandle(linkageContext);
       // Compose it into a handle that just returns the first parameter.
       membersHandle =
           MethodHandles.foldArguments(

--- a/core/src/com/google/inject/internal/DefaultConstructionProxyFactory.java
+++ b/core/src/com/google/inject/internal/DefaultConstructionProxyFactory.java
@@ -136,6 +136,8 @@ final class DefaultConstructionProxyFactory<T> implements ConstructionProxyFacto
               .asType(methodType(Object.class, Object.class, Object[].class));
       // (Object[])->Object
       handle = MethodHandles.insertArguments(handle, 0, (Object) null); // no receiver type.
+      // catch here so we don't catch errors from our parameters
+      handle = InternalMethodHandles.catchErrorInConstructorAndRethrowWithSource(handle, injectionPoint);
       // (InternalContext)->Object
       handle =
           MethodHandles.filterArguments(
@@ -165,6 +167,9 @@ final class DefaultConstructionProxyFactory<T> implements ConstructionProxyFacto
       // See comments in ProviderMethod on how this rarely happens and why it happens
       // (Object[])->Object
       var handle = CONSTRUCTOR_NEWINSTANCE_HANDLE.bindTo(constructor);
+      // Catch here so we don't catch errors from our parameters
+      handle = InternalMethodHandles.catchErrorInConstructorAndRethrowWithSource(handle, injectionPoint);
+
       // (InternalContext)->Object
       handle =
           MethodHandles.filterArguments(
@@ -201,7 +206,9 @@ final class DefaultConstructionProxyFactory<T> implements ConstructionProxyFacto
           IntStream.range(0, parameterHandles.length)
               .mapToObj(i -> castReturnTo(parameterHandles[i], type.parameterType(i)))
               .toArray(MethodHandle[]::new);
-      var handle = MethodHandles.filterArguments(target, 0, typedHandles);
+      // catch errors from the constructor
+      var handle =  InternalMethodHandles.catchErrorInConstructorAndRethrowWithSource(target, injectionPoint);
+      handle = MethodHandles.filterArguments(handle, 0, typedHandles);
       handle = castReturnToObject(handle); // satisfy the signature of the factory type.
       return MethodHandles.permuteArguments(
           handle, InternalMethodHandles.ELEMENT_FACTORY_TYPE, new int[typedHandles.length]);

--- a/core/src/com/google/inject/internal/DefaultConstructionProxyFactory.java
+++ b/core/src/com/google/inject/internal/DefaultConstructionProxyFactory.java
@@ -144,7 +144,7 @@ final class DefaultConstructionProxyFactory<T> implements ConstructionProxyFacto
       // merge all the internalcontext parameters into a single object factory.
       handle =
           MethodHandles.permuteArguments(
-              handle, InternalMethodHandles.FACTORY_TYPE, new int[parameterHandles.length]);
+              handle, InternalMethodHandles.ELEMENT_FACTORY_TYPE, new int[parameterHandles.length]);
       return handle;
     }
   }
@@ -175,7 +175,7 @@ final class DefaultConstructionProxyFactory<T> implements ConstructionProxyFacto
       handle = MethodHandles.filterArguments(handle, 0, parameterHandles);
       // merge all the internalcontext parameters into a single object factory.
       return MethodHandles.permuteArguments(
-          handle, InternalMethodHandles.FACTORY_TYPE, new int[parameterHandles.length]);
+          handle, InternalMethodHandles.ELEMENT_FACTORY_TYPE, new int[parameterHandles.length]);
     }
   }
 
@@ -210,7 +210,7 @@ final class DefaultConstructionProxyFactory<T> implements ConstructionProxyFacto
       var handle = MethodHandles.filterArguments(target, 0, typedHandles);
       handle = castReturnToObject(handle); // satisfy the signature of the factory type.
       return MethodHandles.permuteArguments(
-          handle, InternalMethodHandles.FACTORY_TYPE, new int[typedHandles.length]);
+          handle, InternalMethodHandles.ELEMENT_FACTORY_TYPE, new int[typedHandles.length]);
     }
   }
 }

--- a/core/src/com/google/inject/internal/DefaultConstructionProxyFactory.java
+++ b/core/src/com/google/inject/internal/DefaultConstructionProxyFactory.java
@@ -16,7 +16,6 @@
 
 package com.google.inject.internal;
 
-import static com.google.inject.internal.InternalMethodHandles.CONSTRUCTOR_NEWINSTANCE_HANDLE;
 import static com.google.inject.internal.InternalMethodHandles.castReturnTo;
 import static com.google.inject.internal.InternalMethodHandles.castReturnToObject;
 import static java.lang.invoke.MethodType.methodType;
@@ -166,7 +165,7 @@ final class DefaultConstructionProxyFactory<T> implements ConstructionProxyFacto
     public MethodHandle getConstructHandle(MethodHandle[] parameterHandles) {
       // See comments in ProviderMethod on how this rarely happens and why it happens
       // (Object[])->Object
-      var handle = CONSTRUCTOR_NEWINSTANCE_HANDLE.bindTo(constructor);
+      var handle = InternalMethodHandles.newInstanceHandle(constructor);
       // Catch here so we don't catch errors from our parameters
       handle = InternalMethodHandles.catchErrorInConstructorAndRethrowWithSource(handle, injectionPoint);
 

--- a/core/src/com/google/inject/internal/DefaultConstructionProxyFactory.java
+++ b/core/src/com/google/inject/internal/DefaultConstructionProxyFactory.java
@@ -134,17 +134,12 @@ final class DefaultConstructionProxyFactory<T> implements ConstructionProxyFacto
           InternalMethodHandles.BIFUNCTION_APPLY_HANDLE
               .bindTo(fastConstructor)
               .asType(methodType(Object.class, Object.class, Object[].class));
+      // (Object[])->Object
       handle = MethodHandles.insertArguments(handle, 0, (Object) null); // no receiver type.
-      // NOTE: is is safe to use asCollector here because the number of parameters is the same
-      // as the number of parameters to the constructor which should never exceed the maxiumum
-      // number of method parameters.
-      handle = handle.asCollector(Object[].class, parameterHandles.length);
-      // Pass all the parameters to the constructor.
-      handle = MethodHandles.filterArguments(handle, 0, parameterHandles);
-      // merge all the internalcontext parameters into a single object factory.
+      // (InternalContext)->Object
       handle =
-          MethodHandles.permuteArguments(
-              handle, InternalMethodHandles.ELEMENT_FACTORY_TYPE, new int[parameterHandles.length]);
+          MethodHandles.filterArguments(
+              handle, 0, InternalMethodHandles.buildObjectArrayFactory(parameterHandles));
       return handle;
     }
   }
@@ -168,14 +163,13 @@ final class DefaultConstructionProxyFactory<T> implements ConstructionProxyFacto
     @Override
     public MethodHandle getConstructHandle(MethodHandle[] parameterHandles) {
       // See comments in ProviderMethod on how this rarely happens and why it happens
+      // (Object[])->Object
       var handle = CONSTRUCTOR_NEWINSTANCE_HANDLE.bindTo(constructor);
-      // collect the parameters into an array of type Object[]
-      handle = handle.asCollector(Object[].class, parameterHandles.length);
-      // apply all the parameters to the constructor.
-      handle = MethodHandles.filterArguments(handle, 0, parameterHandles);
-      // merge all the internalcontext parameters into a single object factory.
-      return MethodHandles.permuteArguments(
-          handle, InternalMethodHandles.ELEMENT_FACTORY_TYPE, new int[parameterHandles.length]);
+      // (InternalContext)->Object
+      handle =
+          MethodHandles.filterArguments(
+              handle, 0, InternalMethodHandles.buildObjectArrayFactory(parameterHandles));
+      return handle;
     }
   }
 

--- a/core/src/com/google/inject/internal/ExposedKeyFactory.java
+++ b/core/src/com/google/inject/internal/ExposedKeyFactory.java
@@ -25,7 +25,7 @@ import java.lang.invoke.MethodHandle;
  * This factory exists in a parent injector. When invoked, it retrieves its value from a child
  * injector.
  */
-final class ExposedKeyFactory<T> implements InternalFactory<T>, CreationListener {
+final class ExposedKeyFactory<T> extends InternalFactory<T> implements CreationListener {
   private final Key<T> key;
   private final Object source;
   private final PrivateElements privateElements;

--- a/core/src/com/google/inject/internal/ExposedKeyFactory.java
+++ b/core/src/com/google/inject/internal/ExposedKeyFactory.java
@@ -19,7 +19,6 @@ package com.google.inject.internal;
 import com.google.inject.Key;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.PrivateElements;
-import java.lang.invoke.MethodHandle;
 
 /**
  * This factory exists in a parent injector. When invoked, it retrieves its value from a child
@@ -66,8 +65,9 @@ final class ExposedKeyFactory<T> extends InternalFactory<T> implements CreationL
   }
 
   @Override
-  MethodHandle makeHandle(LinkageContext context, boolean linked) {
-    return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-        this.delegate.getHandle(context, linked), source);
+  MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+    return makeCachableOnLinkedSetting(
+        InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
+            this.delegate.getHandle(context, linked), source));
   }
 }

--- a/core/src/com/google/inject/internal/ExposedKeyFactory.java
+++ b/core/src/com/google/inject/internal/ExposedKeyFactory.java
@@ -66,8 +66,8 @@ final class ExposedKeyFactory<T> implements InternalFactory<T>, CreationListener
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, Dependency<?> dependency, boolean linked) {
+  public MethodHandle getHandle(LinkageContext context, boolean linked) {
     return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-        this.delegate.getHandle(context, dependency, linked), source);
+        this.delegate.getHandle(context, linked), source);
   }
 }

--- a/core/src/com/google/inject/internal/ExposedKeyFactory.java
+++ b/core/src/com/google/inject/internal/ExposedKeyFactory.java
@@ -66,7 +66,7 @@ final class ExposedKeyFactory<T> extends InternalFactory<T> implements CreationL
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, boolean linked) {
+  MethodHandle makeHandle(LinkageContext context, boolean linked) {
     return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
         this.delegate.getHandle(context, linked), source);
   }

--- a/core/src/com/google/inject/internal/FactoryProxy.java
+++ b/core/src/com/google/inject/internal/FactoryProxy.java
@@ -64,9 +64,9 @@ final class FactoryProxy<T> implements InternalFactory<T>, CreationListener {
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, Dependency<?> dependency, boolean linked) {
+  public MethodHandle getHandle(LinkageContext context, boolean linked) {
     return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-        targetFactory.getHandle(context, dependency, /* linked= */ true), targetKey);
+        targetFactory.getHandle(context, /* linked= */ true), targetKey);
   }
 
   @Override

--- a/core/src/com/google/inject/internal/FactoryProxy.java
+++ b/core/src/com/google/inject/internal/FactoryProxy.java
@@ -20,7 +20,6 @@ import com.google.common.base.MoreObjects;
 import com.google.inject.Key;
 import com.google.inject.internal.InjectorImpl.JitLimitation;
 import com.google.inject.spi.Dependency;
-import java.lang.invoke.MethodHandle;
 
 /**
  * A placeholder which enables us to swap in the real factory once the injector is created. Used for
@@ -64,9 +63,10 @@ final class FactoryProxy<T> extends InternalFactory<T> implements CreationListen
   }
 
   @Override
-  MethodHandle makeHandle(LinkageContext context, boolean linked) {
-    return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-        targetFactory.getHandle(context, /* linked= */ true), targetKey);
+  MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+    return makeCachable(
+        InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
+            targetFactory.getHandle(context, /* linked= */ true), targetKey));
   }
 
   @Override

--- a/core/src/com/google/inject/internal/FactoryProxy.java
+++ b/core/src/com/google/inject/internal/FactoryProxy.java
@@ -64,7 +64,7 @@ final class FactoryProxy<T> extends InternalFactory<T> implements CreationListen
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, boolean linked) {
+  MethodHandle makeHandle(LinkageContext context, boolean linked) {
     return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
         targetFactory.getHandle(context, /* linked= */ true), targetKey);
   }

--- a/core/src/com/google/inject/internal/FactoryProxy.java
+++ b/core/src/com/google/inject/internal/FactoryProxy.java
@@ -26,7 +26,7 @@ import java.lang.invoke.MethodHandle;
  * A placeholder which enables us to swap in the real factory once the injector is created. Used for
  * a linked binding, so that getting the linked binding returns the link's factory.
  */
-final class FactoryProxy<T> implements InternalFactory<T>, CreationListener {
+final class FactoryProxy<T> extends InternalFactory<T> implements CreationListener {
 
   private final InjectorImpl injector;
   private final Key<T> key;

--- a/core/src/com/google/inject/internal/InitializableFactory.java
+++ b/core/src/com/google/inject/internal/InitializableFactory.java
@@ -25,7 +25,7 @@ import java.lang.invoke.MethodHandle;
 /**
  * @author crazybob@google.com (Bob Lee)
  */
-final class InitializableFactory<T> implements InternalFactory<T> {
+final class InitializableFactory<T> extends InternalFactory<T> {
 
   private final Initializable<T> initializable;
   // Cache the values here so we can optimize the behavior of Provider instances.

--- a/core/src/com/google/inject/internal/InitializableFactory.java
+++ b/core/src/com/google/inject/internal/InitializableFactory.java
@@ -47,7 +47,7 @@ final class InitializableFactory<T> extends InternalFactory<T> {
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, boolean linked) {
+  MethodHandle makeHandle(LinkageContext context, boolean linked) {
     return InternalMethodHandles.initializableFactoryGetHandle(initializable);
   }
 

--- a/core/src/com/google/inject/internal/InitializableFactory.java
+++ b/core/src/com/google/inject/internal/InitializableFactory.java
@@ -20,7 +20,6 @@ import com.google.common.base.MoreObjects;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.inject.Provider;
 import com.google.inject.spi.Dependency;
-import java.lang.invoke.MethodHandle;
 
 /**
  * @author crazybob@google.com (Bob Lee)
@@ -47,8 +46,8 @@ final class InitializableFactory<T> extends InternalFactory<T> {
   }
 
   @Override
-  MethodHandle makeHandle(LinkageContext context, boolean linked) {
-    return InternalMethodHandles.initializableFactoryGetHandle(initializable);
+  MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+    return makeCachable(InternalMethodHandles.initializableFactoryGetHandle(initializable));
   }
 
   @Override

--- a/core/src/com/google/inject/internal/InitializableFactory.java
+++ b/core/src/com/google/inject/internal/InitializableFactory.java
@@ -47,7 +47,7 @@ final class InitializableFactory<T> implements InternalFactory<T> {
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, Dependency<?> dependency, boolean linked) {
+  public MethodHandle getHandle(LinkageContext context, boolean linked) {
     return InternalMethodHandles.initializableFactoryGetHandle(initializable);
   }
 

--- a/core/src/com/google/inject/internal/Initializer.java
+++ b/core/src/com/google/inject/internal/Initializer.java
@@ -262,8 +262,6 @@ final class Initializer {
           default:
             throw new IllegalStateException("Unknown state: " + state);
         }
-        // TODO(b/366058184): Investigate a MethodHandle approach for this.
-
         // if in Stage.TOOL, we only want to inject & notify toolable injection points.
         // (otherwise we'll inject all of them)
         try {

--- a/core/src/com/google/inject/internal/InjectionRequestProcessor.java
+++ b/core/src/com/google/inject/internal/InjectionRequestProcessor.java
@@ -138,8 +138,6 @@ final class InjectionRequestProcessor extends AbstractProcessor {
     }
 
     void injectMembers() {
-
-      // TODO(b/366058184): investigate a methodhandle version of this.
       InternalContext context = injector.enterContext();
       try {
         boolean isStageTool = injector.options.stage == Stage.TOOL;
@@ -147,10 +145,27 @@ final class InjectionRequestProcessor extends AbstractProcessor {
           // Run injections if we're not in tool stage (ie, PRODUCTION or DEV),
           // or if we are in tool stage and the injection point is toolable.
           if (!isStageTool || memberInjector.getInjectionPoint().isToolable()) {
-            try {
-              memberInjector.inject(context, null);
-            } catch (InternalProvisionException e) {
-              errors.merge(e);
+            if (InternalFlags.getUseExperimentalMethodHandlesOption()) {
+              try {
+                // In theory, constructing the handle to invoke it exactly once is expensive and wasteful, and it is true for
+                // directly injecting the member this is probably slower than the reflective SingleFieldInjector. However,
+                // by taking this path we::
+                // 1. Don't need to construct fastclasses for method injections (SingleMethodInjector).
+                // 2. construct fast classes for transitive injections (constructors/@Provides methods).
+                // 3. Can leverage or initialize caches for transitive InternalFactory.getHandle calls.
+                memberInjector.getInjectHandle(new LinkageContext()).invokeExact((Object) null, context);
+              } catch (InternalProvisionException e) {
+                errors.merge(e);
+              } catch (Throwable t) {
+                // This will propagate unexpected Errors.
+                InternalMethodHandles.sneakyThrow(t);
+              }
+            } else {
+              try {
+                memberInjector.inject(context, null);
+              } catch (InternalProvisionException e) {
+                errors.merge(e);
+              }
             }
           }
         }

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -404,7 +404,7 @@ final class InjectorImpl implements Injector, Lookups {
         }
 
         @Override
-        public MethodHandle getHandle(LinkageContext context, boolean linked) {
+        MethodHandle makeHandle(LinkageContext context, boolean linked) {
           return InternalMethodHandles.constantFactoryGetHandle(providedBinding.getProvider());
         }
       };

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -52,7 +52,6 @@ import com.google.inject.spi.ProviderBinding;
 import com.google.inject.spi.TypeConverterBinding;
 import com.google.inject.util.Providers;
 import java.lang.annotation.Annotation;
-import java.lang.invoke.MethodHandle;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -404,8 +403,8 @@ final class InjectorImpl implements Injector, Lookups {
         }
 
         @Override
-        MethodHandle makeHandle(LinkageContext context, boolean linked) {
-          return InternalMethodHandles.constantFactoryGetHandle(providedBinding.getProvider());
+        MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+          return makeCachable(InternalMethodHandles.constantFactoryGetHandle(providedBinding.getProvider()));
         }
       };
     }

--- a/core/src/com/google/inject/internal/InjectorImpl.java
+++ b/core/src/com/google/inject/internal/InjectorImpl.java
@@ -404,8 +404,7 @@ final class InjectorImpl implements Injector, Lookups {
         }
 
         @Override
-        public MethodHandle getHandle(
-            LinkageContext context, Dependency<?> dependency, boolean linked) {
+        public MethodHandle getHandle(LinkageContext context, boolean linked) {
           return InternalMethodHandles.constantFactoryGetHandle(providedBinding.getProvider());
         }
       };

--- a/core/src/com/google/inject/internal/InjectorShell.java
+++ b/core/src/com/google/inject/internal/InjectorShell.java
@@ -286,8 +286,8 @@ final class InjectorShell {
     }
 
     @Override
-    MethodHandle makeHandle(LinkageContext context, boolean linked) {
-      return InternalMethodHandles.constantFactoryGetHandle(injector);
+    MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+      return makeCachable(InternalMethodHandles.constantFactoryGetHandle(injector));
     }
 
     @Override
@@ -334,8 +334,8 @@ final class InjectorShell {
     }
 
     @Override
-    MethodHandle makeHandle(LinkageContext context, boolean linked) {
-      return MAKE_LOGGER_MH;
+    MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+      return makeCachable(MAKE_LOGGER_MH);
     }
 
     private static final MethodHandle MAKE_LOGGER_MH;

--- a/core/src/com/google/inject/internal/InjectorShell.java
+++ b/core/src/com/google/inject/internal/InjectorShell.java
@@ -263,7 +263,7 @@ final class InjectorShell {
                 ImmutableSet.<InjectionPoint>of()));
   }
 
-  private static class InjectorFactory implements InternalFactory<Injector>, Provider<Injector> {
+  private static class InjectorFactory extends InternalFactory<Injector> implements Provider<Injector> {
     private final Injector injector;
 
     private InjectorFactory(Injector injector) {
@@ -317,7 +317,7 @@ final class InjectorShell {
                 ImmutableSet.<InjectionPoint>of()));
   }
 
-  private static class LoggerFactory implements InternalFactory<Logger>, Provider<Logger> {
+  private static class LoggerFactory extends InternalFactory<Logger> implements Provider<Logger> {
     @Override
     public Logger get(InternalContext context, Dependency<?> dependency, boolean linked) {
       return makeLogger(dependency);

--- a/core/src/com/google/inject/internal/InjectorShell.java
+++ b/core/src/com/google/inject/internal/InjectorShell.java
@@ -19,6 +19,8 @@ package com.google.inject.internal;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.internal.GuiceInternal.GUICE_INTERNAL;
+import static com.google.inject.internal.InternalMethodHandles.castReturnToObject;
+import static java.lang.invoke.MethodType.methodType;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -42,6 +44,7 @@ import com.google.inject.spi.PrivateElements;
 import com.google.inject.spi.ProvisionListenerBinding;
 import com.google.inject.spi.TypeListenerBinding;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
@@ -237,7 +240,6 @@ final class InjectorShell {
 
       return injectorShells;
     }
-
   }
 
   /**
@@ -284,8 +286,7 @@ final class InjectorShell {
     }
 
     @Override
-    public MethodHandle getHandle(
-        LinkageContext context, Dependency<?> dependency, boolean linked) {
+    public MethodHandle getHandle(LinkageContext context, boolean linked) {
       return InternalMethodHandles.constantFactoryGetHandle(injector);
     }
 
@@ -333,9 +334,27 @@ final class InjectorShell {
     }
 
     @Override
-    public MethodHandle getHandle(
-        LinkageContext context, Dependency<?> dependency, boolean linked) {
-      return InternalMethodHandles.constantFactoryGetHandle(makeLogger(dependency));
+    public MethodHandle getHandle(LinkageContext context, boolean linked) {
+      return MAKE_LOGGER_MH;
+    }
+
+    private static final MethodHandle MAKE_LOGGER_MH;
+
+    static {
+      try {
+        MAKE_LOGGER_MH =
+            castReturnToObject(
+                MethodHandles.dropArguments(
+                    MethodHandles.lookup()
+                        .findStatic(
+                            LoggerFactory.class,
+                            "makeLogger",
+                            methodType(Logger.class, Dependency.class)),
+                    0,
+                    InternalContext.class));
+      } catch (NoSuchMethodException | IllegalAccessException e) {
+        throw new LinkageError("Failed to find makeLogger function", e);
+      }
     }
 
     private static Logger makeLogger(Dependency<?> dependency) {

--- a/core/src/com/google/inject/internal/InjectorShell.java
+++ b/core/src/com/google/inject/internal/InjectorShell.java
@@ -286,7 +286,7 @@ final class InjectorShell {
     }
 
     @Override
-    public MethodHandle getHandle(LinkageContext context, boolean linked) {
+    MethodHandle makeHandle(LinkageContext context, boolean linked) {
       return InternalMethodHandles.constantFactoryGetHandle(injector);
     }
 
@@ -334,7 +334,7 @@ final class InjectorShell {
     }
 
     @Override
-    public MethodHandle getHandle(LinkageContext context, boolean linked) {
+    MethodHandle makeHandle(LinkageContext context, boolean linked) {
       return MAKE_LOGGER_MH;
     }
 

--- a/core/src/com/google/inject/internal/InternalFactory.java
+++ b/core/src/com/google/inject/internal/InternalFactory.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.inject.Provider;
 import com.google.inject.spi.Dependency;
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
 
 /**
  * Creates objects which will be injected.
@@ -56,11 +55,7 @@ interface InternalFactory<T> {
    * @param linked true if getting as a result of a linked binding
    * @return the method handle for the object to be injected
    */
-  default MethodHandle getHandle(LinkageContext context, boolean linked) {
-    // The default implementation simply delegates to the `get` method.
-    MethodHandle handle = InternalMethodHandles.INTERNAL_FACTORY_GET_HANDLE.bindTo(this);
-    return MethodHandles.insertArguments(handle, 2, linked);
-  }
+  abstract MethodHandle getHandle(LinkageContext context, boolean linked);
 
   /**
    * Returns a provider for the object to be injected using the given factory.

--- a/core/src/com/google/inject/internal/InternalFactory.java
+++ b/core/src/com/google/inject/internal/InternalFactory.java
@@ -55,7 +55,11 @@ abstract class InternalFactory<T> {
    * @param linked true if getting as a result of a linked binding
    * @return the method handle for the object to be injected
    */
-  abstract MethodHandle getHandle(LinkageContext context, boolean linked);
+  final MethodHandle getHandle(LinkageContext context, boolean linked) {
+    return context.makeHandle(this, linked);
+  }
+
+  abstract MethodHandle makeHandle(LinkageContext context, boolean linked);
 
   /**
    * Returns a provider for the object to be injected using the given factory.

--- a/core/src/com/google/inject/internal/InternalFactory.java
+++ b/core/src/com/google/inject/internal/InternalFactory.java
@@ -16,11 +16,13 @@
 
 package com.google.inject.internal;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.inject.Provider;
 import com.google.inject.spi.Dependency;
 import java.lang.invoke.MethodHandle;
+import javax.annotation.Nullable;
 
 /**
  * Creates objects which will be injected.
@@ -28,6 +30,12 @@ import java.lang.invoke.MethodHandle;
  * @author crazybob@google.com (Bob Lee)
  */
 abstract class InternalFactory<T> {
+
+  /**
+   * Accessed in a double checked manner and updated under the `this` lock. See {@link
+   * HandleCache#getHandleAndMaybeUpdateCache(boolean, MethodHandleResult)}.
+   */
+  private volatile HandleCache handleCache = HandleCache.EMPTY;
 
   /**
    * Creates an object to be injected.
@@ -56,10 +64,59 @@ abstract class InternalFactory<T> {
    * @return the method handle for the object to be injected
    */
   final MethodHandle getHandle(LinkageContext context, boolean linked) {
-    return context.makeHandle(this, linked);
+    var currentCache = handleCache;
+    var local = currentCache.getHandle(linked);
+    if (local != null) {
+      return local;
+    }
+    // NOTE: we do not hold a lock while actually constructing the handle, instead we atomically
+    // update the handleCache using compareAndSet.  The `updateCache` methods ensure that we converge
+    // quickly on a terminal state so we will 
+    // method will simply ensure that we only save one.  The reason for this is that the `getHandle`
+    // method can be invoked by multiple threads concurrently and can be re-entrant. For a single
+    // thread the re-entrancy is managed by the `LinkageContext` class but for multiple threads do
+    // not have a solution. So holding a lock while constructing handles could lead to a deadlock.
+    // Instead we just ensure that exactly one handle is actually stored and races instead just
+    // create garbage handles.
+    var result = context.makeHandle(this, linked);
+    return HandleCache.getHandleAndMaybeUpdateCache(this, linked, result);
   }
 
-  abstract MethodHandle makeHandle(LinkageContext context, boolean linked);
+  /**
+   * Produce the method handle for the object to be injected.
+   *
+   * @param context should be propagated to delegate {@link #getHandle(LinkageContext, boolean)}
+   *     calls
+   * @param linked true if getting as a result of a linked binding
+   * @return a {@link MethodHandleResult} containing the method handle and its cachability settings
+   */
+  abstract MethodHandleResult makeHandle(LinkageContext context, boolean linked);
+
+  static MethodHandleResult makeCachable(MethodHandle methodHandle) {
+    return new MethodHandleResult(methodHandle, MethodHandleResult.Cachability.ALWAYS);
+  }
+  static MethodHandleResult makeCachableOnLinkedSetting(MethodHandle methodHandle) {
+    return new MethodHandleResult(methodHandle, MethodHandleResult.Cachability.ON_LINKED_SETTING);
+  }
+  static MethodHandleResult makeUncachable(MethodHandle methodHandle) {
+    return new MethodHandleResult(methodHandle, MethodHandleResult.Cachability.NEVER);
+  }
+  static final class MethodHandleResult {
+    static enum Cachability {
+      ALWAYS,
+      ON_LINKED_SETTING ,
+      NEVER,
+    }
+
+    
+    final MethodHandle methodHandle;
+    final Cachability cachability;
+
+    private MethodHandleResult(MethodHandle methodHandle, Cachability cachability) {
+      this.methodHandle = methodHandle;
+      this.cachability = cachability;
+    }
+  }
 
   /**
    * Returns a provider for the object to be injected using the given factory.
@@ -173,4 +230,152 @@ abstract class InternalFactory<T> {
       return factory.toString();
     }
   }
+
+  /**
+   * A small latice of classes that can handle the cache transitions that may occur.
+   *
+   * <p>Each cache object is immutable and updates require creating new cache objects.
+   */
+  private abstract static class HandleCache {
+
+    static MethodHandle getHandleAndMaybeUpdateCache(
+        InternalFactory<?> factory, boolean linked, MethodHandleResult result) {
+      if (result.cachability == MethodHandleResult.Cachability.NEVER) {
+        return result.methodHandle;
+      }
+
+      // Update the cache under the factory lock to ensure that we pick a consistent winner.
+      // NOTE: we could perform the cache updates outside of the lock and use a CAS style pattern
+      // but that seems like overkill since the `updateCache` methods are very fast and simple.
+      HandleCache cache;
+      synchronized (factory) {
+        cache = factory.handleCache.updateCache(linked, result);
+        factory.handleCache = cache;
+      }
+      return cache.getHandle(linked);
+    }
+
+    static final HandleCache EMPTY = new EmptyCache();
+
+    /** Returns the cached handle or `null` matching the {@code linked} setting. */
+    @Nullable
+    abstract MethodHandle getHandle(boolean linked);
+
+    /**
+     * Updates the cache using the given result for the {@code linked} setting.
+     * 
+     * Returns a new cache object that should be used to update the cache.
+    */
+    abstract HandleCache updateCache(boolean linked, MethodHandleResult result);
+
+    /** An always empty cache, suitable for starting the cache process. */
+    private static final class EmptyCache extends HandleCache {
+      @Override
+      MethodHandle getHandle(boolean linked) {
+        return null;
+      }
+
+      @Override
+      HandleCache updateCache(boolean linked, MethodHandleResult result) {
+        switch (result.cachability) {
+          case NEVER:
+            throw new IllegalArgumentException("Caller should have handled NEVER");
+          case ON_LINKED_SETTING:
+            return new PartialLinkedCache(linked, result.methodHandle);
+          case ALWAYS:
+            return new AlwaysCache(result.methodHandle);
+        }
+        throw new AssertionError("Unsupported cachability: " + result.cachability);
+      }
+    }
+
+    /**
+     * A cache that is only partially filled with a handle that is sensitive the the `{@code linked}
+     * setting.
+     */
+    private static final class PartialLinkedCache extends HandleCache {
+      private final boolean linked;
+      private final MethodHandle handle;
+
+      PartialLinkedCache(boolean linked, MethodHandle result) {
+        this.linked = linked;
+        this.handle = result;
+      }
+
+      @Override
+      MethodHandle getHandle(boolean linked) {
+        return  linked == this.linked ? handle : null;
+      }
+
+      @Override
+      HandleCache updateCache(boolean linked, MethodHandleResult result) {
+        checkArgument(
+            result.cachability == MethodHandleResult.Cachability.ON_LINKED_SETTING,
+            "Once a cache has transitioned to ON_LINKED_SETTING racy updates shouldn't have a"
+                + " different setting, got %s",
+            result.cachability);
+        var thisLinked = this.linked;
+        if (linked == thisLinked) {
+          return this; // caller lost a race condition
+        }
+        if (thisLinked) {
+          return new FullLinkedCache(handle, result.methodHandle);
+        }
+        return new FullLinkedCache(result.methodHandle, handle);
+      }
+    }
+
+    /** A full cache for handles that are sensitive to the {@code linked} setting. */
+    private static final class FullLinkedCache extends HandleCache {
+      private final MethodHandle linkedHandle;
+      private final MethodHandle notLinkedHandle;
+
+      FullLinkedCache(MethodHandle linkedHandle, MethodHandle notLinkedHandle) {
+        this.linkedHandle = linkedHandle;
+        this.notLinkedHandle = notLinkedHandle;
+      }
+
+      @Override
+      MethodHandle getHandle(boolean linked) {
+        return linked ? linkedHandle : notLinkedHandle;
+      }
+
+      @Override
+      HandleCache updateCache(boolean linked, MethodHandleResult result) {
+        checkArgument(
+            result.cachability == MethodHandleResult.Cachability.ON_LINKED_SETTING,
+            "Once a cache has transitioned to ON_LINKED_SETTING racy updates shouldn't have a"
+                + " different setting, got %s",
+            result.cachability);
+        // Ignore the result since we are always cachable and already cached.
+        return this;
+      }
+    }
+
+    /** A cache holding a handle that is not sensitive to the {@code linked} setting. */
+    private static final class AlwaysCache extends HandleCache{
+      private final MethodHandle handle;
+
+      AlwaysCache(MethodHandle handle) {
+        this.handle = handle;
+      }
+
+      @Override
+      MethodHandle getHandle(boolean linked) {
+        return handle;
+      }
+
+      @Override
+      HandleCache updateCache(boolean linked, MethodHandleResult result) {
+        checkArgument(
+            result.cachability == MethodHandleResult.Cachability.ALWAYS,
+            "Once a cache has transitioned to ALWAYS racy updatee shouldn't have a different"
+                + " setting, got %s",
+            result.cachability);
+        // Ignore the result since we are always cachable and already cached.
+        return this;
+      }
+    }
+  }
+
 }

--- a/core/src/com/google/inject/internal/InternalFactory.java
+++ b/core/src/com/google/inject/internal/InternalFactory.java
@@ -53,14 +53,13 @@ interface InternalFactory<T> {
    * of the object to be injected as determined by the {@link Dependency}.
    *
    * @param context the linkage context
-   * @param dependency the dependency to be injected
    * @param linked true if getting as a result of a linked binding
    * @return the method handle for the object to be injected
    */
-  default MethodHandle getHandle(LinkageContext context, Dependency<?> dependency, boolean linked) {
+  default MethodHandle getHandle(LinkageContext context, boolean linked) {
     // The default implementation simply delegates to the `get` method.
     MethodHandle handle = InternalMethodHandles.INTERNAL_FACTORY_GET_HANDLE.bindTo(this);
-    return MethodHandles.insertArguments(handle, 1, dependency, linked);
+    return MethodHandles.insertArguments(handle, 2, linked);
   }
 
   /**

--- a/core/src/com/google/inject/internal/InternalFactory.java
+++ b/core/src/com/google/inject/internal/InternalFactory.java
@@ -27,7 +27,7 @@ import java.lang.invoke.MethodHandle;
  *
  * @author crazybob@google.com (Bob Lee)
  */
-interface InternalFactory<T> {
+abstract class InternalFactory<T> {
 
   /**
    * Creates an object to be injected.
@@ -37,11 +37,11 @@ interface InternalFactory<T> {
    * @throws com.google.inject.internal.InternalProvisionException if a value cannot be provided
    * @return instance that was created
    */
-  T get(InternalContext context, Dependency<?> dependency, boolean linked)
+  abstract T get(InternalContext context, Dependency<?> dependency, boolean linked)
       throws InternalProvisionException;
 
   /** Returns a provider for the object to be injected. */
-  default Provider<T> makeProvider(InjectorImpl injector, Dependency<?> dependency) {
+  Provider<T> makeProvider(InjectorImpl injector, Dependency<?> dependency) {
     return makeDefaultProvider(this, injector, dependency);
   }
 

--- a/core/src/com/google/inject/internal/InternalFactoryToInitializableAdapter.java
+++ b/core/src/com/google/inject/internal/InternalFactoryToInitializableAdapter.java
@@ -49,12 +49,9 @@ final class InternalFactoryToInitializableAdapter<T> extends ProviderInternalFac
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, Dependency<?> dependency, boolean linked) {
+  public MethodHandle getHandle(LinkageContext context, boolean linked) {
     return circularGetHandle(
-        InternalMethodHandles.initializableFactoryGetHandle(
-            initializable, jakarta.inject.Provider.class),
-        dependency,
-        provisionCallback);
+        InternalMethodHandles.initializableFactoryGetHandle(initializable), provisionCallback);
   }
 
   @Override

--- a/core/src/com/google/inject/internal/InternalFactoryToInitializableAdapter.java
+++ b/core/src/com/google/inject/internal/InternalFactoryToInitializableAdapter.java
@@ -49,7 +49,7 @@ final class InternalFactoryToInitializableAdapter<T> extends ProviderInternalFac
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, boolean linked) {
+  MethodHandle makeHandle(LinkageContext context, boolean linked) {
     return circularGetHandle(
         InternalMethodHandles.initializableFactoryGetHandle(initializable), provisionCallback);
   }

--- a/core/src/com/google/inject/internal/InternalFactoryToInitializableAdapter.java
+++ b/core/src/com/google/inject/internal/InternalFactoryToInitializableAdapter.java
@@ -19,7 +19,7 @@ package com.google.inject.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.inject.spi.Dependency;
-import java.lang.invoke.MethodHandle;
+import com.google.inject.spi.ProviderInstanceBinding;
 
 /**
  * Adapts {@link ProviderInstanceBinding} providers, ensuring circular proxies fail (or proxy)
@@ -49,9 +49,10 @@ final class InternalFactoryToInitializableAdapter<T> extends ProviderInternalFac
   }
 
   @Override
-  MethodHandle makeHandle(LinkageContext context, boolean linked) {
-    return circularGetHandle(
-        InternalMethodHandles.initializableFactoryGetHandle(initializable), provisionCallback);
+  MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+    return makeCachable(
+        circularGetHandle(
+            InternalMethodHandles.initializableFactoryGetHandle(initializable), provisionCallback));
   }
 
   @Override

--- a/core/src/com/google/inject/internal/InternalFactoryToScopedProviderAdapter.java
+++ b/core/src/com/google/inject/internal/InternalFactoryToScopedProviderAdapter.java
@@ -73,29 +73,29 @@ class InternalFactoryToScopedProviderAdapter<T> implements InternalFactory<T> {
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, Dependency<?> dependency, boolean linked) {
+  public MethodHandle getHandle(LinkageContext context, boolean linked) {
     // Call Provider.get() on the constant provider
     // ()->Object
     var invokeProvider =
         InternalMethodHandles.getProvider(
             MethodHandles.constant(jakarta.inject.Provider.class, provider));
 
+    // Satisfy the signature for the factory protocol.
+    // (InternalContext, Dependency) -> Object
+    invokeProvider =
+        MethodHandles.dropArguments(invokeProvider, 0, InternalContext.class, Dependency.class);
     // null check the result using the dependency.
     // ()->Object
-    invokeProvider = InternalMethodHandles.nullCheckResult(invokeProvider, source, dependency);
+    invokeProvider = InternalMethodHandles.nullCheckResult(invokeProvider, source);
     // Catch any RuntimeException as an InternalProvisionException.
     // ()->Object
     invokeProvider =
         InternalMethodHandles.catchErrorInProviderAndRethrowWithSource(invokeProvider, source);
-    // (InternalContext) -> Object
-    // Add an InternalContext argument to match the factory protocol.
-    invokeProvider = MethodHandles.dropArguments(invokeProvider, 0, InternalContext.class);
+
     // We need to call 'setDependency' so it is available to scope implementations and scope
     // delegate providers. See comment in `get` method for more details.
     invokeProvider =
-        MethodHandles.foldArguments(
-            invokeProvider,
-            MethodHandles.insertArguments(INTERNAL_CONTEXT_SET_DEPENDENCY_HANDLE, 1, dependency));
+        MethodHandles.foldArguments(invokeProvider, INTERNAL_CONTEXT_SET_DEPENDENCY_HANDLE);
     return invokeProvider;
   }
 
@@ -150,24 +150,21 @@ class InternalFactoryToScopedProviderAdapter<T> implements InternalFactory<T> {
     }
 
     @Override
-    public MethodHandle getHandle(
-        LinkageContext context, Dependency<?> dependency, boolean linked) {
+    public MethodHandle getHandle(LinkageContext context, boolean linked) {
       // If it is somehow already initialized, we can return a constant handle.
       Object value = this.value;
       if (value != UNINITIALIZED_VALUE) {
-        return getHandleForConstant(dependency, source, value);
+        return getHandleForConstant(source, value);
       }
       // Otherwise we bind to a callsite that will patch itself once it is initialized.
-      return new SingletonCallSite(super.getHandle(context, dependency, linked), dependency, source)
-          .dynamicInvoker();
+      return new SingletonCallSite(super.getHandle(context, linked), source).dynamicInvoker();
     }
 
-    private static MethodHandle getHandleForConstant(
-        Dependency<?> dependency, Object source, Object value) {
+    private static MethodHandle getHandleForConstant(Object source, Object value) {
       var handle = InternalMethodHandles.constantFactoryGetHandle(value);
       // Since this is a constant, we only need to null check if it is actually null.
       if (value == null) {
-        handle = InternalMethodHandles.nullCheckResult(handle, source, dependency);
+        handle = InternalMethodHandles.nullCheckResult(handle, source);
       }
       return handle;
     }
@@ -183,33 +180,26 @@ class InternalFactoryToScopedProviderAdapter<T> implements InternalFactory<T> {
           findVirtualOrDie(
               SingletonCallSite.class,
               "boostrapCallSite",
-              methodType(Object.class, InternalContext.class, Object.class));
+              methodType(Object.class, Object.class, InternalContext.class, Dependency.class));
 
-      private final Dependency<?> dependency;
       private final Object source;
 
-      SingletonCallSite(MethodHandle actualGetHandle, Dependency<?> dependency, Object source) {
+      SingletonCallSite(MethodHandle actualGetHandle, Object source) {
         super(actualGetHandle.type());
-        this.dependency = dependency;
         this.source = source;
         // Invoke the 'actual' handle and then pass the result to the `boostrapCallSite` method.
         // This will allow us to eventually 'fold' the result into the callsite.
         // (InternalContext, InternalContext) -> Object
         var invokeBootstrap =
-            MethodHandles.filterArguments(BOOTSTRAP_CALL_MH.bindTo(this), 1, actualGetHandle);
-        // Merge the two internalContext parameters into one.
-        // (InternalContext) -> Object
-        invokeBootstrap =
-            MethodHandles.permuteArguments(
-                invokeBootstrap, InternalMethodHandles.FACTORY_TYPE, new int[2]);
+            MethodHandles.foldArguments(BOOTSTRAP_CALL_MH.bindTo(this), actualGetHandle);
         setTarget(invokeBootstrap);
       }
 
       @Keep
-      Object boostrapCallSite(InternalContext context, Object result) {
-        // Don't cache circular proxies.
+      Object boostrapCallSite(Object result, InternalContext context, Dependency<?> dependency) {
+        // Don't cache circular, proxies.
         if (!context.areCircularProxiesEnabled() || !BytecodeGen.isCircularProxy(result)) {
-          setTarget(getHandleForConstant(dependency, source, result));
+          setTarget(getHandleForConstant(source, result));
           // This ensures that other threads will see the new target.  This isn't strictly necessary
           // since the underlying provider is both ThreadSafe and idempotent, but it should improve
           // performance by giving the JIT and easy optimization opportunity.

--- a/core/src/com/google/inject/internal/InternalFactoryToScopedProviderAdapter.java
+++ b/core/src/com/google/inject/internal/InternalFactoryToScopedProviderAdapter.java
@@ -34,7 +34,7 @@ import java.lang.invoke.MutableCallSite;
  *
  * @author crazybob@google.com (Bob Lee)
  */
-class InternalFactoryToScopedProviderAdapter<T> implements InternalFactory<T> {
+class InternalFactoryToScopedProviderAdapter<T> extends InternalFactory<T> {
   /** Creates a factory around a scoped provider. */
   static <T> InternalFactoryToScopedProviderAdapter<T> create(
       Scope scopeInstance, Provider<? extends T> provider, Object source) {

--- a/core/src/com/google/inject/internal/InternalFactoryToScopedProviderAdapter.java
+++ b/core/src/com/google/inject/internal/InternalFactoryToScopedProviderAdapter.java
@@ -73,7 +73,7 @@ class InternalFactoryToScopedProviderAdapter<T> extends InternalFactory<T> {
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, boolean linked) {
+  MethodHandle makeHandle(LinkageContext context, boolean linked) {
     // Call Provider.get() on the constant provider
     // ()->Object
     var invokeProvider =
@@ -150,14 +150,14 @@ class InternalFactoryToScopedProviderAdapter<T> extends InternalFactory<T> {
     }
 
     @Override
-    public MethodHandle getHandle(LinkageContext context, boolean linked) {
+    MethodHandle makeHandle(LinkageContext context, boolean linked) {
       // If it is somehow already initialized, we can return a constant handle.
       Object value = this.value;
       if (value != UNINITIALIZED_VALUE) {
         return getHandleForConstant(source, value);
       }
       // Otherwise we bind to a callsite that will patch itself once it is initialized.
-      return new SingletonCallSite(super.getHandle(context, linked), source).dynamicInvoker();
+      return new SingletonCallSite(super.makeHandle(context, linked), source).dynamicInvoker();
     }
 
     private static MethodHandle getHandleForConstant(Object source, Object value) {

--- a/core/src/com/google/inject/internal/InternalFactoryToScopedProviderAdapter.java
+++ b/core/src/com/google/inject/internal/InternalFactoryToScopedProviderAdapter.java
@@ -91,7 +91,7 @@ class InternalFactoryToScopedProviderAdapter<T> extends InternalFactory<T> {
     // Catch any RuntimeException as an InternalProvisionException.
     // ()->Object
     invokeProvider =
-        InternalMethodHandles.catchErrorInProviderAndRethrowWithSource(invokeProvider, source);
+        InternalMethodHandles.catchRuntimeExceptionInProviderAndRethrowWithSource(invokeProvider, source);
 
     // We need to call 'setDependency' so it is available to scope implementations and scope
     // delegate providers. See comment in `get` method for more details.

--- a/core/src/com/google/inject/internal/InternalMethodHandles.java
+++ b/core/src/com/google/inject/internal/InternalMethodHandles.java
@@ -228,13 +228,6 @@ public final class InternalMethodHandles {
         castReturnTo(providerHandle, jakarta.inject.Provider.class), PROVIDER_GET_HANDLE);
   }
 
-  /** Direct handle for {@link InternalFactory#get} */
-  static final MethodHandle INTERNAL_FACTORY_GET_HANDLE =
-      findVirtualOrDie(
-          InternalFactory.class,
-          "get",
-          methodType(Object.class, InternalContext.class, Dependency.class, boolean.class));
-
   static MethodHandle findStaticOrDie(Class<?> clazz, String name, MethodType type) {
     try {
       return lookup.findStatic(clazz, name, type);

--- a/core/src/com/google/inject/internal/InternalMethodHandles.java
+++ b/core/src/com/google/inject/internal/InternalMethodHandles.java
@@ -17,7 +17,6 @@ package com.google.inject.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.invoke.MethodType.methodType;
-import static java.util.Arrays.stream;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PROTECTED;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
@@ -34,10 +33,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ObjectArrays;
 import com.google.errorprone.annotations.ForOverride;
 import com.google.errorprone.annotations.Keep;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.internal.ProvisionListenerStackCallback.ProvisionCallback;
@@ -75,16 +72,35 @@ public final class InternalMethodHandles {
   /**
    * The type of the method handle for {@link InternalFactory#getHandle}.
    *
-   * <p>In theory we could specialize types for handles to be more specific, and this might even
-   * allow us to do something cool like support {@code @Provides int provideInt() { return 1; }}
-   * without boxing. However, this adds a fair bit of complexity as every single factory helper in
-   * this file would need to support generic returns (e.g. the try-catch and finally adapters), this
-   * is achievable but would be a fair bit of complexity for a small performance win. Instead we
-   * model everything as returning Object and rely on various injection sinks to enforce
+   * <p>It accepts an {@link InternalContext} and a {@link Dependency} and returns an {@link
+   * Object}.
+   *
+   * <p>In theory we could specialize return types for handles to be more specific, and this might
+   * even allow us to do something cool like support {@code @Provides int provideInt() { return 1;
+   * }} without boxing. However, this adds a fair bit of complexity as every single factory helper
+   * in this file would need to support generic returns (e.g. the try-catch and finally adapters),
+   * this is achievable but would be a fair bit of complexity for a small performance win. Instead
+   * we model everything as returning Object and rely on various injection sinks to enforce
    * correctness, which is the same strategy that we use for the `InternalFactory.get` protocol.
    */
-  static final MethodType FACTORY_TYPE = methodType(Object.class, InternalContext.class);
+  static final MethodType FACTORY_TYPE =
+      methodType(Object.class, InternalContext.class, Dependency.class);
 
+  /** The type of a factory that has encapsulated the Dependency. */
+  static final MethodType ELEMENT_FACTORY_TYPE = methodType(Object.class, InternalContext.class);
+
+  static void checkHasFactoryType(MethodHandle handle) {
+    checkArgument(
+        handle.type().equals(FACTORY_TYPE), "Expected %s to have type %s", handle, FACTORY_TYPE);
+  }
+
+  static void checkHasElementFactoryType(MethodHandle handle) {
+    checkArgument(
+      handle.type().equals(ELEMENT_FACTORY_TYPE),
+      "Element handle must be an element factory type %s got %s",
+      ELEMENT_FACTORY_TYPE,
+      handle.type());
+  }
   /**
    * A handle for {@link BiFunction#apply}, useful for targeting fastclasses.
    *
@@ -260,29 +276,30 @@ public final class InternalMethodHandles {
   }
 
   /**
-   * Returns a method handle with the signature {@code (InternalContext) -> Object} that returns the
+   * Returns a method handle with the signature {@code (InternalContext, Dependency) -> Object} that returns the
    * given instance.
    */
   static MethodHandle constantFactoryGetHandle(Object instance) {
+    return MethodHandles.dropArguments(
+        MethodHandles.constant(Object.class, instance), 0, InternalContext.class, Dependency.class);
+  }
+
+  /**
+   * Returns a method handle with the signature {@code (InternalContext) -> Object} that returns the
+   * given instance.
+   */
+  static MethodHandle constantElementFactoryGetHandle(Object instance) {
     return MethodHandles.dropArguments(
         MethodHandles.constant(Object.class, instance), 0, InternalContext.class);
   }
 
   /**
-   * Returns a method handle with the signature {@code (InternalContext) -> T} that returns the
-   * result of the given initializable.
+   * Returns a method handle with the {@link #FACTORY_TYPE} signature that returns the result of the
+   * given initializable.
    */
   static MethodHandle initializableFactoryGetHandle(Initializable<?> initializable) {
-    return new InitializableCallSite(initializable).dynamicInvoker();
-  }
-
-  /**
-   * Returns a method handle with the signature {@code (InternalContext) -> T} that returns the
-   * result of the given initializable.
-   */
-  static MethodHandle initializableFactoryGetHandle(
-      Initializable<?> initializable, Class<?> forType) {
-    return new InitializableCallSite(initializable).dynamicInvoker();
+    return MethodHandles.dropArguments(
+        new InitializableCallSite(initializable).dynamicInvoker(), 1, Dependency.class);
   }
 
   /**
@@ -317,7 +334,7 @@ public final class InternalMethodHandles {
             methodType(Object.class, Initializable.class, InternalContext.class));
 
     InitializableCallSite(Initializable<?> initializable) {
-      super(FACTORY_TYPE);
+      super(ELEMENT_FACTORY_TYPE);
       // Have the first call go to `bootstrapCall` which will set the target to the constant
       // factory get handle if the initializable succeeds.
       setTarget(MethodHandles.insertArguments(BOOTSTRAP_CALL_MH.bindTo(this), 0, initializable));
@@ -331,7 +348,7 @@ public final class InternalMethodHandles {
       // We also do not synchronize and instead rely on the underlying initializable to enforce
       // single-initialization semantics, but we publish via a volatile call site.
       Object value = initializable.get(context);
-      setTarget(constantFactoryGetHandle(value));
+      setTarget(constantElementFactoryGetHandle(value));
       // This ensures that other threads will see the new target.  This isn't strictly necessary
       // since Initializable is both ThreadSafe and idempotent, but it should improve performance
       // by allowing the JIT to inline the constant.
@@ -347,26 +364,34 @@ public final class InternalMethodHandles {
    * <p>The returned handle has the same type as the delegate.
    */
   static MethodHandle nullCheckResult(
-      MethodHandle delegate, Object source, Dependency<?> dependency) {
-    if (dependency.isNullable()) {
-      return delegate;
-    }
-    // (Object) -> Object
+      MethodHandle delegate, Object source) {
+    var type = delegate.type();
+    checkArgument(
+        type.parameterCount() >= 2
+            && type.parameterType(0).equals(InternalContext.class)
+            && type.parameterType(1).equals(Dependency.class),
+        "Expected %s to have an initial InternalContext and Dependency parameter",
+        delegate);
+    // (Object, InternalContext, Dependency) -> Object
     var nullCheckResult =
-        MethodHandles.insertArguments(NULL_CHECK_RESULT_MH, 1, source, dependency);
-    return MethodHandles.filterReturnValue(delegate, nullCheckResult);
+        MethodHandles.insertArguments(NULL_CHECK_RESULT_MH, 1, source);
+    if (type.parameterCount() > 2) {
+      // (InternalContext, Dependency) -> Object
+      nullCheckResult = MethodHandles.dropArguments(nullCheckResult, 3, type.parameterList().subList(2, type.parameterCount()));
+    }
+    return MethodHandles.foldArguments(nullCheckResult, delegate);
   }
 
   private static final MethodHandle NULL_CHECK_RESULT_MH =
       findStaticOrDie(
           InternalMethodHandles.class,
           "doNullCheckResult",
-          methodType(Object.class, Object.class, Object.class, Dependency.class));
+          methodType(Object.class, Object.class, Object.class, InternalContext.class, Dependency.class));
 
   @Keep
-  private static Object doNullCheckResult(Object result, Object source, Dependency<?> dependency)
+  private static Object doNullCheckResult(Object result, Object source, InternalContext ignored, Dependency<?> dependency)
       throws InternalProvisionException {
-    if (result == null) {
+    if (result == null && !dependency.isNullable()) {
       // This will either throw, warn or do nothing.
       InternalProvisionException.onNullInjectedIntoNonNullableDependency(source, dependency);
     }
@@ -386,17 +411,15 @@ public final class InternalMethodHandles {
    */
   static final MethodHandle invokeThroughProvisionCallback(
       MethodHandle delegate,
-      Dependency<?> dependency,
       @Nullable ProvisionListenerStackCallback<?> listener) {
     var type = delegate.type();
     checkArgument(type.parameterType(0).equals(InternalContext.class));
+    checkArgument(type.parameterType(1).equals(Dependency.class));
     if (listener == null) {
       return delegate;
     }
-    // (InternalContext, ProvisionCallback)->Object
-    var provision =
-        MethodHandles.insertArguments(
-            PROVISION_CALLBACK_PROVISION_HANDLE.bindTo(listener), 1, dependency);
+    // (InternalContext, Dependency, ProvisionCallback)->Object
+    var provision = PROVISION_CALLBACK_PROVISION_HANDLE.bindTo(listener);
     // Support a few kinds of provision callbacks, as needed.
     // The problem we have is that we need to create a MethodHandle that constructs a
     // ProvisionCallback around the delegate.  If the delegate only accepts an InternalContext then
@@ -404,44 +427,40 @@ public final class InternalMethodHandles {
     // has other 'free' parameters we will need to construct a MethodHandle that accepts those free
     // parameters and constructs a ProvisionCallback that calls the delegate with those parameters
     // plus the InternalContext and the ProvisionCallback.
-    switch (type.parameterCount()) {
-      case 1:
-        {
-          // By allocating the delegate here it will be a constant across all invocations.
-          var finalDelegate = delegate.asType(FACTORY_TYPE);
-          ProvisionCallback<Object> callback =
-              (ctx, dep) -> {
-                try {
-                  // This invokeExact is not as fast as it could be since the `delegate` is not
-                  // constant foldable. The only solution to that is custom bytecode generation, but
-                  // that probably isn't worth the effort since provision callbacks are rare.
-                  return (Object) finalDelegate.invokeExact(ctx);
-                } catch (Throwable t) {
-                  // This is lame but is needed to work around the different exception semantics of
-                  // method handles.  In reality this is either a InternalProvisionException or a
-                  // RuntimeException. Both of which are throwable by this method.
-                  // The only alternative is to generate bytecode to call the method handle which
-                  // avoids this problem at great expense.
-                  throw sneakyThrow(t);
-                }
-              };
-          return MethodHandles.insertArguments(provision, 1, callback).asType(delegate.type());
-        }
-      case 2:
-        var callback =
-            MethodHandles.insertArguments(
-                MAKE_PROVISION_CALLBACK_1_HANDLE,
-                0,
-                delegate.asType(
-                    delegate
-                        .type()
-                        .changeReturnType(Object.class)
-                        .changeParameterType(1, Object.class)));
-        return MethodHandles.filterArguments(provision, 1, callback).asType(delegate.type());
-      default:
-        // We could add support for more cases here as needed.
-        throw new IllegalArgumentException(
-            "Unexpected number of parameters to delegate: " + type.parameterCount());
+    if (type.equals(FACTORY_TYPE)) {
+      ProvisionCallback<Object> callback =
+          (ctx, dep) -> {
+            try {
+              // This invokeExact is not as fast as it could be since the `delegate` is not
+              // constant foldable. The only solution to that is custom bytecode generation, but
+              // that probably isn't worth the effort since provision callbacks are rare.
+              return (Object) delegate.invokeExact(ctx, dep);
+            } catch (Throwable t) {
+              // This is lame but is needed to work around the different exception semantics of
+              // method handles.  In reality this is either a InternalProvisionException or a
+              // RuntimeException. Both of which are throwable by this method.
+              // The only alternative is to generate bytecode to call the method handle which
+              // avoids this problem at great expense.
+              throw sneakyThrow(t);
+            }
+          };
+      return MethodHandles.insertArguments(provision, 2, callback);
+    } else if (type.parameterCount() == 3) {
+      var callback =
+          MethodHandles.insertArguments(
+              MAKE_PROVISION_CALLBACK_1_HANDLE,
+              0,
+              delegate.asType(
+                  delegate
+                      .type()
+                      // Upcast the parameter type to Object so we don't need to care about it.
+                      .changeParameterType(2, Object.class)));
+      // Cast it back to the original type of the delegate.
+      return MethodHandles.filterArguments(provision, 2, callback).asType(delegate.type());
+    } else {
+      // We could add support for more cases here as needed.
+      throw new IllegalArgumentException(
+          "Unexpected number of parameters to delegate: " + type.parameterCount());
     }
   }
 
@@ -451,13 +470,13 @@ public final class InternalMethodHandles {
           "makeProvisionCallback",
           methodType(ProvisionCallback.class, MethodHandle.class, Object.class));
 
-  // A simple factory for the case where the delegate only has a single free parameter.
+  // A simple factory for the case where the delegate only has a single free parameter that we need to capture.
   @Keep
   private static final ProvisionCallback<Object> makeProvisionCallback(
       MethodHandle delegate, Object capture) {
     return (ctx, dep) -> {
       try {
-        return (Object) delegate.invokeExact(ctx, capture);
+        return (Object) delegate.invokeExact(ctx, dep, capture);
       } catch (Throwable t) {
         throw sneakyThrow(t);
       }
@@ -706,16 +725,16 @@ public final class InternalMethodHandles {
    * }</pre>
    */
   static MethodHandle tryStartConstruction(
-      MethodHandle delegate, Dependency<?> dependency, int circularFactoryId) {
+      MethodHandle delegate, int circularFactoryId) {
     // NOTE: we cannot optimize this further by assuming that the return value is always null when
     // circular proxies are disabled, because if parent and child injectors differ in that setting
     // then injectors with circularProxiesDisabled may still run in a context where they are enabled
     // and visa versa.
 
-    // (InternalContext)->Object
+    // (InternalContext, Dependency)->Object
     var tryStartConstruction =
         MethodHandles.insertArguments(
-            TRY_START_CONSTRUCTION_HANDLE, 1, circularFactoryId, dependency);
+            TRY_START_CONSTRUCTION_HANDLE, 1, circularFactoryId);
     // This takes the first Object parameter and casts it to the return type of the delegate.
     // It also ignores all the other parameters.
     var returnProxy =
@@ -798,11 +817,9 @@ public final class InternalMethodHandles {
                 injector,
                 factory,
                 dependency,
-                () ->
-                    new ConstantCallSite(
+                () -> 
                         factory
-                            .getHandle(new LinkageContext(), dependency, /* linked= */ false)
-                            .asType(FACTORY_TYPE)),
+                            .getHandle(new LinkageContext(), /* linked= */ false),
                 /* isScoped= */ false);
     return typedProvider;
   }
@@ -825,7 +842,8 @@ public final class InternalMethodHandles {
                 injector,
                 factory,
                 dependency,
-                () -> new ScopedDelegateCallSite(factory, dependency),
+                () ->factory
+                            .getHandle(new LinkageContext(), /* linked= */ true),
                 /* isScoped= */ true);
     return typedProvider;
   }
@@ -852,7 +870,7 @@ public final class InternalMethodHandles {
     public T get() {
       InternalContext currentContext = injector.enterContext();
       try {
-        return doGet(currentContext);
+        return doGet(currentContext, dependency);
       } catch (InternalProvisionException e) {
         throw e.addSource(dependency).toProvisionException();
       } finally {
@@ -866,7 +884,7 @@ public final class InternalMethodHandles {
     }
 
     @ForOverride
-    protected abstract T doGet(InternalContext context) throws InternalProvisionException;
+    protected abstract T doGet(InternalContext context, Dependency<?> dependency) throws InternalProvisionException;
   }
 
   /**
@@ -908,7 +926,7 @@ public final class InternalMethodHandles {
         InjectorImpl injector,
         InternalFactory<?> factory,
         Dependency<?> dependency,
-        Supplier<CallSite> handleCreator,
+        Supplier<MethodHandle> handleCreator,
         boolean isScoped) {
       // Even if we are using the anonymous classloading mechanisms we still need to pick a name,
       // it just ends up being ignored.
@@ -983,11 +1001,12 @@ public final class InternalMethodHandles {
                 /* exceptions= */ null);
         mv.visitCode();
         mv.visitVarInsn(ALOAD, 1); // ctx
+        mv.visitVarInsn(ALOAD, 2); // dependency
         mv.visitInvokeDynamicInsn("get", descriptor, BOOSTRAP_HANDLE);
         mv.visitInsn(ARETURN);
         mv.visitMaxs(
-            /* maxStack= */ 1, // Just the return value of the dynamic call
-            /* maxLocals= */ 2 // Just the 'this' and ctx parameters
+            /* maxStack= */ 2, // Just the 2 parameters
+            /* maxLocals= */ 3 // Just the 'this' and the two parameters
             );
         mv.visitEnd();
       }
@@ -1023,241 +1042,6 @@ public final class InternalMethodHandles {
     private ProviderMaker() {}
   }
 
-  /**
-   * A callsite to implement the logic for the implementation of InternalFactories that are being
-   * scoped when circular proxies are enabled.
-   *
-   * <p>To support circular proxies the {@link InternalFactoryToScopedProviderAdapter} will call
-   * {@link InternalContext#setDependency} to propagate dependency information across the scope
-   * implementation. This allows proxies to be constructed for super-interfaces that are needed at
-   * the injection point rather than the concrete type of the binding.
-   *
-   * <p>This uses a self-patching callsite that will re-patch whenever we see a new dependency. When
-   * a new dependency is seen the callsite will call through to the {@link #fallback} method which
-   * will compute the new handle and update the callsite with it. This is threadsafe because handle
-   * allocation is done under a lock and we are essentially accumulating new handles so prior ones
-   * remain available. So even if multiple threads are racing to update the callsite, they will all
-   * end up with the same set of handles.
-   */
-  private static final class ScopedDelegateCallSite extends MutableCallSite {
-    private static final MethodHandle FALLBACK_GET_HANDLE =
-        findVirtualOrDie(
-            ScopedDelegateCallSite.class,
-            "fallback",
-            methodType(Object.class, InternalContext.class));
-    private static final MethodHandle DEPENDENCY_EQUALS_HANDLE =
-        findStaticOrDie(
-            ScopedDelegateCallSite.class,
-            "dependencyEquals",
-            methodType(boolean.class, InternalContext.class, Dependency.class, Dependency.class));
-    private static final MethodHandle INVOKE_HANDLE_HANDLE =
-        findStaticOrDie(
-            ScopedDelegateCallSite.class,
-            "invokeHandle",
-            methodType(
-                Object.class,
-                ImmutableMap.class,
-                MethodHandle[].class,
-                Dependency.class,
-                MethodHandle.class,
-                InternalContext.class));
-
-    private static final MethodHandle SWITCH_KEY_HANDLE =
-        findStaticOrDie(
-            ScopedDelegateCallSite.class,
-            "switchKey",
-            methodType(int.class, ImmutableMap.class, Dependency.class, InternalContext.class));
-
-    /** {@link MethodHandles#tableSwitch} if it is available. */
-    @Nullable private static final MethodHandle TABLE_SWITCH_HANDLE;
-
-    static {
-      MethodHandle handle;
-      try {
-        handle =
-            lookup.findStatic(
-                MethodHandles.class,
-                "tableSwitch",
-                methodType(MethodHandle.class, MethodHandle.class, MethodHandle[].class));
-      } catch (Throwable t) {
-        handle = null;
-      }
-      TABLE_SWITCH_HANDLE = handle;
-    }
-
-    private final InternalFactory<?> factory;
-    private final MethodHandle fallback;
-
-    /**
-     * A dependency object for factory being scoped. So for:
-     * `bind(X.class).to(Y.class).in(Scopes.SINGLETON)`, we would allocate one of these for the `Y`
-     * provider and the this dependency object would be {@code Dependency.get(Key.get(Y.class))}.
-     *
-     * <p>This is needed because {@link InternalFactory#getHandle} requires a non-null dependency
-     * object (unlike {@link InternalFactory#get} which only sometimes requires it), so if scoped
-     * providers interacted with outside an injector context this will be the dependency that is
-     * used.
-     */
-    private final Dependency<?> bindingDependency;
-
-    // We update this map under a lock in a 'copy on write' fashion.
-    @GuardedBy("this")
-    private ImmutableMap<Dependency<?>, Integer> handleIndices = ImmutableMap.of();
-
-    @GuardedBy("this")
-    private MethodHandle[] handles = new MethodHandle[0];
-
-    ScopedDelegateCallSite(InternalFactory<?> factory, Dependency<?> bindingDependency) {
-      super(FACTORY_TYPE);
-      this.factory = factory;
-      this.bindingDependency = bindingDependency;
-      this.fallback = FALLBACK_GET_HANDLE.bindTo(this);
-      setTarget(fallback);
-    }
-
-    @Keep
-    Object fallback(InternalContext context) throws Throwable {
-      MethodHandle handle;
-      synchronized (this) {
-        Dependency<?> dependency = getDependency(context, bindingDependency);
-        int handleIndex = handleIndices.getOrDefault(dependency, -1);
-        if (handleIndex == -1) {
-          // Always pretend that we are a linked binding, to support
-          // scoping implicit bindings.  If we are not actually a linked
-          // binding, we'll fail properly elsewhere in the chain.
-          handle = factory.getHandle(new LinkageContext(), dependency, /* linked= */ true);
-          handleIndices =
-              ImmutableMap.<Dependency<?>, Integer>builder()
-                  .putAll(handleIndices)
-                  .put(dependency, handleIndices.size())
-                  .buildOrThrow();
-          handles = ObjectArrays.concat(handles, handle);
-          // Now rebuild the target
-          // Special case for a single handle, we can just use a guard.  This case is very common
-          // for bindings that are scoped and bound to a single interface.
-          // Generate `dependencyEquals(ctx, dependency) ? handle(ctx) : fallback(ctx)`
-          if (handles.length == 1) {
-            // This is a handle of type (InternalContext) -> boolean
-            var isEqual =
-                MethodHandles.insertArguments(
-                    DEPENDENCY_EQUALS_HANDLE, 1, bindingDependency, dependency);
-            setTarget(MethodHandles.guardWithTest(isEqual, handle, fallback));
-          } else {
-            // If we have multiple handles we need to pick the right one based on the dependency.
-            // in jdk17+ we can use a switch statement, but in jdk11 we need to use a simpler
-            // approach of a dispatch through a map and an Array.
-            if (TABLE_SWITCH_HANDLE != null) {
-              // Generate a switch. Switches always take an `int` as the first argument (the switch
-              // expression).  We don't actually use it in the cases, so we drop it.
-              // The function will look like
-              // Object switch(InternalContext ctx) {
-              //   int index = getSwitchIndex(handles, defaultDependency, ctx);
-              //   switch (index) {
-              //     case 0:
-              //       return handle0(ctx)
-              //     ...
-              //     case 1:
-              //       return handles1(ctx);
-              //     ...
-              //     default:
-              //       return callsite.fallback(ctx);
-              //   }
-              // }
-              // NOTE: This pattern is modeled after how the JVM generates switch statements for
-              // enums and simple class patterns.
-              var switchHandle =
-                  (MethodHandle)
-                      TABLE_SWITCH_HANDLE.invokeExact(
-                          /* fallback= */ MethodHandles.dropArguments(fallback, 0, int.class),
-                          /* targets= */ stream(handles)
-                              .map(h -> MethodHandles.dropArguments(h, 0, int.class))
-                              .toArray(MethodHandle[]::new));
-              var getIndex =
-                  MethodHandles.insertArguments(
-                      SWITCH_KEY_HANDLE, 0, handleIndices, bindingDependency);
-              // This will return a handle of type (InternalContext) -> MethodHandle
-              var executeSwitch = MethodHandles.foldArguments(switchHandle, getIndex);
-              setTarget(executeSwitch);
-            } else {
-              // If we cannot use a switch statement, we need to use a dispatch through the array.
-              // This is the jdk11 path. Generates:
-              // `invokeHandle(handles, handleIndices, bindingDependency, fallback, ctx)`
-              //
-              // The main alternative is to generate a set of guardWithTest handles that 'binary
-              // search' for the matching handle.  This would be more efficient than the
-              // exactInvoker, but would be more complicated to generate. The table switch path
-              // above should trigger most of the time so optimizing this path probably isn't that
-              // important.
-              var getHandle =
-                  MethodHandles.insertArguments(
-                      INVOKE_HANDLE_HANDLE, 0, handleIndices, handles, bindingDependency, fallback);
-              setTarget(getHandle);
-            }
-          }
-          // Ensure all callers see the update.
-          MutableCallSite.syncAll(new MutableCallSite[] {this});
-        } else {
-          handle = handles[handleIndex];
-        }
-      }
-      // For the current invocation just invoke the delegate handle directly.
-      return handle.invokeExact(context);
-    }
-
-    /**
-     * A helper to get the dependency from the context or the default dependency if that isn't
-     * available.
-     */
-    private static Dependency<?> getDependency(
-        InternalContext context, Dependency<?> bindingDependency) {
-      var dep = context.getDependency();
-      if (dep == null) {
-        // We need to handle null in case the provider is being called directly but outside of its
-        // original call-stack, so the InternalContext may not have a dependency set.
-        dep = bindingDependency;
-      }
-      return dep;
-    }
-
-    /** Used for the guard in the case that we have constructed a single delegate handle. */
-    @Keep
-    static boolean dependencyEquals(
-        InternalContext context, Dependency<?> bindingDependency, Dependency<?> dependency) {
-      return dependency.equals(getDependency(context, bindingDependency));
-    }
-
-    /**
-     * Used for the guard in the case that we have many handles and no `tableSwitch` support.
-     *
-     * <p>The caller should use a `MethodHandle.exactInvoker` to invoke the handle.
-     */
-    @Keep
-    static Object invokeHandle(
-        ImmutableMap<Dependency<?>, Integer> handleIndices,
-        MethodHandle[] handles,
-        Dependency<?> bindingDependency,
-        MethodHandle fallback,
-        InternalContext context)
-        throws Throwable {
-      int switchKey = switchKey(handleIndices, bindingDependency, context);
-      return switchKey == -1
-          ? fallback.invokeExact(context)
-          : handles[switchKey].invokeExact(context);
-    }
-
-    /**
-     * Used for the switch statement in the case that we have many handles and `tableSwitch`
-     * support.
-     */
-    @Keep
-    static int switchKey(
-        ImmutableMap<Dependency<?>, Integer> handleIndices,
-        Dependency<?> bindingDependency,
-        InternalContext context) {
-      var index = handleIndices.get(getDependency(context, bindingDependency));
-      return index == null ? -1 : index;
-    }
-  }
 
   /**
    * Our bootstrap method that is called by the generated provider.
@@ -1280,13 +1064,15 @@ public final class InternalMethodHandles {
       synchronized (lookup.getClass()) {
         handleCreator = varHandle.get();
         if (handleCreator instanceof Supplier) {
-          CallSite callSite = (CallSite) ((Supplier) handleCreator).get();
-          varHandle.setVolatile((Object) callSite);
-          return callSite;
+          MethodHandle handle = (MethodHandle) ((Supplier) handleCreator).get();
+          varHandle.setVolatile((Object) handle);
+          return new ConstantCallSite(handle);
         }
       }
     }
-    return (CallSite) handleCreator;
+    // This path means we are in some kind of race condition, produce a new identical callsite just in case
+    // we somehow end up winning.
+    return  new ConstantCallSite((MethodHandle) handleCreator);
   }
 
   // The `throws` clause tricks Java type inference into deciding that E must be some subtype of
@@ -1312,33 +1098,34 @@ public final class InternalMethodHandles {
    * }</pre>
    *
    * <p>Plus handling for some special cases.
+   * 
+   * <p>Returns a handle with the signature `(InternalContext) -> Object`.
    */
   static MethodHandle buildImmutableSetFactory(Iterable<MethodHandle> elementHandles) {
     var elementHandlesList = ImmutableList.copyOf(elementHandles);
     for (var handle : elementHandlesList) {
-      checkArgument(
-          handle.type().equals(FACTORY_TYPE),
-          "Element handle must be a factory type %s got %s",
-          handle.type(),
-          FACTORY_TYPE);
+      checkHasElementFactoryType(handle);
     }
+    MethodHandle setHandle;
     if (elementHandlesList.isEmpty()) {
       // ImmutableSet.of()
-      return constantFactoryGetHandle(ImmutableSet.of());
+      return constantElementFactoryGetHandle(ImmutableSet.of());
     }
     if (elementHandlesList.size() == 1) {
       // ImmutableSet.of(<element>(ctx))
-      return MethodHandles.filterReturnValue(elementHandlesList.get(0), IMMUTABLE_SET_OF_HANDLE)
-          .asType(FACTORY_TYPE);
-    }
-    // ImmutableSet.builderWithExpectedSize(<size>)
-    var builder =
-        MethodHandles.insertArguments(
-            IMMUTABLE_SET_BUILDER_OF_SIZE_HANDLE, 0, elementHandlesList.size());
+      setHandle =
+          MethodHandles.filterReturnValue(elementHandlesList.get(0), IMMUTABLE_SET_OF_HANDLE);
+    } else {
+      // ImmutableSet.builderWithExpectedSize(<size>)
+      var builder =
+          MethodHandles.insertArguments(
+              IMMUTABLE_SET_BUILDER_OF_SIZE_HANDLE, 0, elementHandlesList.size());
 
-    builder = MethodHandles.foldArguments(doAddToImmutableSet(elementHandlesList), builder);
-    return MethodHandles.filterReturnValue(builder, IMMUTABLE_SET_BUILDER_BUILD_HANDLE)
-        .asType(FACTORY_TYPE);
+      builder = MethodHandles.foldArguments(doAddToImmutableSet(elementHandlesList), builder);
+      setHandle = MethodHandles.filterReturnValue(builder, IMMUTABLE_SET_BUILDER_BUILD_HANDLE);
+    }
+
+    return castReturnToObject(setHandle);
   }
 
   /**
@@ -1404,10 +1191,15 @@ public final class InternalMethodHandles {
    * }</pre>
    *
    * <p>Plus handling for some special cases.
+   * 
+   * <p>Returns a handle with the signature `(InternalContext) -> Object`.
    */
   static <T> MethodHandle buildImmutableMapFactory(List<Map.Entry<T, MethodHandle>> entries) {
+    for (var entry : entries) {
+      checkHasElementFactoryType(entry.getValue());
+    }
     if (entries.isEmpty()) {
-      return InternalMethodHandles.constantFactoryGetHandle(ImmutableMap.of());
+      return InternalMethodHandles.constantElementFactoryGetHandle(ImmutableMap.of());
     }
     // ImmutableMap.Builder.of(K, V) has a special case for a single entry.
     if (entries.size() == 1) {
@@ -1415,7 +1207,7 @@ public final class InternalMethodHandles {
       return MethodHandles.filterReturnValue(
               entry.getValue(),
               MethodHandles.insertArguments(IMMUTABLE_MAP_OF_HANDLE, 0, entry.getKey()))
-          .asType(FACTORY_TYPE);
+          .asType(ELEMENT_FACTORY_TYPE);
     }
     // Otherwise, we use the builder API by chaining a bunch of put() calls.
     // It might be slightly more efficient to bind to one of the ImmutableMap.of(...) overloads
@@ -1427,7 +1219,7 @@ public final class InternalMethodHandles {
             IMMUTABLE_MAP_BUILDER_WITH_EXPECTED_SIZE_HANDLE, 0, entries.size());
     builder = MethodHandles.foldArguments(doPutEntries(entries), builder);
     return MethodHandles.filterReturnValue(builder, IMMUTABLE_MAP_BUILDER_BUILD_OR_THROW_HANDLE)
-        .asType(FACTORY_TYPE);
+        .asType(ELEMENT_FACTORY_TYPE);
   }
 
   /** Returns a handle of type (ImmutableMap.Builder, InternalContext) -> ImmutableMap.Builder */

--- a/core/src/com/google/inject/internal/InternalProviderInstanceBindingImpl.java
+++ b/core/src/com/google/inject/internal/InternalProviderInstanceBindingImpl.java
@@ -158,10 +158,9 @@ final class InternalProviderInstanceBindingImpl<T> extends ProviderInstanceBindi
     }
 
     @Override
-    public MethodHandle getHandle(
-        LinkageContext context, Dependency<?> dependency, boolean linked) {
+    public MethodHandle getHandle(LinkageContext context, boolean linked) {
       return InternalMethodHandles.invokeThroughProvisionCallback(
-          doGetHandle(context, dependency, linked), dependency, provisionCallback);
+          doGetHandle(context, linked), provisionCallback);
     }
 
     // Implements ProvisionCallback<T>
@@ -181,7 +180,6 @@ final class InternalProviderInstanceBindingImpl<T> extends ProviderInstanceBindi
         throws InternalProvisionException;
 
     /** Creates a method handle that constructs the object to be injected. */
-    protected abstract MethodHandle doGetHandle(
-        LinkageContext context, Dependency<?> dependency, boolean linked);
+    protected abstract MethodHandle doGetHandle(LinkageContext context, boolean linked);
   }
 }

--- a/core/src/com/google/inject/internal/InternalProviderInstanceBindingImpl.java
+++ b/core/src/com/google/inject/internal/InternalProviderInstanceBindingImpl.java
@@ -72,11 +72,8 @@ final class InternalProviderInstanceBindingImpl<T> extends ProviderInstanceBindi
   }
 
   /** A base factory implementation. */
-  abstract static class Factory<T>
-      implements InternalFactory<T>,
-          Provider<T>,
-          HasDependencies,
-          ProvisionListenerStackCallback.ProvisionCallback<T> {
+  abstract static class Factory<T> extends InternalFactory<T>
+      implements Provider<T>, HasDependencies, ProvisionListenerStackCallback.ProvisionCallback<T> {
     private final InitializationTiming initializationTiming;
     private Object source;
     private InjectorImpl injector;

--- a/core/src/com/google/inject/internal/InternalProviderInstanceBindingImpl.java
+++ b/core/src/com/google/inject/internal/InternalProviderInstanceBindingImpl.java
@@ -155,9 +155,10 @@ final class InternalProviderInstanceBindingImpl<T> extends ProviderInstanceBindi
     }
 
     @Override
-    MethodHandle makeHandle(LinkageContext context, boolean linked) {
-      return InternalMethodHandles.invokeThroughProvisionCallback(
-          doGetHandle(context, linked), provisionCallback);
+    MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+      return makeCachable(
+          InternalMethodHandles.invokeThroughProvisionCallback(
+              doGetHandle(context), provisionCallback));
     }
 
     // Implements ProvisionCallback<T>
@@ -177,6 +178,6 @@ final class InternalProviderInstanceBindingImpl<T> extends ProviderInstanceBindi
         throws InternalProvisionException;
 
     /** Creates a method handle that constructs the object to be injected. */
-    protected abstract MethodHandle doGetHandle(LinkageContext context, boolean linked);
+    protected abstract MethodHandle doGetHandle(LinkageContext context);
   }
 }

--- a/core/src/com/google/inject/internal/InternalProviderInstanceBindingImpl.java
+++ b/core/src/com/google/inject/internal/InternalProviderInstanceBindingImpl.java
@@ -155,7 +155,7 @@ final class InternalProviderInstanceBindingImpl<T> extends ProviderInstanceBindi
     }
 
     @Override
-    public MethodHandle getHandle(LinkageContext context, boolean linked) {
+    MethodHandle makeHandle(LinkageContext context, boolean linked) {
       return InternalMethodHandles.invokeThroughProvisionCallback(
           doGetHandle(context, linked), provisionCallback);
     }

--- a/core/src/com/google/inject/internal/LinkageContext.java
+++ b/core/src/com/google/inject/internal/LinkageContext.java
@@ -22,6 +22,8 @@ import java.lang.invoke.MutableCallSite;
 import java.util.IdentityHashMap;
 import java.util.function.Supplier;
 
+import com.google.inject.internal.InternalFactory.MethodHandleResult;
+
 /**
  * Linkage context allows circular factories to bind to themselves recursively when needed.
  *
@@ -58,7 +60,7 @@ final class LinkageContext {
    * @return a method handle that will invoke the given factory, resolving cycles as needed, using
    *     the {@link InternalFactory#FACTORY_TYPE} signature.
    */
-  MethodHandle makeHandle(InternalFactory<?> factory, boolean linked) {
+  MethodHandleResult makeHandle(InternalFactory<?> factory, boolean linked) {
     var previous = linkingFactories.putIfAbsent(factory, CONSTRUCTING);
     if (previous == CONSTRUCTING) {
       // We are the first to 're-enter' this factory, so we need to create a MutableCallSite that
@@ -70,19 +72,24 @@ final class LinkageContext {
       // We are re-entering the same factory, so we can just return the dynamic invoker and rely on
       // the original invocation to finish the construction and call setTarget to finalize the
       // callsite.
-      return ((MutableCallSite) previous).dynamicInvoker();
+      // We instruct the caller to not cache the result since we don't know if the `factory` would
+      // produce a handle that was always cachable or `makeCachableOnLinkedSetting`.
+      // This shouldn't be too wasteful since any later attempt to enter this cycle will hit a cache
+      // on one of the other factories in the cycle.  Furthermore, since this is in a recursive call
+      // we will simply cache the result of the first call when _it_ returns.
+      return InternalFactory.makeUncachable(((MutableCallSite) previous).dynamicInvoker());
     } else {
       checkState(previous == null, "Unexpected previous value: %s", previous);
     }
-    MethodHandle handle = factory.makeHandle(this, linked);
-    InternalMethodHandles.checkHasFactoryType(handle);
+    MethodHandleResult result = factory.makeHandle(this, linked);
+    InternalMethodHandles.checkHasFactoryType(result.methodHandle);
     previous = linkingFactories.remove(factory);
     checkState(previous != null, "construction state was cleared already?");
     if (previous != CONSTRUCTING) {
       var callSite = (MutableCallSite) previous;
-      callSite.setTarget(handle);
+      callSite.setTarget(result.methodHandle);
       MutableCallSite.syncAll(new MutableCallSite[] {callSite});
     }
-    return handle;
+    return result;
   }
 }

--- a/core/src/com/google/inject/internal/LinkageContext.java
+++ b/core/src/com/google/inject/internal/LinkageContext.java
@@ -75,6 +75,7 @@ final class LinkageContext {
       checkState(previous == null, "Unexpected previous value: %s", previous);
     }
     MethodHandle handle = factory.get();
+    InternalMethodHandles.checkHasFactoryType(handle);
     previous = linkingFactories.remove(source);
     checkState(previous != null, "construction state was cleared already?");
     if (previous != CONSTRUCTING) {

--- a/core/src/com/google/inject/internal/MembersInjectorImpl.java
+++ b/core/src/com/google/inject/internal/MembersInjectorImpl.java
@@ -35,34 +35,64 @@ import javax.annotation.Nullable;
  *
  * @author jessewilson@google.com (Jesse Wilson)
  */
-final class MembersInjectorImpl<T> implements MembersInjector<T> {
-  private final TypeLiteral<T> typeLiteral;
-  private final InjectorImpl injector;
-  // a null list means empty. Since it is common for many of these lists to be empty we can save
-  // some memory lookups by representing empty as null.
-  @Nullable private final ImmutableList<SingleMemberInjector> memberInjectors;
-  @Nullable private final ImmutableList<MembersInjector<? super T>> userMembersInjectors;
-  @Nullable private final ImmutableList<InjectionListener<? super T>> injectionListeners;
-  @Nullable private final ImmutableList<MethodAspect> addedAspects;
+class MembersInjectorImpl<T> implements MembersInjector<T> {
 
-  MembersInjectorImpl(
+  static <T> MembersInjectorImpl<T> create(
       InjectorImpl injector,
       TypeLiteral<T> typeLiteral,
       EncounterImpl<T> encounter,
       ImmutableList<SingleMemberInjector> memberInjectors) {
-    this.injector = injector;
-    this.typeLiteral = typeLiteral;
-    this.memberInjectors = memberInjectors.isEmpty() ? null : memberInjectors;
-    this.userMembersInjectors =
+    memberInjectors = memberInjectors.isEmpty() ? null : memberInjectors;
+    var userMembersInjectors =
         encounter.getMembersInjectors().isEmpty() ? null : encounter.getMembersInjectors().asList();
-    this.injectionListeners =
+    var injectionListeners =
         encounter.getInjectionListeners().isEmpty()
             ? null
             : encounter.getInjectionListeners().asList();
-    this.addedAspects =
+    var addedAspects =
         (InternalFlags.isBytecodeGenEnabled() && !encounter.getAspects().isEmpty())
             ? encounter.getAspects()
             : null;
+    if (InternalFlags.getUseExperimentalMethodHandlesOption()) {
+      return new MethodHandleMembersInjectorImpl<>(
+          injector,
+          typeLiteral,
+          memberInjectors,
+          userMembersInjectors,
+          injectionListeners,
+          addedAspects);
+    }
+    return new MembersInjectorImpl<>(
+        injector,
+        typeLiteral,
+        memberInjectors,
+        userMembersInjectors,
+        injectionListeners,
+        addedAspects);
+  }
+
+  protected final TypeLiteral<T> typeLiteral;
+  protected final InjectorImpl injector;
+  // a null list means empty. Since it is common for many of these lists to be empty we can save
+  // some memory lookups by representing empty as null.
+  @Nullable protected final ImmutableList<SingleMemberInjector> memberInjectors;
+  @Nullable protected final ImmutableList<MembersInjector<? super T>> userMembersInjectors;
+  @Nullable protected final ImmutableList<InjectionListener<? super T>> injectionListeners;
+  @Nullable protected final ImmutableList<MethodAspect> addedAspects;
+
+  private MembersInjectorImpl(
+      InjectorImpl injector,
+      TypeLiteral<T> typeLiteral,
+      ImmutableList<SingleMemberInjector> memberInjectors,
+      ImmutableList<MembersInjector<? super T>> userMembersInjectors,
+      ImmutableList<InjectionListener<? super T>> injectionListeners,
+      ImmutableList<MethodAspect> addedAspects) {
+    this.injector = injector;
+    this.typeLiteral = typeLiteral;
+    this.memberInjectors = memberInjectors;
+    this.userMembersInjectors = userMembersInjectors;
+    this.injectionListeners = injectionListeners;
+    this.addedAspects = addedAspects;
   }
 
   public ImmutableList<SingleMemberInjector> getMemberInjectors() {
@@ -71,8 +101,6 @@ final class MembersInjectorImpl<T> implements MembersInjector<T> {
 
   @Override
   public void injectMembers(T instance) {
-    // TODO(b/366058184): investigate a methodhandle version of this to support explicit members
-    // injection requests.
     if (instance == null) {
       return;
     }
@@ -122,7 +150,7 @@ final class MembersInjectorImpl<T> implements MembersInjector<T> {
     }
   }
 
-  private void notifyListeners(T instance) throws InternalProvisionException {
+  protected void notifyListeners(T instance) throws InternalProvisionException {
     ImmutableList<InjectionListener<? super T>> localInjectionListeners = injectionListeners;
     if (localInjectionListeners == null) {
       // no listeners
@@ -140,99 +168,7 @@ final class MembersInjectorImpl<T> implements MembersInjector<T> {
     }
   }
 
-  /**
-   * Returns a method handle that injects all members. The signature is {@code (T, InternalContext)
-   * -> void}
-   */
-  MethodHandle getInjectMembersAndNotifyListenersHandle(LinkageContext linkageContext) {
-    var handle = MethodHandles.empty(methodType(void.class, Object.class, InternalContext.class));
-    if (memberInjectors != null) {
-      for (SingleMemberInjector injector : memberInjectors) {
-        handle = MethodHandles.foldArguments(injector.getInjectHandle(linkageContext), handle);
-      }
-    }
-    if (userMembersInjectors != null) {
-      for (MembersInjector<? super T> injector : userMembersInjectors) {
-        var userHandle = INJECT_MEMBERS_HANDLE.bindTo(injector);
-        // Wrap it in a try..catch.
-        // Catch RuntimeException and rethrow as InternalProvisionException.errorInUserInjector
-        // (RuntimeException)->InternalProvisionException
-        var rethrow =
-            MethodHandles.insertArguments(ERROR_IN_USER_INJECTOR_HANDLE, 0, injector, typeLiteral);
-        // Throw that exception.
-        // (RuntimeException)->void
-        rethrow =
-            MethodHandles.filterArguments(
-                MethodHandles.throwException(void.class, InternalProvisionException.class),
-                0,
-                rethrow);
-        // Catch any exceptions and rethrow it.
-        userHandle = MethodHandles.catchException(userHandle, RuntimeException.class, rethrow);
-        // match the expected signature of the method.
-        userHandle = MethodHandles.dropArguments(userHandle, 1, InternalContext.class);
-        // Execute prior and then this listener.
-        handle = MethodHandles.foldArguments(userHandle, handle);
-      }
-    }
-
-    // Now notify listeners.
-    if (injectionListeners != null) {
-      for (InjectionListener<? super T> listener : injectionListeners) {
-        var listenerHandle = AFTER_INJECTION_HANDLE.bindTo(listener);
-        // Wrap it in a try..catch.
-        // Catch RuntimeException and rethrow as
-        // InternalProvisionException.errorNotifyingInjectionListener
-        // (RuntimeException)->InternalProvisionException
-        var rethrow =
-            MethodHandles.insertArguments(
-                ERROR_NOTIFYING_INJECTION_LISTENER_HANDLE, 0, listener, typeLiteral);
-        // (RuntimeException)->void
-        rethrow =
-            MethodHandles.filterArguments(
-                MethodHandles.throwException(void.class, InternalProvisionException.class),
-                0,
-                rethrow);
-
-        listenerHandle =
-            MethodHandles.catchException(listenerHandle, RuntimeException.class, rethrow);
-        // match the expected signature of the method.
-        listenerHandle = MethodHandles.dropArguments(listenerHandle, 1, InternalContext.class);
-        // Execute prior and then this listener.
-        handle = MethodHandles.foldArguments(listenerHandle, handle);
-      }
-    }
-
-    return handle;
-  }
-
-  private static final MethodHandle INJECT_MEMBERS_HANDLE =
-      findVirtualOrDie(
-          MembersInjector.class, "injectMembers", methodType(void.class, Object.class));
-
-  private static final MethodHandle AFTER_INJECTION_HANDLE =
-      findVirtualOrDie(
-          InjectionListener.class, "afterInjection", methodType(void.class, Object.class));
-
-  private static final MethodHandle ERROR_IN_USER_INJECTOR_HANDLE =
-      findStaticOrDie(
-          InternalProvisionException.class,
-          "errorInUserInjector",
-          methodType(
-              InternalProvisionException.class,
-              MembersInjector.class,
-              TypeLiteral.class,
-              RuntimeException.class));
-  private static final MethodHandle ERROR_NOTIFYING_INJECTION_LISTENER_HANDLE =
-      findStaticOrDie(
-          InternalProvisionException.class,
-          "errorNotifyingInjectionListener",
-          methodType(
-              InternalProvisionException.class,
-              InjectionListener.class,
-              TypeLiteral.class,
-              RuntimeException.class));
-
-  private void doInjectMembers(T t, InternalContext context, boolean toolableOnly)
+  protected void doInjectMembers(T t, InternalContext context, boolean toolableOnly)
       throws InternalProvisionException {
     ImmutableList<SingleMemberInjector> localMembersInjectors = memberInjectors;
     if (localMembersInjectors != null) {
@@ -290,5 +226,287 @@ final class MembersInjectorImpl<T> implements MembersInjector<T> {
 
   public ImmutableList<MethodAspect> getAddedAspects() {
     return addedAspects == null ? ImmutableList.<MethodAspect>of() : addedAspects;
+  }
+
+  /** A specialized implementation that is implemented in terms of MethodHandles. */
+  static final class MethodHandleMembersInjectorImpl<T> extends MembersInjectorImpl<T> {
+
+    // Lazily allocated and initialized.
+    private volatile MethodHandle doInjectHandle;
+    private volatile MethodHandle notifyListenersHandle;
+    private volatile MethodHandle injectMembersAndNotifyListenersHandle;
+
+    private MethodHandleMembersInjectorImpl(
+        InjectorImpl injector,
+        TypeLiteral<T> typeLiteral,
+        ImmutableList<SingleMemberInjector> memberInjectors,
+        ImmutableList<MembersInjector<? super T>> userMembersInjectors,
+        ImmutableList<InjectionListener<? super T>> injectionListeners,
+        ImmutableList<MethodAspect> addedAspects) {
+      super(
+          injector,
+          typeLiteral,
+          memberInjectors,
+          userMembersInjectors,
+          injectionListeners,
+          addedAspects);
+    }
+
+    @Override
+    protected void injectMembers(T instance, InternalContext ctx)
+        throws InternalProvisionException {
+      try {
+        getInjectMembersAndNotifyListenersHandle(null).invokeExact(instance, ctx);
+      } catch (InternalProvisionException ipe) {
+        throw ipe;
+      } catch (Throwable t) {
+        throw InternalMethodHandles.sneakyThrow(t);
+      }
+    }
+
+    @Override
+    protected void notifyListeners(T instance) throws InternalProvisionException {
+      try {
+        getNotifyListenersHandle().invokeExact((Object) instance);
+      } catch (InternalProvisionException ipe) {
+        throw ipe;
+      } catch (Throwable t) {
+        throw InternalMethodHandles.sneakyThrow(t);
+      }
+    }
+
+    @Override
+    protected void doInjectMembers(T instance, InternalContext context, boolean toolableOnly)
+        throws InternalProvisionException {
+      try {
+        getDoInjectHandle(null).invokeExact((Object) instance, context, toolableOnly);
+      } catch (InternalProvisionException ipe) {
+        throw ipe;
+      } catch (Throwable t) {
+        throw InternalMethodHandles.sneakyThrow(t);
+      }
+    }
+
+    /**
+     * Returns a method handle that injects all members. The signature is {@code (T,
+     * InternalContext) -> void}
+     * 
+     * This produces a handle that is equivalent to calling `injectMembers(instance, context, false)`.
+     */
+    MethodHandle getInjectMembersAndNotifyListenersHandle(@Nullable LinkageContext linkageContext) {
+      var local = injectMembersAndNotifyListenersHandle;
+      if (local != null) {
+        return local;
+      }
+      // Set `toolableOnly` to false
+      // (Object, InternalContext)->void
+      var injectMembers =
+          MethodHandles.insertArguments(getDoInjectHandle(linkageContext), 2, false);
+
+      // (Object, InternalContext)->void
+      var notifyListeners =
+          MethodHandles.dropArguments(getNotifyListenersHandle(), 1, InternalContext.class);
+      ;
+
+      local = MethodHandles.foldArguments(notifyListeners, injectMembers);
+
+      synchronized (this) {
+        var race = injectMembersAndNotifyListenersHandle;
+        if (race == null) {
+          injectMembersAndNotifyListenersHandle = local;
+        } else {
+          local = race;
+        }
+      }
+      return local;
+    }
+
+    private static final MethodHandle DO_NOTHING_INJECT =
+        MethodHandles.empty(
+            methodType(void.class, Object.class, InternalContext.class, boolean.class));
+
+    private static final MethodHandle TEST_TOOLABLE_ONLY =
+        MethodHandles.dropArguments(
+            MethodHandles.identity(boolean.class), 0, Object.class, InternalContext.class);
+
+    /**
+     * Returns a handle with the siganture (Object, InternalContext, boolean)->void that injects all
+     * the members.
+     */
+    private MethodHandle getDoInjectHandle(@Nullable LinkageContext linkageContext) {
+      var local = doInjectHandle;
+      if (local != null) {
+        return local;
+      }
+
+      if (linkageContext == null) {
+        linkageContext = new LinkageContext();
+      }
+      if (this.memberInjectors != null) {
+        for (SingleMemberInjector injector : memberInjectors) {
+          var injectHandle = injector.getInjectHandle(linkageContext);
+          injectHandle = MethodHandles.dropArguments(injectHandle, 2, boolean.class);
+          // If it is toolable we can always inject it, but if not we need to skip it if
+          // toolableonly is set
+          if (!injector.getInjectionPoint().isToolable()) {
+            injectHandle =
+                MethodHandles.guardWithTest(TEST_TOOLABLE_ONLY, DO_NOTHING_INJECT, injectHandle);
+          }
+          if (local == null) {
+            local = injectHandle;
+          } else {
+            local = MethodHandles.foldArguments(injectHandle, local);
+          }
+        }
+      }
+      if (userMembersInjectors != null) {
+        // (Object)->void
+        MethodHandle userMembersInjectorsHandle = null;
+
+        for (MembersInjector<? super T> injector : userMembersInjectors) {
+          // (Object)->void
+          var userHandle = INJECT_MEMBERS_HANDLE.bindTo(injector);
+          // Wrap it in a try..catch.
+          // Catch RuntimeException and rethrow as InternalProvisionException.errorInUserInjector
+          // (RuntimeException)->InternalProvisionException
+          var rethrow =
+              MethodHandles.insertArguments(
+                  ERROR_IN_USER_INJECTOR_HANDLE, 0, injector, typeLiteral);
+          // Throw that exception.
+          // (RuntimeException)->void
+          rethrow =
+              MethodHandles.filterArguments(
+                  MethodHandles.throwException(void.class, InternalProvisionException.class),
+                  0,
+                  rethrow);
+          // Catch any exceptions and rethrow it.
+          userHandle = MethodHandles.catchException(userHandle, RuntimeException.class, rethrow);
+
+          // merge with the previous one if necessary
+          if (userMembersInjectorsHandle == null) {
+            userMembersInjectorsHandle = userHandle;
+          } else {
+            userMembersInjectorsHandle =
+                MethodHandles.foldArguments(userHandle, userMembersInjectorsHandle);
+          }
+        }
+        var test =
+            MethodHandles.dropArguments(
+                MethodHandles.identity(boolean.class), 0, Object.class, InternalContext.class);
+        var ifToolableOnly =
+            MethodHandles.empty(
+                methodType(void.class, Object.class, InternalContext.class, boolean.class));
+        var ifNotToolableOnly =
+            MethodHandles.dropArguments(
+                userMembersInjectorsHandle, 1, InternalContext.class, boolean.class);
+        userMembersInjectorsHandle =
+            MethodHandles.guardWithTest(test, ifToolableOnly, ifNotToolableOnly);
+
+        if (local == null) {
+          local = userMembersInjectorsHandle;
+        } else {
+          local = MethodHandles.foldArguments(userMembersInjectorsHandle, local);
+        }
+      }
+      // there must be no injectors at all
+      if (local == null) {
+        local = DO_NOTHING_INJECT;
+      }
+
+      // update the cache
+      synchronized (this) {
+        // See if we lost a race
+        var raceValue = doInjectHandle;
+        if (raceValue == null) {
+          doInjectHandle = local;
+        } else {
+          local = raceValue;
+        }
+      }
+      return local;
+    }
+
+    /**
+     * Returns a handle with the signature (Object instance)->void that invokes all the listeners.
+     *
+     * <p>Catches exceptions and rethrows them as InternalProvisionException.
+     */
+    private MethodHandle getNotifyListenersHandle() {
+      var local = notifyListenersHandle;
+      if (local != null) {
+        return local;
+      }
+      // Now notify listeners.
+      if (injectionListeners != null) {
+        for (InjectionListener<? super T> listener : injectionListeners) {
+          // (Object)->void
+          var listenerHandle = AFTER_INJECTION_HANDLE.bindTo(listener);
+          // Wrap it in a try..catch.
+          // Catch RuntimeException and rethrow as
+          // InternalProvisionException.errorNotifyingInjectionListener
+          // (RuntimeException)->InternalProvisionException
+          var rethrow =
+              MethodHandles.insertArguments(
+                  ERROR_NOTIFYING_INJECTION_LISTENER_HANDLE, 0, listener, typeLiteral);
+          // (RuntimeException)->void
+          rethrow =
+              MethodHandles.filterArguments(
+                  MethodHandles.throwException(void.class, InternalProvisionException.class),
+                  0,
+                  rethrow);
+
+          listenerHandle =
+              MethodHandles.catchException(listenerHandle, RuntimeException.class, rethrow);
+          // Execute prior and then this listener.
+          if (local == null) {
+            local = listenerHandle;
+          } else {
+            local = MethodHandles.foldArguments(listenerHandle, local);
+          }
+        }
+      } else {
+        local = MethodHandles.empty(methodType(void.class, Object.class));
+      }
+
+      // update the cache
+      synchronized (this) {
+        // See if we lost a race
+        var raceValue = notifyListenersHandle;
+        if (raceValue == null) {
+          notifyListenersHandle = local;
+        } else {
+          local = raceValue;
+        }
+      }
+
+      return local;
+    }
+
+    private static final MethodHandle INJECT_MEMBERS_HANDLE =
+        findVirtualOrDie(
+            MembersInjector.class, "injectMembers", methodType(void.class, Object.class));
+
+    private static final MethodHandle AFTER_INJECTION_HANDLE =
+        findVirtualOrDie(
+            InjectionListener.class, "afterInjection", methodType(void.class, Object.class));
+
+    private static final MethodHandle ERROR_IN_USER_INJECTOR_HANDLE =
+        findStaticOrDie(
+            InternalProvisionException.class,
+            "errorInUserInjector",
+            methodType(
+                InternalProvisionException.class,
+                MembersInjector.class,
+                TypeLiteral.class,
+                RuntimeException.class));
+    private static final MethodHandle ERROR_NOTIFYING_INJECTION_LISTENER_HANDLE =
+        findStaticOrDie(
+            InternalProvisionException.class,
+            "errorNotifyingInjectionListener",
+            methodType(
+                InternalProvisionException.class,
+                InjectionListener.class,
+                TypeLiteral.class,
+                RuntimeException.class));
   }
 }

--- a/core/src/com/google/inject/internal/MembersInjectorStore.java
+++ b/core/src/com/google/inject/internal/MembersInjectorStore.java
@@ -113,7 +113,7 @@ final class MembersInjectorStore {
     encounter.invalidate();
     errors.throwIfNewErrors(numErrorsBefore);
 
-    return new MembersInjectorImpl<T>(injector, type, encounter, injectors);
+    return MembersInjectorImpl.create(injector, type, encounter, injectors);
   }
 
   /** Returns the injectors for the specified injection points. */

--- a/core/src/com/google/inject/internal/ProvidedByInternalFactory.java
+++ b/core/src/com/google/inject/internal/ProvidedByInternalFactory.java
@@ -77,22 +77,20 @@ class ProvidedByInternalFactory<T> extends ProviderInternalFactory<T> implements
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, Dependency<?> dependency, boolean linked) {
+  public MethodHandle getHandle(LinkageContext context, boolean linked) {
     return context.makeHandle(
         this,
         () ->
             InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
                 circularGetHandle(
-                    providerFactory.getHandle(context, PROVIDER_DEPENDENCY, /* linked= */ true),
-                    dependency,
-                    provisionCallback),
+                    providerFactory.getHandle(context, /* linked= */ true), provisionCallback),
                 providerKey));
   }
 
   @Override
-  protected MethodHandle provisionHandle(MethodHandle providerHandle, Dependency<?> dependency) {
+  protected MethodHandle provisionHandle(MethodHandle providerHandle) {
     // Do normal provisioning and then check that the result is the correct subtype.
-    MethodHandle invokeProvider = super.provisionHandle(providerHandle, dependency);
+    MethodHandle invokeProvider = super.provisionHandle(providerHandle);
     return MethodHandles.filterReturnValue(
         invokeProvider,
         MethodHandles.insertArguments(

--- a/core/src/com/google/inject/internal/ProvidedByInternalFactory.java
+++ b/core/src/com/google/inject/internal/ProvidedByInternalFactory.java
@@ -22,9 +22,9 @@ import com.google.errorprone.annotations.Keep;
 import com.google.inject.Key;
 import com.google.inject.internal.InjectorImpl.JitLimitation;
 import com.google.inject.spi.Dependency;
+import jakarta.inject.Provider;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import jakarta.inject.Provider;
 
 /**
  * An {@link InternalFactory} for {@literal @}{@link ProvidedBy} bindings.
@@ -77,14 +77,11 @@ class ProvidedByInternalFactory<T> extends ProviderInternalFactory<T> implements
   }
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, boolean linked) {
-    return context.makeHandle(
-        this,
-        () ->
-            InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-                circularGetHandle(
-                    providerFactory.getHandle(context, /* linked= */ true), provisionCallback),
-                providerKey));
+  MethodHandle makeHandle(LinkageContext context, boolean linked) {
+    return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
+        circularGetHandle(
+            providerFactory.getHandle(context, /* linked= */ true), provisionCallback),
+        providerKey);
   }
 
   @Override

--- a/core/src/com/google/inject/internal/ProvidedByInternalFactory.java
+++ b/core/src/com/google/inject/internal/ProvidedByInternalFactory.java
@@ -77,11 +77,12 @@ class ProvidedByInternalFactory<T> extends ProviderInternalFactory<T> implements
   }
 
   @Override
-  MethodHandle makeHandle(LinkageContext context, boolean linked) {
-    return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-        circularGetHandle(
-            providerFactory.getHandle(context, /* linked= */ true), provisionCallback),
-        providerKey);
+  MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+    return makeCachable(
+        InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
+            circularGetHandle(
+                providerFactory.getHandle(context, /* linked= */ true), provisionCallback),
+            providerKey));
   }
 
   @Override

--- a/core/src/com/google/inject/internal/ProviderInternalFactory.java
+++ b/core/src/com/google/inject/internal/ProviderInternalFactory.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
  *
  * @author sameb@google.com (Sam Berlin)
  */
-abstract class ProviderInternalFactory<T> implements InternalFactory<T> {
+abstract class ProviderInternalFactory<T> extends InternalFactory<T> {
   protected final Object source;
   private final int circularFactoryId;
 

--- a/core/src/com/google/inject/internal/ProviderInternalFactory.java
+++ b/core/src/com/google/inject/internal/ProviderInternalFactory.java
@@ -141,7 +141,7 @@ abstract class ProviderInternalFactory<T> extends InternalFactory<T> {
   protected MethodHandle provisionHandle(MethodHandle providerHandle) {
     // Call Provider.get() and catch any RuntimeException as an InternalProvisionException.
     var invokeProvider =
-        InternalMethodHandles.catchErrorInProviderAndRethrowWithSource(
+        InternalMethodHandles.catchRuntimeExceptionInProviderAndRethrowWithSource(
             InternalMethodHandles.getProvider(providerHandle), source);
     // Wrap in a try..finally.. that calls `finishConstruction` on the context.
     invokeProvider = InternalMethodHandles.finishConstruction(invokeProvider, circularFactoryId);

--- a/core/src/com/google/inject/internal/ProviderInternalFactory.java
+++ b/core/src/com/google/inject/internal/ProviderInternalFactory.java
@@ -20,12 +20,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.inject.internal.InternalMethodHandles.castReturnTo;
 import static java.lang.invoke.MethodType.methodType;
 
-import com.google.inject.Key;
 import com.google.inject.spi.Dependency;
+import jakarta.inject.Provider;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import javax.annotation.Nullable;
-import jakarta.inject.Provider;
 
 /**
  * Base class for InternalFactories that are used by Providers, to handle circular dependencies.
@@ -33,8 +32,6 @@ import jakarta.inject.Provider;
  * @author sameb@google.com (Sam Berlin)
  */
 abstract class ProviderInternalFactory<T> implements InternalFactory<T> {
-  protected static final Dependency<?> PROVIDER_DEPENDENCY =
-      Dependency.get(new Key<jakarta.inject.Provider<?>>() {});
   protected final Object source;
   private final int circularFactoryId;
 
@@ -74,19 +71,15 @@ abstract class ProviderInternalFactory<T> implements InternalFactory<T> {
    * callbacks or failure modes. This is the case for constant provider bindings at least.
    */
   protected MethodHandle circularGetHandleImmediate(
-      MethodHandle providerHandle,
-      Dependency<?> dependency,
-      @Nullable ProvisionListenerStackCallback<T> provisionCallback) {
+      MethodHandle providerHandle, @Nullable ProvisionListenerStackCallback<T> provisionCallback) {
 
-    var invokeProvider = provisionHandle(providerHandle, dependency);
+    var invokeProvider = provisionHandle(providerHandle);
 
     // Apply the provision callback if needed
     invokeProvider =
-        InternalMethodHandles.invokeThroughProvisionCallback(
-            invokeProvider, dependency, provisionCallback);
+        InternalMethodHandles.invokeThroughProvisionCallback(invokeProvider, provisionCallback);
     // Start construction and possibly return a proxy.
-    invokeProvider =
-        InternalMethodHandles.tryStartConstruction(invokeProvider, dependency, circularFactoryId);
+    invokeProvider = InternalMethodHandles.tryStartConstruction(invokeProvider, circularFactoryId);
     return invokeProvider;
   }
 
@@ -97,9 +90,7 @@ abstract class ProviderInternalFactory<T> implements InternalFactory<T> {
    * it, such that provision listeners get called in the correct order.
    */
   protected MethodHandle circularGetHandle(
-      MethodHandle providerHandle,
-      Dependency<?> dependency,
-      @Nullable ProvisionListenerStackCallback<T> provisionCallback) {
+      MethodHandle providerHandle, @Nullable ProvisionListenerStackCallback<T> provisionCallback) {
     // The combinators below assume this type.
     providerHandle = castReturnTo(providerHandle, jakarta.inject.Provider.class);
     // TODO: lukes - This is annoying, but various tests assert that we invoke the provision
@@ -118,20 +109,23 @@ abstract class ProviderInternalFactory<T> implements InternalFactory<T> {
     // and returns a Provider.
     var providerPlaceholder =
         MethodHandles.dropArguments(
-            MethodHandles.identity(jakarta.inject.Provider.class), 0, InternalContext.class);
+            MethodHandles.identity(jakarta.inject.Provider.class),
+            0,
+            InternalContext.class,
+            Dependency.class);
     // (InternalContext, Provider) ->T
-    var invokeProvider =
-        circularGetHandleImmediate(providerPlaceholder, dependency, provisionCallback);
+    var invokeProvider = circularGetHandleImmediate(providerPlaceholder, provisionCallback);
     // To call `fold` we need to permute the arguments so that the provider is the first argument.
     // (Provider, InternalContext) ->T
     invokeProvider =
         MethodHandles.permuteArguments(
             invokeProvider,
             methodType(
-                invokeProvider.type().returnType(),
+                Object.class,
                 jakarta.inject.Provider.class,
-                InternalContext.class),
-            new int[] {1, 0});
+                InternalContext.class,
+                Dependency.class),
+            new int[] {1, 2, 0});
     // Basically invoke the `providerHandle` and then pass the provider to `invokeProvider`
     return MethodHandles.foldArguments(invokeProvider, 0, providerHandle);
   }
@@ -141,8 +135,10 @@ abstract class ProviderInternalFactory<T> implements InternalFactory<T> {
    * RuntimeException as an InternalProvisionException.
    *
    * <p>Subclasses should override this to add more validation checks.
+   *
+   * <p>Returns a handle with the signature {@code (InternalContext, Dependency) -> Object}
    */
-  protected MethodHandle provisionHandle(MethodHandle providerHandle, Dependency<?> dependency) {
+  protected MethodHandle provisionHandle(MethodHandle providerHandle) {
     // Call Provider.get() and catch any RuntimeException as an InternalProvisionException.
     var invokeProvider =
         InternalMethodHandles.catchErrorInProviderAndRethrowWithSource(
@@ -150,8 +146,13 @@ abstract class ProviderInternalFactory<T> implements InternalFactory<T> {
     // Wrap in a try..finally.. that calls `finishConstruction` on the context.
     invokeProvider = InternalMethodHandles.finishConstruction(invokeProvider, circularFactoryId);
 
+    // Add a Dependency parameter if it isn't present
+    if (invokeProvider.type().parameterCount() == 1
+        || !invokeProvider.type().parameterType(1).equals(Dependency.class)) {
+      invokeProvider = MethodHandles.dropArguments(invokeProvider, 1, Dependency.class);
+    }
     // null check the result using the dependency.
-    invokeProvider = InternalMethodHandles.nullCheckResult(invokeProvider, source, dependency);
+    invokeProvider = InternalMethodHandles.nullCheckResult(invokeProvider, source);
     return invokeProvider;
   }
 

--- a/core/src/com/google/inject/internal/ProviderMethod.java
+++ b/core/src/com/google/inject/internal/ProviderMethod.java
@@ -18,7 +18,6 @@ package com.google.inject.internal;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.inject.internal.InternalMethodHandles.BIFUNCTION_APPLY_HANDLE;
-import static com.google.inject.internal.InternalMethodHandles.METHOD_INVOKE_HANDLE;
 import static com.google.inject.internal.InternalMethodHandles.castReturnTo;
 import static com.google.inject.internal.InternalMethodHandles.castReturnToObject;
 import static java.lang.invoke.MethodType.methodType;
@@ -394,7 +393,7 @@ public abstract class ProviderMethod<T> extends InternalProviderInstanceBindingI
       // goes through a JVM native method... le sigh...
       // bind to the `Method` object
       // (Object, Object[]) -> Object
-      var handle = METHOD_INVOKE_HANDLE.bindTo(method);
+      var handle = InternalMethodHandles.invokeHandle(method);
       // insert the instance
       // (Object[]) -> Object
       handle = MethodHandles.insertArguments(handle, 0, instance);
@@ -403,9 +402,6 @@ public abstract class ProviderMethod<T> extends InternalProviderInstanceBindingI
       handle =
           MethodHandles.filterArguments(
               handle, 0, InternalMethodHandles.buildObjectArrayFactory(parameters));
-      // MethodHandles expect the root Throwable to be thrown directly, unpack and rethrow the
-      // cause instead of complicating the normal flow.
-      handle = InternalMethodHandles.catchInvocationTargetExceptionAndRethrowCause(handle);
       return handle;
     }
   }

--- a/core/src/com/google/inject/internal/ProviderMethod.java
+++ b/core/src/com/google/inject/internal/ProviderMethod.java
@@ -236,14 +236,10 @@ public abstract class ProviderMethod<T> extends InternalProviderInstanceBindingI
       throws IllegalAccessException, InvocationTargetException;
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, boolean linked) {
-    return context.makeHandle(
-        this,
-        () -> {
-          MethodHandle handle = super.getHandle(context, linked);
-          // Handle circular proxies.
-          return InternalMethodHandles.tryStartConstruction(handle, circularFactoryId);
-        });
+  MethodHandle makeHandle(LinkageContext context, boolean linked) {
+    MethodHandle handle = super.makeHandle(context, linked);
+    // Handle circular proxies.
+    return InternalMethodHandles.tryStartConstruction(handle, circularFactoryId);
   }
 
   /** Creates a method handle that constructs the object to be injected. */

--- a/core/src/com/google/inject/internal/ProviderMethod.java
+++ b/core/src/com/google/inject/internal/ProviderMethod.java
@@ -254,7 +254,7 @@ public abstract class ProviderMethod<T> extends InternalProviderInstanceBindingI
     handle = MethodHandles.dropArguments(handle, 1, Dependency.class);
     handle = InternalMethodHandles.nullCheckResult(handle, getMethod());
     // catch everything else and rethrow as an error in provider.
-    handle = InternalMethodHandles.catchErrorInProviderAndRethrowWithSource(handle, getSource());
+    handle = InternalMethodHandles.catchThrowableInProviderAndRethrowWithSource(handle, getSource());
     handle = InternalMethodHandles.finishConstruction(handle, circularFactoryId);
 
     return handle;

--- a/core/src/com/google/inject/internal/ProviderMethod.java
+++ b/core/src/com/google/inject/internal/ProviderMethod.java
@@ -236,24 +236,23 @@ public abstract class ProviderMethod<T> extends InternalProviderInstanceBindingI
       throws IllegalAccessException, InvocationTargetException;
 
   @Override
-  public MethodHandle getHandle(LinkageContext context, Dependency<?> dependency, boolean linked) {
+  public MethodHandle getHandle(LinkageContext context, boolean linked) {
     return context.makeHandle(
         this,
         () -> {
-          MethodHandle handle = super.getHandle(context, dependency, linked);
+          MethodHandle handle = super.getHandle(context, linked);
           // Handle circular proxies.
-          return InternalMethodHandles.tryStartConstruction(handle, dependency, circularFactoryId);
+          return InternalMethodHandles.tryStartConstruction(handle, circularFactoryId);
         });
   }
 
   /** Creates a method handle that constructs the object to be injected. */
   @Override
-  protected final MethodHandle doGetHandle(
-      LinkageContext context, Dependency<?> dependency, boolean linked) {
+  protected final MethodHandle doGetHandle(LinkageContext context, boolean linked) {
     MethodHandle handle =
         doProvisionHandle(SingleParameterInjector.getAllHandles(context, parameterInjectors));
     handle = castReturnToObject(handle);
-    handle = InternalMethodHandles.nullCheckResult(handle, getMethod(), dependency);
+    handle = InternalMethodHandles.nullCheckResult(handle, getMethod());
     // catch everything else and rethrow as an error in provider.
     handle = InternalMethodHandles.catchErrorInProviderAndRethrowWithSource(handle, getSource());
     handle = InternalMethodHandles.finishConstruction(handle, circularFactoryId);

--- a/core/src/com/google/inject/internal/ProviderToInternalFactoryAdapter.java
+++ b/core/src/com/google/inject/internal/ProviderToInternalFactoryAdapter.java
@@ -18,6 +18,7 @@ package com.google.inject.internal;
 
 import com.google.inject.Key;
 import com.google.inject.Provider;
+import com.google.inject.spi.Dependency;
 
 /**
  * A provider that wraps an internal factory in order to pass to Scope instances.
@@ -57,7 +58,7 @@ public class ProviderToInternalFactoryAdapter<T> implements Provider<T> {
   public T get() {
     InternalContext context = injector.enterContext();
     try {
-      return doGet(context);
+      return doGet(context, context.getDependency());
     } catch (InternalProvisionException e) {
       throw e.toProvisionException();
     } finally {
@@ -67,11 +68,12 @@ public class ProviderToInternalFactoryAdapter<T> implements Provider<T> {
 
   // Exposed so it can be overridden by the generated provider when method handles are enabled.
   // See InternalMethodHandles.makeScopedProvider.
-  protected T doGet(InternalContext context) throws InternalProvisionException {
+  protected T doGet(InternalContext context, Dependency<?> dependency)
+      throws InternalProvisionException {
     // Always pretend that we are a linked binding, to support
     // scoping implicit bindings.  If we are not actually a linked
     // binding, we'll fail properly elsewhere in the chain.
-    return internalFactory.get(context, context.getDependency(), true);
+    return internalFactory.get(context, dependency, true);
   }
 
   /** Exposed for SingletonScope. */

--- a/core/src/com/google/inject/internal/ProviderToInternalFactoryAdapter.java
+++ b/core/src/com/google/inject/internal/ProviderToInternalFactoryAdapter.java
@@ -37,12 +37,12 @@ import com.google.inject.spi.Dependency;
 public class ProviderToInternalFactoryAdapter<T> implements Provider<T> {
 
   private final InjectorImpl injector;
-  private final InternalFactory<? extends T> internalFactory;
+  final InternalFactory<? extends T> internalFactory;
 
   static <T> ProviderToInternalFactoryAdapter<T> create(
-      InjectorImpl injector, InternalFactory<? extends T> internalFactory, Key<T> key) {
+      InjectorImpl injector, InternalFactory<? extends T> internalFactory) {
     if (InternalFlags.getUseExperimentalMethodHandlesOption()) {
-      return InternalMethodHandles.makeScopedProvider(internalFactory, injector, key);
+      return InternalMethodHandles.makeScopedProvider(internalFactory, injector);
     }
 
     return new ProviderToInternalFactoryAdapter<>(injector, internalFactory);

--- a/core/src/com/google/inject/internal/ProxyFactory.java
+++ b/core/src/com/google/inject/internal/ProxyFactory.java
@@ -195,6 +195,8 @@ final class ProxyFactory<T> implements ConstructionProxyFactory<T> {
               .asType(methodType(Object.class, Object.class, Object[].class));
       // (Object[])->Object
       handle = MethodHandles.insertArguments(handle, 0, (Object) callbacks);
+      // catch here so we don't catch errors from our parameters
+      handle = InternalMethodHandles.catchErrorInConstructorAndRethrowWithSource(handle, injectionPoint);
       // (InternalContext)->Object
       handle =
           MethodHandles.filterArguments(

--- a/core/src/com/google/inject/internal/ProxyFactory.java
+++ b/core/src/com/google/inject/internal/ProxyFactory.java
@@ -203,7 +203,7 @@ final class ProxyFactory<T> implements ConstructionProxyFactory<T> {
       // Merge all the internalcontext parameters into a single object factory.
       handle =
           MethodHandles.permuteArguments(
-              handle, InternalMethodHandles.FACTORY_TYPE, new int[parameterHandles.length]);
+              handle, InternalMethodHandles.ELEMENT_FACTORY_TYPE, new int[parameterHandles.length]);
       return handle;
     }
 

--- a/core/src/com/google/inject/internal/ProxyFactory.java
+++ b/core/src/com/google/inject/internal/ProxyFactory.java
@@ -193,17 +193,12 @@ final class ProxyFactory<T> implements ConstructionProxyFactory<T> {
           InternalMethodHandles.BIFUNCTION_APPLY_HANDLE
               .bindTo(enhancedConstructor)
               .asType(methodType(Object.class, Object.class, Object[].class));
+      // (Object[])->Object
       handle = MethodHandles.insertArguments(handle, 0, (Object) callbacks);
-      // Turn the array parameter into a fixed set of parameters.
-      // This is safe because the number of parameters is the same as the number of parameters to
-      // the constructor which should never exceed the maximum number of method parameters.
-      handle = handle.asCollector(Object[].class, parameterHandles.length);
-      // Pass all the parameters to the constructor.
-      handle = MethodHandles.filterArguments(handle, 0, parameterHandles);
-      // Merge all the internalcontext parameters into a single object factory.
+      // (InternalContext)->Object
       handle =
-          MethodHandles.permuteArguments(
-              handle, InternalMethodHandles.ELEMENT_FACTORY_TYPE, new int[parameterHandles.length]);
+          MethodHandles.filterArguments(
+              handle, 0, InternalMethodHandles.buildObjectArrayFactory(parameterHandles));
       return handle;
     }
 

--- a/core/src/com/google/inject/internal/RealMapBinder.java
+++ b/core/src/com/google/inject/internal/RealMapBinder.java
@@ -742,7 +742,7 @@ public final class RealMapBinder<K, V> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context) {
       return InternalMethodHandles.constantFactoryGetHandle(mapOfProviders);
     }
   }
@@ -825,7 +825,7 @@ public final class RealMapBinder<K, V> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context) {
       if (injectors == null) {
         return InternalMethodHandles.constantFactoryGetHandle(ImmutableMap.of());
       }
@@ -1134,7 +1134,7 @@ public final class RealMapBinder<K, V> implements Module {
       }
 
       @Override
-      protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+      protected MethodHandle doGetHandle(LinkageContext context) {
         return InternalMethodHandles.constantFactoryGetHandle(multimapOfProviders);
       }
     }
@@ -1248,7 +1248,7 @@ public final class RealMapBinder<K, V> implements Module {
       }
 
       @Override
-      protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+      protected MethodHandle doGetHandle(LinkageContext context) {
         if (perKeyDatas.length == 0) {
           return InternalMethodHandles.constantFactoryGetHandle(ImmutableMap.of());
         }
@@ -1314,7 +1314,7 @@ public final class RealMapBinder<K, V> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context) {
       return InternalMethodHandles.constantFactoryGetHandle(entry);
     }
 

--- a/core/src/com/google/inject/internal/RealMapBinder.java
+++ b/core/src/com/google/inject/internal/RealMapBinder.java
@@ -742,8 +742,7 @@ public final class RealMapBinder<K, V> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(
-        LinkageContext context, Dependency<?> dependency, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
       return InternalMethodHandles.constantFactoryGetHandle(mapOfProviders);
     }
   }
@@ -826,8 +825,7 @@ public final class RealMapBinder<K, V> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(
-        LinkageContext context, Dependency<?> dependency, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
       if (injectors == null) {
         return InternalMethodHandles.constantFactoryGetHandle(ImmutableMap.of());
       }
@@ -847,7 +845,7 @@ public final class RealMapBinder<K, V> implements Module {
                     bindingSelection.getMapBindings().get(key).getSource()));
         entries.add(Map.entry(key, valueHandle));
       }
-      return buildImmutableMapFactory(entries);
+      return MethodHandles.dropArguments(buildImmutableMapFactory(entries), 1, Dependency.class);
     }
 
     @Override
@@ -1136,8 +1134,7 @@ public final class RealMapBinder<K, V> implements Module {
       }
 
       @Override
-      protected MethodHandle doGetHandle(
-          LinkageContext context, Dependency<?> dependency, boolean linked) {
+      protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
         return InternalMethodHandles.constantFactoryGetHandle(multimapOfProviders);
       }
     }
@@ -1251,8 +1248,7 @@ public final class RealMapBinder<K, V> implements Module {
       }
 
       @Override
-      protected MethodHandle doGetHandle(
-          LinkageContext context, Dependency<?> dependency, boolean linked) {
+      protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
         if (perKeyDatas.length == 0) {
           return InternalMethodHandles.constantFactoryGetHandle(ImmutableMap.of());
         }
@@ -1280,7 +1276,7 @@ public final class RealMapBinder<K, V> implements Module {
                   perKeyData.key, InternalMethodHandles.buildImmutableSetFactory(elementHandles)));
         }
 
-        return buildImmutableMapFactory(entries);
+        return MethodHandles.dropArguments(buildImmutableMapFactory(entries), 1, Dependency.class);
       }
     }
   }
@@ -1318,8 +1314,7 @@ public final class RealMapBinder<K, V> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(
-        LinkageContext context, Dependency<?> dependency, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
       return InternalMethodHandles.constantFactoryGetHandle(entry);
     }
 

--- a/core/src/com/google/inject/internal/RealMultibinder.java
+++ b/core/src/com/google/inject/internal/RealMultibinder.java
@@ -290,8 +290,7 @@ public final class RealMultibinder<T> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(
-        LinkageContext context, Dependency<?> dependency, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
       if (injectors == null) {
         return InternalMethodHandles.constantFactoryGetHandle(ImmutableSet.of());
       }
@@ -310,7 +309,8 @@ public final class RealMultibinder<T> implements Module {
       if (permitDuplicates || elementHandles.size() == 1) {
         // we just want to construct an ImmutableSet.Builder, and add everything to it.
         // This generates exactly the code a human would write.
-        return InternalMethodHandles.buildImmutableSetFactory(elementHandles);
+        return MethodHandles.dropArguments(
+            InternalMethodHandles.buildImmutableSetFactory(elementHandles), 1, Dependency.class);
       } else {
         // Duplicates are not permitted, so we need to check for duplicates by constructing all
         // elements and then checking the size of the set.
@@ -335,8 +335,8 @@ public final class RealMultibinder<T> implements Module {
         var collector = MAKE_IMMUTABLE_SET_AND_CHECK_DUPLICATES_HANDLE.bindTo(this);
         // (InternalContext ctx) -> ImmutableSet<T>
         collector = MethodHandles.filterArguments(collector, 0, populateArray);
-
-        return castReturnToObject(collector);
+        // (InternalContext, Dependency) -> Object
+        return MethodHandles.dropArguments(castReturnToObject(collector), 1, Dependency.class);
       }
     }
 
@@ -518,8 +518,7 @@ public final class RealMultibinder<T> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(
-        LinkageContext context, Dependency<?> dependency, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
       return InternalMethodHandles.constantFactoryGetHandle(providers);
     }
   }

--- a/core/src/com/google/inject/internal/RealMultibinder.java
+++ b/core/src/com/google/inject/internal/RealMultibinder.java
@@ -290,7 +290,7 @@ public final class RealMultibinder<T> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context) {
       if (injectors == null) {
         return InternalMethodHandles.constantFactoryGetHandle(ImmutableSet.of());
       }
@@ -518,7 +518,7 @@ public final class RealMultibinder<T> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context) {
       return InternalMethodHandles.constantFactoryGetHandle(providers);
     }
   }

--- a/core/src/com/google/inject/internal/RealOptionalBinder.java
+++ b/core/src/com/google/inject/internal/RealOptionalBinder.java
@@ -292,21 +292,16 @@ public final class RealOptionalBinder<T> implements Module {
       if (target == null) {
         return InternalMethodHandles.constantFactoryGetHandle(java.util.Optional.empty());
       }
-      return context.makeHandle(
-          this,
-          () -> {
-            var handle =
-                MethodHandles.insertArguments(
-                    target.getHandle(context, /* linked= */ false), 1, targetDependency);
-            handle =
-                InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-                    handle, targetDependency);
-            return MethodHandles.dropArguments(
-                castReturnToObject(
-                    MethodHandles.filterReturnValue(handle, OPTIONAL_OF_NULLABLE_MH)),
-                1,
-                Dependency.class);
-          });
+      var handle =
+          MethodHandles.insertArguments(
+              target.getHandle(context, /* linked= */ false), 1, targetDependency);
+      handle =
+          InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
+              handle, targetDependency);
+      return MethodHandles.dropArguments(
+          castReturnToObject(MethodHandles.filterReturnValue(handle, OPTIONAL_OF_NULLABLE_MH)),
+          1,
+          Dependency.class);
     }
 
     private static final MethodHandle OPTIONAL_OF_NULLABLE_MH =
@@ -439,11 +434,8 @@ public final class RealOptionalBinder<T> implements Module {
 
     @Override
     protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
-      return context.makeHandle(
-          this,
-          () ->
-              InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-                  targetFactory.getHandle(context, /* linked= */ true), targetKey));
+      return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
+          targetFactory.getHandle(context, /* linked= */ true), targetKey);
     }
 
     @Override
@@ -552,21 +544,17 @@ public final class RealOptionalBinder<T> implements Module {
       if (delegate == null) {
         return InternalMethodHandles.constantFactoryGetHandle(Optional.absent());
       }
-      return context.makeHandle(
-          this,
-          () -> {
-            var handle =
-                MethodHandles.insertArguments(
-                    delegate.getHandle(context, /* linked= */ false), 1, targetDependency);
-            handle =
-                InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-                    handle, targetDependency);
-            return MethodHandles.dropArguments(
-                castReturnToObject(
-                    MethodHandles.filterReturnValue(handle, OPTIONAL_FROM_NULLABLE_MH)),
-                1,
-                Dependency.class);
-          });
+
+      var handle =
+          MethodHandles.insertArguments(
+              delegate.getHandle(context, /* linked= */ false), 1, targetDependency);
+      handle =
+          InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
+              handle, targetDependency);
+      return MethodHandles.dropArguments(
+          castReturnToObject(MethodHandles.filterReturnValue(handle, OPTIONAL_FROM_NULLABLE_MH)),
+          1,
+          Dependency.class);
     }
 
     private static final MethodHandle OPTIONAL_FROM_NULLABLE_MH =

--- a/core/src/com/google/inject/internal/RealOptionalBinder.java
+++ b/core/src/com/google/inject/internal/RealOptionalBinder.java
@@ -288,7 +288,7 @@ public final class RealOptionalBinder<T> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context) {
       if (target == null) {
         return InternalMethodHandles.constantFactoryGetHandle(java.util.Optional.empty());
       }
@@ -387,7 +387,7 @@ public final class RealOptionalBinder<T> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context) {
       return InternalMethodHandles.constantFactoryGetHandle(value);
     }
 
@@ -433,7 +433,7 @@ public final class RealOptionalBinder<T> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context) {
       return InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
           targetFactory.getHandle(context, /* linked= */ true), targetKey);
     }
@@ -474,7 +474,7 @@ public final class RealOptionalBinder<T> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context) {
       return InternalMethodHandles.constantFactoryGetHandle(value);
     }
 
@@ -540,7 +540,7 @@ public final class RealOptionalBinder<T> implements Module {
     }
 
     @Override
-    protected MethodHandle doGetHandle(LinkageContext context, boolean linked) {
+    protected MethodHandle doGetHandle(LinkageContext context) {
       if (delegate == null) {
         return InternalMethodHandles.constantFactoryGetHandle(Optional.absent());
       }

--- a/core/src/com/google/inject/internal/Scoping.java
+++ b/core/src/com/google/inject/internal/Scoping.java
@@ -297,7 +297,7 @@ public abstract class Scoping {
     // ProviderToInternalFactoryAdapter here.  If you change the type make sure to update
     // SingletonScope as well.
     Provider<T> scoped =
-        scope.scope(key, ProviderToInternalFactoryAdapter.create(injector, creator, key));
+        scope.scope(key, ProviderToInternalFactoryAdapter.create(injector, creator));
     return InternalFactoryToScopedProviderAdapter.create(scope, scoped, source);
   }
 

--- a/core/src/com/google/inject/internal/SingleFieldInjector.java
+++ b/core/src/com/google/inject/internal/SingleFieldInjector.java
@@ -76,7 +76,9 @@ final class SingleFieldInjector implements SingleMemberInjector {
     // Catch and rethrow exceptions from our dependency factory.
     var injectHandle =
         InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-            factory.getHandle(linkageContext, dependency, /* linked= */ false), dependency);
+            MethodHandles.insertArguments(
+                factory.getHandle(linkageContext, /* linked= */ false), 1, dependency),
+            dependency);
     // We might need a boxing conversion or some other type conversion here to satisfy a generic.
     injectHandle = castReturnTo(injectHandle, handle.type().parameterType(1));
     // Call the injectHandle and pass it to the field handle.

--- a/core/src/com/google/inject/internal/SingleFieldInjector.java
+++ b/core/src/com/google/inject/internal/SingleFieldInjector.java
@@ -25,6 +25,7 @@ import com.google.inject.spi.InjectionPoint;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 /** Sets an injectable field. */
 final class SingleFieldInjector implements SingleMemberInjector {
@@ -69,8 +70,8 @@ final class SingleFieldInjector implements SingleMemberInjector {
     // unreflect should always succeed due to the setAccessible call in the constructor.
     // (T, V)->void
     var handle = InternalMethodHandles.unreflectSetter(field);
-    // Add an ignored receiver if there are no parameters (aka it is a static field).
-    if (handle.type().parameterCount() == 0) {
+    // Add an ignored receiver if there is no reciever parameter (aka it is a static field).
+    if (Modifier.isStatic(field.getModifiers())) {
       handle = MethodHandles.dropArguments(handle, 0, Object.class);
     }
     // Catch and rethrow exceptions from our dependency factory.

--- a/core/src/com/google/inject/internal/SingleMethodInjector.java
+++ b/core/src/com/google/inject/internal/SingleMethodInjector.java
@@ -19,7 +19,6 @@ package com.google.inject.internal;
 import static com.google.inject.internal.InternalMethodHandles.BIFUNCTION_APPLY_HANDLE;
 import static com.google.inject.internal.InternalMethodHandles.METHOD_INVOKE_HANDLE;
 import static com.google.inject.internal.InternalMethodHandles.castReturnTo;
-import static com.google.inject.internal.InternalMethodHandles.castReturnToObject;
 import static java.lang.invoke.MethodType.methodType;
 
 import com.google.inject.spi.InjectionPoint;
@@ -60,6 +59,7 @@ final class SingleMethodInjector implements SingleMemberInjector {
     if (InternalFlags.getUseExperimentalMethodHandlesOption()) {
       MethodHandle methodHandle = InternalMethodHandles.unreflect(method);
       if (methodHandle != null) {
+        methodHandle = InternalMethodHandles.dropReturn(methodHandle);
         if ((method.getModifiers() & Modifier.STATIC) != 0) {
           // insert a fake ignored receiver
           methodHandle = MethodHandles.dropArguments(methodHandle, 0, Object.class);
@@ -115,19 +115,20 @@ final class SingleMethodInjector implements SingleMemberInjector {
     if (InternalFlags.isBytecodeGenEnabled()) {
       try {
         BiFunction<Object, Object[], Object> fastMethod = BytecodeGen.fastMethod(method);
-        // (Object o1, Object o2, ...Object oN, Object receiver) -> void
         if (fastMethod != null) {
-          MethodHandle fastMethodHandle =
-              InternalFlags.getUseExperimentalMethodHandlesOption()
-                  ? BIFUNCTION_APPLY_HANDLE
+          // (Object receiver, Object[]) -> void
+          MethodHandle fastMethodHandle;
+          if (InternalFlags.getUseExperimentalMethodHandlesOption()) {
+              var handle = BIFUNCTION_APPLY_HANDLE
                       .bindTo(fastMethod)
-                      .asType(methodType(Object.class, Object[].class, Object.class))
-                      // Have it collect N arguments into an array of type Object[]
-                      // This is safe because the number of parameters is the same as the number of
-                      // parameters to the method which should never exceed the maximum number of
-                      // method parameters.
-                      .asCollector(Object[].class, method.getParameterCount())
-                  : null;
+                      // Cast the first parameter to `Object[]`
+                      .asType(methodType(Object.class, Object[].class, Object.class));
+              handle = InternalMethodHandles.dropReturn(handle);
+              handle = MethodHandles.permuteArguments(handle, methodType(void.class, Object.class, InternalContext.class), new int[]{1,0});
+              fastMethodHandle = handle;
+          } else {
+            fastMethodHandle = null;
+          }
           return new MethodInvoker() {
             @Override
             public Object invoke(Object target, Object... parameters)
@@ -142,25 +143,14 @@ final class SingleMethodInjector implements SingleMemberInjector {
             @Override
             public MethodHandle getInjectHandle(
                 LinkageContext linkageContext, MethodHandle[] parameterHandles) {
-              // We are calling the fast class method which we have use `asCollector` adapter to
-              // turn into N object parameters, cast each parameterInjector to Object to account.
-              for (int i = 0; i < parameterHandles.length; i++) {
-                parameterHandles[i] = castReturnToObject(parameterHandles[i]);
-              }
               // Invoke the handle with the parameters.
               // The signature is now:
-              // (nternalContext,InternalContext,InternalContext...,Object receiver)-R
-              // With one internalContext per parameter.
-              var handle = MethodHandles.filterArguments(fastMethodHandle, 0, parameterHandles);
-              // Now permute to 1. move the receiver to the beginning and 2. merge all the internal
-              // context parameters
-              int[] permutations = new int[parameterHandles.length + 1];
-              permutations[parameterHandles.length] = 1;
-              handle =
-                  MethodHandles.permuteArguments(
-                      handle,
-                      methodType(void.class, InternalContext.class, Object.class),
-                      permutations);
+              // (InternalContext, Object reciever)-R
+              var handle =
+                  MethodHandles.filterArguments(
+                      fastMethodHandle,
+                      1,
+                      InternalMethodHandles.buildObjectArrayFactory(parameterHandles));
               return handle;
             }
           };
@@ -187,20 +177,14 @@ final class SingleMethodInjector implements SingleMemberInjector {
           LinkageContext linkageContext, MethodHandle[] parameterHandles) {
         // See comments in ProviderMethod on why we use reflection here and how rarely this happens.
         // bind to the `Method` object
+        // (Object, Object[])->Object
         var handle = METHOD_INVOKE_HANDLE.bindTo(method);
-        // collect the parameters into an array of type Object[]
-        var arrayHandle =
-            MethodHandles.identity(Object[].class)
-                .asCollector(Object[].class, parameterHandles.length);
-        // supply all parameters
-        arrayHandle = MethodHandles.filterArguments(arrayHandle, 0, parameterHandles);
-        arrayHandle =
-            MethodHandles.permuteArguments(
-                arrayHandle,
-                methodType(Object[].class, InternalContext.class),
-                new int[parameterHandles.length]);
+        // (Object, InternalContext)->Object
+        handle =
+            MethodHandles.filterArguments(
+                handle, 1, InternalMethodHandles.buildObjectArrayFactory(parameterHandles));
+        // (Object, InternalContext)->void
         handle = InternalMethodHandles.dropReturn(handle); // we never care about return values.
-        handle = MethodHandles.filterArguments(handle, 1, arrayHandle);
         return handle;
       }
     };
@@ -229,10 +213,8 @@ final class SingleMethodInjector implements SingleMemberInjector {
   public MethodHandle getInjectHandle(LinkageContext linkageContext) {
     MethodHandle[] parameterInjectors =
         SingleParameterInjector.getAllHandles(linkageContext, this.parameterInjectors);
-    var methodHandle =
-        methodInvoker
-            .getInjectHandle(linkageContext, parameterInjectors)
-            .asType(methodType(void.class, Object.class, InternalContext.class));
+        // ()
+    var methodHandle = methodInvoker.getInjectHandle(linkageContext, parameterInjectors);
     methodHandle =
         InternalMethodHandles.catchErrorInMethodAndRethrowWithSource(methodHandle, injectionPoint);
     return methodHandle;

--- a/core/src/com/google/inject/internal/SingleMethodInjector.java
+++ b/core/src/com/google/inject/internal/SingleMethodInjector.java
@@ -17,11 +17,9 @@
 package com.google.inject.internal;
 
 import static com.google.inject.internal.InternalMethodHandles.BIFUNCTION_APPLY_HANDLE;
-import static com.google.inject.internal.InternalMethodHandles.METHOD_INVOKE_HANDLE;
 import static com.google.inject.internal.InternalMethodHandles.castReturnTo;
 import static java.lang.invoke.MethodType.methodType;
 
-import com.google.inject.internal.UniqueAnnotations.Internal;
 import com.google.inject.spi.InjectionPoint;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -186,8 +184,7 @@ final class SingleMethodInjector implements SingleMemberInjector {
         // See comments in ProviderMethod on why we use reflection here and how rarely this happens.
         // bind to the `Method` object
         // (Object, Object[])->Object
-        var handle = METHOD_INVOKE_HANDLE.bindTo(method);
-        handle = InternalMethodHandles.catchInvocationTargetExceptionAndRethrowCause(handle);
+        var handle = InternalMethodHandles.invokeHandle(method);
         handle = InternalMethodHandles.dropReturn(handle); // we never care about return values.
         handle = InternalMethodHandles.catchErrorInMethodAndRethrowWithSource(handle, injectionPoint);
         // (Object, InternalContext)->Object

--- a/core/src/com/google/inject/internal/SingleParameterInjector.java
+++ b/core/src/com/google/inject/internal/SingleParameterInjector.java
@@ -19,6 +19,7 @@ package com.google.inject.internal;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.inject.spi.Dependency;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 /** Resolves a single parameter, to be used in a constructor or method invocation. */
 final class SingleParameterInjector<T> {
@@ -47,13 +48,19 @@ final class SingleParameterInjector<T> {
     }
   }
 
-  /** Returns a method handle for the injection. */
+  /**
+   * Returns a method handle for the injection.
+   *
+   * <p>The returned handle has the type `(InternalContext)->Object`
+   */
   MethodHandle getInjectHandle(LinkageContext context) {
     var handle = this.handle;
     if (handle == null) {
       handle =
           InternalMethodHandles.catchInternalProvisionExceptionAndRethrowWithSource(
-              factory.getHandle(context, dependency, /* linked= */ false), dependency);
+              MethodHandles.insertArguments(
+                  factory.getHandle(context, /* linked= */ false), 1, dependency),
+              dependency);
       this.handle = handle;
     }
     return handle;

--- a/core/src/com/google/inject/internal/UntargettedBindingImpl.java
+++ b/core/src/com/google/inject/internal/UntargettedBindingImpl.java
@@ -42,7 +42,7 @@ final class UntargettedBindingImpl<T> extends BindingImpl<T> implements Untarget
           }
 
           @Override
-          MethodHandle makeHandle(LinkageContext context, boolean linked) {
+          MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
             throw new AssertionError();
           }
         },

--- a/core/src/com/google/inject/internal/UntargettedBindingImpl.java
+++ b/core/src/com/google/inject/internal/UntargettedBindingImpl.java
@@ -42,7 +42,7 @@ final class UntargettedBindingImpl<T> extends BindingImpl<T> implements Untarget
           }
 
           @Override
-          public MethodHandle getHandle(LinkageContext context, boolean linked) {
+          MethodHandle makeHandle(LinkageContext context, boolean linked) {
             throw new AssertionError();
           }
         },

--- a/core/src/com/google/inject/internal/UntargettedBindingImpl.java
+++ b/core/src/com/google/inject/internal/UntargettedBindingImpl.java
@@ -26,7 +26,6 @@ import com.google.inject.Key;
 import com.google.inject.spi.BindingTargetVisitor;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.UntargettedBinding;
-import java.lang.invoke.MethodHandle;
 
 final class UntargettedBindingImpl<T> extends BindingImpl<T> implements UntargettedBinding<T> {
 

--- a/core/src/com/google/inject/internal/UntargettedBindingImpl.java
+++ b/core/src/com/google/inject/internal/UntargettedBindingImpl.java
@@ -42,8 +42,7 @@ final class UntargettedBindingImpl<T> extends BindingImpl<T> implements Untarget
           }
 
           @Override
-          public MethodHandle getHandle(
-              LinkageContext context, Dependency<?> dependency, boolean linked) {
+          public MethodHandle getHandle(LinkageContext context, boolean linked) {
             throw new AssertionError();
           }
         },

--- a/core/src/com/google/inject/internal/aop/AnonymousClassDefiner.java
+++ b/core/src/com/google/inject/internal/aop/AnonymousClassDefiner.java
@@ -61,10 +61,4 @@ final class AnonymousClassDefiner implements ClassDefiner {
 
     return (Class<?>) ANONYMOUS_DEFINE_METHOD.invoke(THE_UNSAFE, hostClass, bytecode, null);
   }
-
-  @Override
-  public Class<?> defineCollectable(Object lifetimeOwner, Class<?> hostClass, byte[] bytecode)
-      throws Exception {
-    return define(hostClass, bytecode);
-  }
 }

--- a/core/src/com/google/inject/internal/aop/ClassDefiner.java
+++ b/core/src/com/google/inject/internal/aop/ClassDefiner.java
@@ -21,13 +21,4 @@ interface ClassDefiner {
 
   /** Defines a new class relative to the host. */
   Class<?> define(Class<?> hostClass, byte[] bytecode) throws Exception;
-
-  /**
-   * Defines a new class relative to the host. This class should be able to be independently
-   * collected and need not be accessible by name.
-   *
-   * @param lifetimeOwner The object to whose lifetime the new class should be tied.
-   */
-  Class<?> defineCollectable(Object lifetimeOwner, Class<?> hostClass, byte[] bytecode)
-      throws Exception;
 }

--- a/core/src/com/google/inject/internal/aop/ClassDefining.java
+++ b/core/src/com/google/inject/internal/aop/ClassDefining.java
@@ -44,18 +44,6 @@ public final class ClassDefining {
     return ClassDefinerHolder.INSTANCE.define(hostClass, bytecode);
   }
 
-  /**
-   * Defines a new class relative to the host.
-   *
-   * <p>This class should be able to be independently collected and need not be accessible by name.
-   *
-   * @param lifetimeOwner The object to whose lifetime the new class should be tied.
-   */
-  public static Class<?> defineCollectable(
-      Object lifetimeOwner, Class<?> hostClass, byte[] bytecode) throws Exception {
-    return ClassDefinerHolder.INSTANCE.defineCollectable(lifetimeOwner, hostClass, bytecode);
-  }
-
   /** Returns true if the current class definer allows access to package-private members. */
   public static boolean hasPackageAccess() {
     return ClassDefinerHolder.IS_UNSAFE;
@@ -83,21 +71,9 @@ public final class ClassDefining {
       return new ChildClassDefiner(); // second choice unless forbidden
     } else {
       logger.warning(CLASS_DEFINING_UNSUPPORTED);
-      return UnsupportedClassDefiner.INSTANCE;
-    }
-  }
-
-  private static final class UnsupportedClassDefiner implements ClassDefiner {
-    private static final UnsupportedClassDefiner INSTANCE = new UnsupportedClassDefiner();
-
-    @Override
-    public Class<?> define(Class<?> hostClass, byte[] bytecode) {
-      throw new UnsupportedOperationException("Cannot define class, " + CLASS_DEFINING_UNSUPPORTED);
-    }
-
-    @Override
-    public Class<?> defineCollectable(Object lifetimeOwner, Class<?> hostClass, byte[] bytecode) {
-      throw new UnsupportedOperationException("Cannot define class, " + CLASS_DEFINING_UNSUPPORTED);
+      return (host, bytes)-> {
+        throw new UnsupportedOperationException("Cannot define class, " + CLASS_DEFINING_UNSUPPORTED);
+      };
     }
   }
 }

--- a/core/src/com/google/inject/internal/aop/GeneratedClassDefiner.java
+++ b/core/src/com/google/inject/internal/aop/GeneratedClassDefiner.java
@@ -35,9 +35,4 @@ final class GeneratedClassDefiner implements ClassDefiner {
   public Class<?> define(Class<?> hostClass, byte[] bytecode) {
     return defineAccess.apply(hostClass.getClassLoader(), bytecode);
   }
-
-  @Override
-  public Class<?> defineCollectable(Object lifetimeOwner, Class<?> hostClass, byte[] bytecode) {
-    throw new UnsupportedOperationException("Not implemented");
-  }
 }

--- a/core/src/com/google/inject/internal/aop/HiddenClassDefiner.java
+++ b/core/src/com/google/inject/internal/aop/HiddenClassDefiner.java
@@ -88,13 +88,6 @@ final class HiddenClassDefiner implements ClassDefiner {
     return definedLookup.lookupClass();
   }
 
-  @Override
-  public Class<?> defineCollectable(Object lifetimeOwner, Class<?> hostClass, byte[] bytecode)
-      throws Exception {
-    // These are always collectable
-    return define(hostClass, bytecode);
-  }
-
   /** Creates {@link MethodHandles.Lookup.ClassOption} array with the named options. */
   @SuppressWarnings("unchecked")
   private static Object classOptions(String... options) throws ClassNotFoundException {

--- a/core/src/com/google/inject/internal/aop/UnsafeClassDefiner.java
+++ b/core/src/com/google/inject/internal/aop/UnsafeClassDefiner.java
@@ -116,17 +116,6 @@ final class UnsafeClassDefiner implements ClassDefiner {
     return findClassDefiner(hostClass.getClassLoader()).define(hostClass, bytecode);
   }
 
-  @Override
-  public Class<?> defineCollectable(Object lifetimeOwner, Class<?> hostClass, byte[] bytecode)
-      throws Exception {
-    // We want to behave like `ALWAYS_DEFINE_ANOYNMOUSLY` was set
-    // if we define classes into an existing classloader they will be tied to the lifetime of
-    // that classloader, but using the UNSAFE_DEFINER ensures that we either delgate to
-    // MethodHandles.defineHiddenClass or Unsafe.defineAnonymousClass which both create classes
-    // that are independently collectable.
-    return UNSAFE_DEFINER.defineCollectable(lifetimeOwner, hostClass, bytecode);
-  }
-
   /** Finds the appropriate class definer for the given class loader. */
   private static ClassDefiner findClassDefiner(ClassLoader hostLoader) {
     if (hostLoader == null || ALWAYS_DEFINE_ANONYMOUSLY) {

--- a/core/src/com/google/inject/spi/BindingSourceRestriction.java
+++ b/core/src/com/google/inject/spi/BindingSourceRestriction.java
@@ -13,7 +13,6 @@ import com.google.inject.RestrictedBindingSource;
 import com.google.inject.RestrictedBindingSource.RestrictionLevel;
 import com.google.inject.internal.Errors;
 import com.google.inject.internal.GuiceInternal;
-import java.util.regex.Pattern;
 import java.lang.annotation.Annotation;
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -25,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -345,8 +345,12 @@ public final class BindingSourceRestriction {
           Stream.concat(
               annotations, Arrays.stream(clazz.getAnnotatedSuperclass().getAnnotations()));
     }
-    return annotations
-        .map(Annotation::annotationType)
-        .filter(a -> a.isAnnotationPresent(RestrictedBindingSource.Permit.class));
+    @SuppressWarnings("unchecked")  // force wildcard alignment, this works around a bug in ecj
+    Stream<Class<? extends Annotation>> permits =
+        (Stream)
+            annotations
+                .map(Annotation::annotationType)
+                .filter(a -> a.isAnnotationPresent(RestrictedBindingSource.Permit.class));
+    return permits;
   }
 }

--- a/core/test/com/google/inject/ProvisionExceptionsTest.java
+++ b/core/test/com/google/inject/ProvisionExceptionsTest.java
@@ -16,11 +16,17 @@
 
 package com.google.inject;
 
+import static com.google.inject.name.Names.named;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 import com.google.inject.internal.Messages;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import java.io.IOException;
-import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests that ProvisionExceptions are readable and clearly indicate to the user what went wrong with
@@ -28,8 +34,10 @@ import junit.framework.TestCase;
  *
  * @author sameb@google.com (Sam Berlin)
  */
-public class ProvisionExceptionsTest extends TestCase {
+@RunWith(JUnit4.class)
+public class ProvisionExceptionsTest{
 
+  @Test
   public void testConstructorRuntimeException() {
     Injector injector =
         Guice.createInjector(
@@ -41,20 +49,23 @@ public class ProvisionExceptionsTest extends TestCase {
                 bind(Tracer.class).to(TracerImpl.class);
               }
             });
-    try {
-      injector.getInstance(Tracer.class);
-      fail();
-    } catch (ProvisionException pe) {
-      // Make sure our initial error message gives the user exception.
-      Asserts.assertContains(
-          pe.getMessage(), "1) [Guice/ErrorInjectingConstructor]: IllegalStateException: boom!");
-      assertEquals(1, pe.getErrorMessages().size());
-      assertEquals(IllegalStateException.class, pe.getCause().getClass());
-      assertEquals(
-          IllegalStateException.class, Messages.getOnlyCause(pe.getErrorMessages()).getClass());
-    }
+    var pe =
+        assertThrows(
+            ProvisionException.class,
+            () -> {
+              injector.getInstance(Tracer.class);
+            });
+
+    // Make sure our initial error message gives the user exception.
+    Asserts.assertContains(
+        pe.getMessage(), "1) [Guice/ErrorInjectingConstructor]: IllegalStateException: boom!");
+    assertEquals(1, pe.getErrorMessages().size());
+    assertEquals(IllegalStateException.class, pe.getCause().getClass());
+    assertEquals(
+        IllegalStateException.class, Messages.getOnlyCause(pe.getErrorMessages()).getClass());
   }
 
+  @Test
   public void testConstructorCheckedException() {
     Injector injector =
         Guice.createInjector(
@@ -66,19 +77,21 @@ public class ProvisionExceptionsTest extends TestCase {
                 bind(Tracer.class).to(TracerImpl.class);
               }
             });
-    try {
-      injector.getInstance(Tracer.class);
-      fail();
-    } catch (ProvisionException pe) {
-      // Make sure our initial error message gives the user exception.
-      Asserts.assertContains(
-          pe.getMessage(), "[Guice/ErrorInjectingConstructor]: IOException: boom!");
-      assertEquals(1, pe.getErrorMessages().size());
-      assertEquals(IOException.class, pe.getCause().getClass());
-      assertEquals(IOException.class, Messages.getOnlyCause(pe.getErrorMessages()).getClass());
-    }
+    var pe =
+        assertThrows(
+            ProvisionException.class,
+            () -> {
+              injector.getInstance(Tracer.class);
+            });
+    // Make sure our initial error message gives the user exception.
+    Asserts.assertContains(
+        pe.getMessage(), "[Guice/ErrorInjectingConstructor]: IOException: boom!");
+    assertEquals(1, pe.getErrorMessages().size());
+    assertEquals(IOException.class, pe.getCause().getClass());
+    assertEquals(IOException.class, Messages.getOnlyCause(pe.getErrorMessages()).getClass());
   }
 
+  @Test
   public void testCustomProvidersRuntimeException() {
     Injector injector =
         Guice.createInjector(
@@ -96,20 +109,23 @@ public class ProvisionExceptionsTest extends TestCase {
                 bind(Tracer.class).to(TracerImpl.class);
               }
             });
-    try {
-      injector.getInstance(Tracer.class);
-      fail();
-    } catch (ProvisionException pe) {
-      // Make sure our initial error message gives the user exception.
-      Asserts.assertContains(
-          pe.getMessage(), "1) [Guice/ErrorInCustomProvider]: IllegalStateException: boom!");
-      assertEquals(1, pe.getErrorMessages().size());
-      assertEquals(IllegalStateException.class, pe.getCause().getClass());
-      assertEquals(
-          IllegalStateException.class, Messages.getOnlyCause(pe.getErrorMessages()).getClass());
-    }
+    var pe =
+        assertThrows(
+            ProvisionException.class,
+            () -> {
+              injector.getInstance(Tracer.class);
+            });
+
+    // Make sure our initial error message gives the user exception.
+    Asserts.assertContains(
+        pe.getMessage(), "1) [Guice/ErrorInCustomProvider]: IllegalStateException: boom!");
+    assertEquals(1, pe.getErrorMessages().size());
+    assertEquals(IllegalStateException.class, pe.getCause().getClass());
+    assertEquals(
+        IllegalStateException.class, Messages.getOnlyCause(pe.getErrorMessages()).getClass());
   }
 
+  @Test
   public void testProviderMethodRuntimeException() {
     Injector injector =
         Guice.createInjector(
@@ -124,20 +140,22 @@ public class ProvisionExceptionsTest extends TestCase {
                 return Explosion.createRuntime();
               }
             });
-    try {
-      injector.getInstance(Tracer.class);
-      fail();
-    } catch (ProvisionException pe) {
-      // Make sure our initial error message gives the user exception.
-      Asserts.assertContains(
-          pe.getMessage(), "1) [Guice/ErrorInCustomProvider]: IllegalStateException: boom!");
-      assertEquals(1, pe.getErrorMessages().size());
-      assertEquals(IllegalStateException.class, pe.getCause().getClass());
-      assertEquals(
-          IllegalStateException.class, Messages.getOnlyCause(pe.getErrorMessages()).getClass());
-    }
+    var pe =
+        assertThrows(
+            ProvisionException.class,
+            () -> {
+              injector.getInstance(Tracer.class);
+            });
+    // Make sure our initial error message gives the user exception.
+    Asserts.assertContains(
+        pe.getMessage(), "1) [Guice/ErrorInCustomProvider]: IllegalStateException: boom!");
+    assertEquals(1, pe.getErrorMessages().size());
+    assertEquals(IllegalStateException.class, pe.getCause().getClass());
+    assertEquals(
+        IllegalStateException.class, Messages.getOnlyCause(pe.getErrorMessages()).getClass());
   }
 
+  @Test
   public void testProviderMethodCheckedException() {
     Injector injector =
         Guice.createInjector(
@@ -152,18 +170,68 @@ public class ProvisionExceptionsTest extends TestCase {
                 return Explosion.createChecked();
               }
             });
-    try {
-      injector.getInstance(Tracer.class);
-      fail();
-    } catch (ProvisionException pe) {
-      pe.printStackTrace();
-      // Make sure our initial error message gives the user exception.
-      Asserts.assertContains(
-          pe.getMessage(), "1) [Guice/ErrorInCustomProvider]: IOException: boom!");
-      assertEquals(1, pe.getErrorMessages().size());
-      assertEquals(IOException.class, pe.getCause().getClass());
-      assertEquals(IOException.class, Messages.getOnlyCause(pe.getErrorMessages()).getClass());
+    var pe =
+        assertThrows(
+            ProvisionException.class,
+            () -> {
+              injector.getInstance(Tracer.class);
+            });
+    pe.printStackTrace();
+    // Make sure our initial error message gives the user exception.
+    Asserts.assertContains(pe.getMessage(), "1) [Guice/ErrorInCustomProvider]: IOException: boom!");
+    assertEquals(1, pe.getErrorMessages().size());
+    assertEquals(IOException.class, pe.getCause().getClass());
+    assertEquals(IOException.class, Messages.getOnlyCause(pe.getErrorMessages()).getClass());
+  }
+
+  static final class Errorer {
+    @Inject
+    Errorer() {
+      throw new OutOfMemoryError("uh oh");
     }
+  }
+  static final class MethodErrorer {
+    @Inject MethodErrorer() {}
+    @Inject void injectErrorer() {
+      throw new OutOfMemoryError("uh oh");
+    }
+  }
+
+  // Demonstrate that different bindings do and do not wrap Errors thrown.
+  // Constructor and method injection does since the reflection API does it for us via
+  // InvocationTargetException.
+  // Provider instances do not since we have our own catch clauses and only catch RuntimeException
+  @Test
+  public void testErrorPropagation() {
+    Injector injector =
+        Guice.createInjector(
+            new AbstractModule() {
+
+              @Override
+              protected void configure() {
+                bind(Key.get(String.class, named("providerInstance")))
+                    .toProvider(
+                        () -> {
+                          throw new OutOfMemoryError("uh oh");
+                        });
+                bind(Errorer.class);
+                bind(MethodErrorer.class);
+              }
+
+              @Provides
+              @Named("provides")
+              String provideString() {
+                throw new OutOfMemoryError("uh oh");
+              }
+            });
+    assertThrows(ProvisionException.class, () -> injector.getInstance(Errorer.class));
+    assertThrows(ProvisionException.class, () -> injector.getInstance(MethodErrorer.class));
+    assertThrows(
+        OutOfMemoryError.class,
+        () -> injector.getInstance(Key.get(String.class, named("providerInstance"))));
+    assertThrows(
+        ProvisionException.class,
+        () -> injector.getInstance(Key.get(String.class, named("provides"))));
   }
 
   private static interface Exploder {}

--- a/core/test/com/google/inject/ProvisionExceptionsTest.java
+++ b/core/test/com/google/inject/ProvisionExceptionsTest.java
@@ -16,13 +16,17 @@
 
 package com.google.inject;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.inject.name.Names.named;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.Iterables;
 import com.google.inject.internal.Messages;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
+import com.google.inject.spi.Dependency;
+import com.google.inject.spi.HasDependencies;
 import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -196,6 +200,28 @@ public class ProvisionExceptionsTest{
       throw new OutOfMemoryError("uh oh");
     }
   }
+  static final class MethodDependencyErrorer {
+    @Inject MethodDependencyErrorer() {}
+    @Inject void injectErrorer(@Named("providerInstance") String s) {
+    }
+  }
+  static final class FieldDependencyErrorer {
+    @Inject FieldDependencyErrorer() {}
+    @Inject @Named("providerInstance") String s;
+  }
+  static final class ProviderErrorer implements Provider<String> {
+    private final String s;
+
+    @Inject
+    ProviderErrorer(@Named("providerInstance") String s) {
+      this.s = s;
+    }
+
+    @Override
+    public String get() {
+      return s;
+    }
+  }
 
   // Demonstrate that different bindings do and do not wrap Errors thrown.
   // Constructor and method injection does since the reflection API does it for us via
@@ -209,6 +235,8 @@ public class ProvisionExceptionsTest{
 
               @Override
               protected void configure() {
+                bind(Key.get(String.class, named("providerClass")))
+                    .toProvider(ProviderErrorer.class);
                 bind(Key.get(String.class, named("providerInstance")))
                     .toProvider(
                         () -> {
@@ -216,6 +244,8 @@ public class ProvisionExceptionsTest{
                         });
                 bind(Errorer.class);
                 bind(MethodErrorer.class);
+                bind(MethodDependencyErrorer.class);
+                bind(FieldDependencyErrorer.class);
               }
 
               @Provides
@@ -223,15 +253,89 @@ public class ProvisionExceptionsTest{
               String provideString() {
                 throw new OutOfMemoryError("uh oh");
               }
+
+              @Provides
+              @Named("providesFromDependency")
+              String provideString(@Named("providerInstance") String s) {
+                return s;
+              }
             });
     assertThrows(ProvisionException.class, () -> injector.getInstance(Errorer.class));
     assertThrows(ProvisionException.class, () -> injector.getInstance(MethodErrorer.class));
+    assertThrows(OutOfMemoryError.class, () -> injector.getInstance(MethodDependencyErrorer.class));
+    assertThrows(OutOfMemoryError.class, () -> injector.getInstance(FieldDependencyErrorer.class));
     assertThrows(
         OutOfMemoryError.class,
         () -> injector.getInstance(Key.get(String.class, named("providerInstance"))));
     assertThrows(
         ProvisionException.class,
         () -> injector.getInstance(Key.get(String.class, named("provides"))));
+    assertThrows(
+        ProvisionException.class,
+        () -> injector.getInstance(Key.get(String.class, named("providesFromDependency"))));
+    assertThrows(
+        OutOfMemoryError.class,
+        () -> injector.getInstance(Key.get(String.class, named("providerClass"))));
+  }
+
+  static final class DependsOnFailingProvider {
+    @Inject
+    DependsOnFailingProvider(String failing) {
+      throw new AssertionError("unreachable");
+    }
+  }
+
+  /**
+   * Demonstrate that the order of `sources` is different depending on what kind of binding fails.
+   *
+   * <p>`@Provides` methods add the method to the source stack if a dependency fails, but `@Inject`
+   * constructors do not.
+   */
+  @Test
+  public void testDependencyFailingTrace() throws NoSuchMethodException {
+    var module =
+        new AbstractModule() {
+
+          @Provides
+          String provideFailingValue() {
+            throw new RuntimeException("boom");
+          }
+
+          @Provides
+          Object providesDependsOnFailingProvider(String failing) {
+            throw new AssertionError("unreachable");
+          }
+        };
+    Injector injector = Guice.createInjector(module);
+    var provideFailingValue = injector.getBinding(String.class).getSource();
+    var providesDependsOnFailingProvider = injector.getBinding(Object.class).getSource();
+    var providesDependensOnFailingProvider_failing =
+        Iterables.getOnlyElement(
+            ((HasDependencies) injector.getBinding(Object.class)).getDependencies());
+    var pe = assertThrows(ProvisionException.class, () -> injector.getInstance(Object.class));
+    var message = Iterables.getOnlyElement(pe.getErrorMessages()).getErrorDetail();
+    assertThat(message.getCause()).hasMessageThat().isEqualTo("boom");
+    assertThat(message.getSources())
+        .containsExactly(
+            Dependency.get(Key.get(Object.class)), // what we asked for
+            providesDependsOnFailingProvider, // the provider method
+            providesDependensOnFailingProvider_failing, // the dependency of the provider method
+            provideFailingValue); // the thing that failed
+
+    var dependsOnFailingProvider_failing =
+        Iterables.getOnlyElement(
+            ((HasDependencies) injector.getBinding(DependsOnFailingProvider.class))
+                .getDependencies());
+    pe =
+        assertThrows(
+            ProvisionException.class, () -> injector.getInstance(DependsOnFailingProvider.class));
+    message = Iterables.getOnlyElement(pe.getErrorMessages()).getErrorDetail();
+    assertThat(message.getCause()).hasMessageThat().isEqualTo("boom");
+    assertThat(message.getSources())
+        .containsExactly(
+            Dependency.get(Key.get(DependsOnFailingProvider.class)), // what we asked for
+            dependsOnFailingProvider_failing, // the dependency of the constructor
+            provideFailingValue); // the thing that failed.
   }
 
   private static interface Exploder {}

--- a/core/test/com/google/inject/internal/InternalFactoryTest.java
+++ b/core/test/com/google/inject/internal/InternalFactoryTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.inject.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.google.inject.spi.Dependency;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class InternalFactoryTest {
+
+  @Test
+  public void testMethodHandleCaching_returnsOneAcrossConcurrentThreads() throws Exception {
+    int numThreads = 10;
+    // race 10 threads to make the handle, check that they all return the same thing.
+    var makeHandleLatch = new CountDownLatch(numThreads);
+    var factory =
+        new InternalFactory<String>() {
+          @Override
+          public String get(InternalContext context, Dependency<?> dependency, boolean linked) {
+            return "Hello, World!";
+          }
+
+          @Override
+          MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+            makeHandleLatch.countDown();
+            Uninterruptibles.awaitUninterruptibly(makeHandleLatch);
+            return makeCachable(InternalMethodHandles.constantFactoryGetHandle("Hello, World!"));
+          }
+        };
+    var pool = Executors.newFixedThreadPool(numThreads);
+    var futures =
+        pool.invokeAll(
+            Collections.nCopies(numThreads, () -> factory.getHandle(new LinkageContext(), false)));
+    pool.shutdown();
+    var cachedResult = factory.getHandle(new LinkageContext(), false);
+    for (var future : futures) {
+      assertThat(future.get()).isSameInstanceAs(cachedResult);
+    }
+  }
+
+  @Test
+  public void testMethodHandleCaching_uncachableDoesntCache() throws Exception {
+    var factory =
+        new InternalFactory<String>() {
+          @Override
+          public String get(InternalContext context, Dependency<?> dependency, boolean linked) {
+            return "Hello, World!";
+          }
+
+          @Override
+          MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+            return makeUncachable(InternalMethodHandles.constantFactoryGetHandle("Hello, World!"));
+          }
+        };
+
+    assertThat(factory.getHandle(new LinkageContext(), false))
+        .isNotSameInstanceAs(factory.getHandle(new LinkageContext(), false));
+  }
+
+  @Test
+  public void testMethodHandleCaching_linkedCachesForEach() throws Exception {
+    var factory =
+        new InternalFactory<String>() {
+          @Override
+          public String get(InternalContext context, Dependency<?> dependency, boolean linked) {
+            return "Hello, World!";
+          }
+
+          @Override
+          MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+            return makeCachableOnLinkedSetting(
+                InternalMethodHandles.constantFactoryGetHandle("Hello, World!"));
+          }
+        };
+
+    assertThat(factory.getHandle(new LinkageContext(), false))
+        .isSameInstanceAs(factory.getHandle(new LinkageContext(), false));
+    assertThat(factory.getHandle(new LinkageContext(), true))
+        .isSameInstanceAs(factory.getHandle(new LinkageContext(), true));
+
+    assertThat(factory.getHandle(new LinkageContext(), true))
+        .isNotSameInstanceAs(factory.getHandle(new LinkageContext(), false));
+  }
+}

--- a/core/test/com/google/inject/internal/InternalMethodHandlesTest.java
+++ b/core/test/com/google/inject/internal/InternalMethodHandlesTest.java
@@ -68,17 +68,17 @@ public final class InternalMethodHandlesTest {
           }
 
           @Override
-          MethodHandle makeHandle(LinkageContext context, boolean linked) {
+          MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
 
             checkArgument(!linked);
-            return MethodHandles.dropArguments(
+            return makeCachable(MethodHandles.dropArguments(
                 MethodHandles.insertArguments(
                     MethodHandles.throwException(Object.class, InternalProvisionException.class),
                     0,
                     InternalProvisionException.create(ErrorId.OPTIONAL_CONSTRUCTOR, "Hello World")),
                 0,
                 InternalContext.class,
-                Dependency.class);
+                Dependency.class));
           }
         };
     Provider<String> provider = InternalMethodHandles.makeProvider(factory, injector, dep);
@@ -117,7 +117,7 @@ public final class InternalMethodHandlesTest {
         throw new AssertionError();
       }
       @Override 
-      MethodHandle makeHandle(LinkageContext context, boolean linked) {
+      MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
         throw new AssertionError();
       }
     };
@@ -135,8 +135,8 @@ public final class InternalMethodHandlesTest {
           }
 
           @Override
-          MethodHandle makeHandle(LinkageContext context, boolean linked) {
-            return InternalMethodHandles.constantFactoryGetHandle("Hello world");
+          MethodHandleResult makeHandle(LinkageContext context, boolean linked) {
+            return makeCachable(InternalMethodHandles.constantFactoryGetHandle("Hello world"));
           }
         };
     Provider<String> provider =

--- a/core/test/com/google/inject/internal/InternalMethodHandlesTest.java
+++ b/core/test/com/google/inject/internal/InternalMethodHandlesTest.java
@@ -116,6 +116,9 @@ public final class InternalMethodHandlesTest {
       public String get(InternalContext context, Dependency<?> dependency, boolean linked) {
         throw new AssertionError();
       }
+      @Override public MethodHandle getHandle(LinkageContext context, boolean linked) {
+        throw new AssertionError();
+      }
     };
   }
 

--- a/core/test/com/google/inject/internal/InternalMethodHandlesTest.java
+++ b/core/test/com/google/inject/internal/InternalMethodHandlesTest.java
@@ -68,7 +68,7 @@ public final class InternalMethodHandlesTest {
           }
 
           @Override
-          public MethodHandle getHandle(LinkageContext context, boolean linked) {
+          MethodHandle makeHandle(LinkageContext context, boolean linked) {
 
             checkArgument(!linked);
             return MethodHandles.dropArguments(
@@ -116,7 +116,8 @@ public final class InternalMethodHandlesTest {
       public String get(InternalContext context, Dependency<?> dependency, boolean linked) {
         throw new AssertionError();
       }
-      @Override public MethodHandle getHandle(LinkageContext context, boolean linked) {
+      @Override 
+      MethodHandle makeHandle(LinkageContext context, boolean linked) {
         throw new AssertionError();
       }
     };
@@ -134,7 +135,7 @@ public final class InternalMethodHandlesTest {
           }
 
           @Override
-          public MethodHandle getHandle(LinkageContext context, boolean linked) {
+          MethodHandle makeHandle(LinkageContext context, boolean linked) {
             return InternalMethodHandles.constantFactoryGetHandle("Hello world");
           }
         };

--- a/core/test/com/google/inject/internal/InternalMethodHandlesTest.java
+++ b/core/test/com/google/inject/internal/InternalMethodHandlesTest.java
@@ -52,7 +52,7 @@ public final class InternalMethodHandlesTest {
             factory, injector, Dependency.get(Key.get(String.class)));
 
     assertThat(provider.get()).isEqualTo("Hello World");
-    assertThat(provider).isInstanceOf(InternalMethodHandles.GeneratedProvider.class);
+    assertThat(provider).isInstanceOf(InternalMethodHandles.MethodHandleProvider.class);
   }
 
   @Test
@@ -136,7 +136,7 @@ public final class InternalMethodHandlesTest {
           }
         };
     Provider<String> provider =
-        InternalMethodHandles.makeScopedProvider(factory, injector, Key.get(String.class));
+        InternalMethodHandles.makeScopedProvider(factory, injector);
     assertThat(provider).isInstanceOf(ProviderToInternalFactoryAdapter.class);
 
     assertThat(provider.get()).isEqualTo("Hello world");

--- a/core/test/com/google/inject/internal/OptionalBinderTest.java
+++ b/core/test/com/google/inject/internal/OptionalBinderTest.java
@@ -61,6 +61,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.invoke.MethodHandles;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.List;

--- a/core/test/com/googlecode/guice/BytecodeGenTest.java
+++ b/core/test/com/googlecode/guice/BytecodeGenTest.java
@@ -35,11 +35,11 @@ import com.google.inject.Module;
 import com.google.inject.internal.InternalFlags;
 import com.google.inject.internal.InternalFlags.CustomClassLoadingOption;
 import com.googlecode.guice.PackageVisibilityTestModule.PublicUserOfPackagePrivate;
+import jakarta.inject.Inject;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
-import jakarta.inject.Inject;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Before;
@@ -363,8 +363,10 @@ public class BytecodeGenTest {
   // This tests for a situation where an osgi bundle contains a different version of guice.
   @Test
   public void testFastClassWithDifferentVersionsOfGuice() throws Throwable {
-    // Test relies on package access which CHILD loading doesn't have
-    if (InternalFlags.getCustomClassLoadingOption() == CustomClassLoadingOption.CHILD) {
+    // Test relies on package access which CHILD loading doesn't have and the methodhandle path
+    // doesn't use fastclasses
+    if (InternalFlags.getCustomClassLoadingOption() == CustomClassLoadingOption.CHILD
+        || InternalFlags.getUseExperimentalMethodHandlesOption()) {
       return;
     }
     Injector injector = Guice.createInjector();


### PR DESCRIPTION
This series addresses known issues in the experimental method handle implementation

  - MethodHandles produced by InternalFactory.getHandle are now cached.  This should speed up linking and reduce the number of 'lambda forms' we generate.
      - Doing this required demoting `Dependency` from the `getHandle` to be a runtime method parameter and changing InternalFactory to be an abstract class
  - We no longer generate custom `Provider` subclasses to hold `invokedynamic` instructions and instead use a simple hand written Provider class that lazily allocates a `MethodHandle` and calls invokeExact.
       - This should greatly speed up injector creation at the cost of a slightly more expensive `invokeExact` call. 
   - requestStaticInjection and MembersInjectors are now fully supported with MethodHandles.
   
 I imagine there are some as yet undiscovered issues but this should unblock broader experimentation.