### PR TITLE
Fix EntityManager leak in ThreadLocal after failed transaction

### DIFF
--- a/extensions/persist/src/com/google/inject/persist/jpa/JpaLocalTxnInterceptor.java
+++ b/extensions/persist/src/com/google/inject/persist/jpa/JpaLocalTxnInterceptor.java
@@ -65,6 +65,12 @@ class JpaLocalTxnInterceptor implements MethodInterceptor {
     try {
       result = methodInvocation.proceed();
 
+      if (txn.getRollbackOnly()) {
+        txn.rollback();
+      } else {
+        txn.commit();
+      }
+      return result;
     } catch (Exception e) {
       // commit transaction only if rollback didnt occur
       if (rollbackIfNecessary(transactional, e, txn)) {
@@ -74,33 +80,12 @@ class JpaLocalTxnInterceptor implements MethodInterceptor {
       // propagate whatever exception is thrown anyway
       throw e;
     } finally {
-      // Close the em if necessary (guarded so this code doesn't run unless catch fired).
-      if (null != didWeStartWork.get() && !txn.isActive()) {
-        didWeStartWork.remove();
-        unitOfWork.end();
-      }
-    }
-
-    // everything was normal so commit the txn (do not move into try block above as it
-    //  interferes with the advised method's throwing semantics)
-    try {
-      if (txn.isActive()) {
-        if (txn.getRollbackOnly()) {
-          txn.rollback();
-        } else {
-          txn.commit();
-        }
-      }
-    } finally {
-      // close the em if necessary
+      // Close the em if necessary
       if (null != didWeStartWork.get()) {
         didWeStartWork.remove();
         unitOfWork.end();
       }
     }
-
-    // or return result
-    return result;
   }
 
   // TODO(user): Cache this method's results.

--- a/extensions/persist/src/com/google/inject/persist/jpa/JpaLocalTxnInterceptor.java
+++ b/extensions/persist/src/com/google/inject/persist/jpa/JpaLocalTxnInterceptor.java
@@ -65,10 +65,8 @@ class JpaLocalTxnInterceptor implements MethodInterceptor {
     try {
       result = methodInvocation.proceed();
 
-      if (txn.getRollbackOnly()) {
-        txn.rollback();
-      } else {
-        txn.commit();
+      if (txn.isActive()) {
+        commitOrRollback(txn);
       }
       return result;
     } catch (Exception e) {
@@ -85,6 +83,14 @@ class JpaLocalTxnInterceptor implements MethodInterceptor {
         didWeStartWork.remove();
         unitOfWork.end();
       }
+    }
+  }
+
+  private void commitOrRollback(EntityTransaction txn) {
+    if (txn.getRollbackOnly()) {
+      txn.rollback();
+    } else {
+      txn.commit();
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug in JpaLocalTxnInterceptor where a broken EntityManager could remain in a thread’s ThreadLocal after a failed transaction, leading to subsequent requests failing when the same thread is reused by the web server (e.g., Jetty).

## Problem
- Guice Persist stores the EntityManager in a ThreadLocal.
- If a transaction fails due to a database connection issue (e.g., network blip):
- txn.isActive() incorrectly returns false because the connection is already dead.
- The cleanup logic is skipped due to this check.
- The broken EntityManager is never removed from the ThreadLocal.
- When the thread is reused for another request, the stale EntityManager is returned, causing immediate failures.

## Fix
- Updated cleanup logic to always remove the EntityManager from the ThreadLocal if this interceptor started the work, regardless of txn.isActive().
- Reorganized the try/catch/finally blocks so that commit/rollback semantics remain correct while ensuring cleanup runs after transaction handling.
- Ensures no broken EntityManager instances leak into future requests.

## Related Issue

Fixes https://github.com/google/guice/issues/1916 and https://github.com/google/guice/issues/1179