### PR TITLE
feat(multibindings): Enable spanning injectors for Multibinder, MapBinder, and OptionalBinder

### DIFF
--- a/core/src/com/google/inject/internal/RealMapBinder.java
+++ b/core/src/com/google/inject/internal/RealMapBinder.java
@@ -38,6 +38,7 @@ import com.google.inject.multibindings.MultibindingsTargetVisitor;
 import com.google.inject.spi.BindingTargetVisitor;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.Element;
+import com.google.inject.spi.ExposedBinding;
 import com.google.inject.spi.ProviderInstanceBinding;
 import com.google.inject.spi.ProviderWithExtensionVisitor;
 import com.google.inject.util.Types;
@@ -117,6 +118,62 @@ public final class RealMapBinder<K, V> implements Module {
         Key.get(mapOf(keyType, valueType), annotationType),
         RealMultibinder.newRealSetBinder(
             binder, Key.get(entryOfProviderOf(keyType, valueType), annotationType)));
+  }
+
+  /**
+   * Returns a new mapbinder that collects entries of {@code keyType}/{@code valueType} in a {@link
+   * Map} that is itself bound with {@code annotationType}.
+   */
+  public static <K, V> RealMapBinder<K, V> newRealMapBinder(
+      Binder binder,
+      TypeLiteral<K> keyType,
+      TypeLiteral<V> valueType,
+      Class<? extends Annotation> annotationType,
+      boolean bindMap) {
+    return newRealMapBinder(
+        binder,
+        keyType,
+        valueType,
+        Key.get(mapOf(keyType, valueType), annotationType),
+        RealMultibinder.newRealSetBinder(
+            binder, Key.get(entryOfProviderOf(keyType, valueType), annotationType), bindMap),
+        bindMap);
+  }
+
+  /**
+   * Returns a new mapbinder that collects entries of {@code keyType}/{@code valueType} in a {@link
+   * Map} that is itself bound with {@code annotation}.
+   */
+  public static <K, V> RealMapBinder<K, V> newRealMapBinder(
+      Binder binder,
+      TypeLiteral<K> keyType,
+      TypeLiteral<V> valueType,
+      Annotation annotation,
+      boolean bindMap) {
+    return newRealMapBinder(
+        binder,
+        keyType,
+        valueType,
+        Key.get(mapOf(keyType, valueType), annotation),
+        RealMultibinder.newRealSetBinder(
+            binder, Key.get(entryOfProviderOf(keyType, valueType), annotation), bindMap),
+        bindMap);
+  }
+
+  /**
+   * Returns a new mapbinder that collects entries of {@code keyType}/{@code valueType} in a {@link
+   * Map} that is itself bound with no binding annotation.
+   */
+  public static <K, V> RealMapBinder<K, V> newRealMapBinder(
+      Binder binder, TypeLiteral<K> keyType, TypeLiteral<V> valueType, boolean bindMap) {
+    return newRealMapBinder(
+        binder,
+        keyType,
+        valueType,
+        Key.get(mapOf(keyType, valueType)),
+        RealMultibinder.newRealSetBinder(
+            binder, Key.get(entryOfProviderOf(keyType, valueType)), bindMap),
+        bindMap);
   }
 
   @SuppressWarnings("unchecked") // a map of <K, V> is safely a Map<K, V>
@@ -240,8 +297,18 @@ public final class RealMapBinder<K, V> implements Module {
       TypeLiteral<V> valueType,
       Key<Map<K, V>> mapKey,
       RealMultibinder<Map.Entry<K, Provider<V>>> entrySetBinder) {
+    return newRealMapBinder(binder, keyType, valueType, mapKey, entrySetBinder, true);
+  }
+
+  private static <K, V> RealMapBinder<K, V> newRealMapBinder(
+      Binder binder,
+      TypeLiteral<K> keyType,
+      TypeLiteral<V> valueType,
+      Key<Map<K, V>> mapKey,
+      RealMultibinder<Map.Entry<K, Provider<V>>> entrySetBinder,
+      boolean bindMap) {
     RealMapBinder<K, V> mapBinder =
-        new RealMapBinder<>(binder, keyType, valueType, mapKey, entrySetBinder);
+        new RealMapBinder<>(binder, keyType, valueType, mapKey, entrySetBinder, bindMap);
     binder.install(mapBinder);
     return mapBinder;
   }
@@ -253,6 +320,8 @@ public final class RealMapBinder<K, V> implements Module {
 
   private final BindingSelection<K, V> bindingSelection;
   private final Binder binder;
+  private final boolean bindMap;
+  private boolean permitSpanInjectors;
 
   private final RealMultibinder<Map.Entry<K, Provider<V>>> entrySetBinder;
 
@@ -261,16 +330,23 @@ public final class RealMapBinder<K, V> implements Module {
       TypeLiteral<K> keyType,
       TypeLiteral<V> valueType,
       Key<Map<K, V>> mapKey,
-      RealMultibinder<Map.Entry<K, Provider<V>>> entrySetBinder) {
+      RealMultibinder<Map.Entry<K, Provider<V>>> entrySetBinder,
+      boolean bindMap) {
     this.bindingSelection = new BindingSelection<>(keyType, valueType, mapKey, entrySetBinder);
     this.binder = binder;
     this.entrySetBinder = entrySetBinder;
+    this.bindMap = bindMap;
   }
 
   public void permitDuplicates() {
     checkConfiguration(!bindingSelection.isInitialized(), "MapBinder was already initialized");
     entrySetBinder.permitDuplicates();
     binder.install(new MultimapBinder<K, V>(bindingSelection));
+  }
+
+  public void permitSpanInjectors() {
+    this.permitSpanInjectors = true;
+    entrySetBinder.permitSpanInjectors();
   }
 
   /** Adds a binding to the map for the given key. */
@@ -294,7 +370,12 @@ public final class RealMapBinder<K, V> implements Module {
    * V}.
    */
   public LinkedBindingBuilder<V> addBinding(K key) {
-    return binder.bind(getKeyForNewValue(key));
+    Key<V> valueKey = getKeyForNewValue(key);
+    LinkedBindingBuilder<V> builder = binder.bind(valueKey);
+    if (permitSpanInjectors && binder instanceof com.google.inject.PrivateBinder) {
+      ((com.google.inject.PrivateBinder) binder).expose(valueKey);
+    }
+    return builder;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"}) // we use raw Key to link bindings.
@@ -302,32 +383,34 @@ public final class RealMapBinder<K, V> implements Module {
   public void configure(Binder binder) {
     checkConfiguration(!bindingSelection.isInitialized(), "MapBinder was already initialized");
 
-    // Binds a Map<K, Provider<V>>
-    binder
-        .bind(bindingSelection.getProviderMapKey())
-        .toProvider(new RealProviderMapProvider<>(bindingSelection));
+    if (bindMap) {
+      // Binds a Map<K, Provider<V>>
+      binder
+          .bind(bindingSelection.getProviderMapKey())
+          .toProvider(new RealProviderMapProvider<>(bindingSelection));
 
-    // The map this exposes is internally an ImmutableMap, so it's OK to massage
-    // the guice Provider to jakarta Provider in the value (since Guice provider
-    // implements jakarta Provider).
-    binder
-        .bind(bindingSelection.getJakartaProviderMapKey())
-        .to((Key) bindingSelection.getProviderMapKey());
+      // The map this exposes is internally an ImmutableMap, so it's OK to massage
+      // the guice Provider to jakarta Provider in the value (since Guice provider
+      // implements jakarta Provider).
+      binder
+          .bind(bindingSelection.getJakartaProviderMapKey())
+          .to((Key) bindingSelection.getProviderMapKey());
 
-    // Bind Map<K, V> to the provider w/ extension support.
-    binder
-        .bind(bindingSelection.getMapKey())
-        .toProvider(new ExtensionRealMapProvider<>(bindingSelection));
-    // Bind Map<K, ? extends V> to the provider w/o the extension support.
-    binder
-        .bind(bindingSelection.getMapOfKeyExtendsValueKey())
-        .to((Key) bindingSelection.getMapKey());
+      // Bind Map<K, V> to the provider w/ extension support.
+      binder
+          .bind(bindingSelection.getMapKey())
+          .toProvider(new ExtensionRealMapProvider<>(bindingSelection));
+      // Bind Map<K, ? extends V> to the provider w/o the extension support.
+      binder
+          .bind(bindingSelection.getMapOfKeyExtendsValueKey())
+          .to((Key) bindingSelection.getMapKey());
 
-    // The Map.Entries are all ProviderMapEntry instances which do not allow setValue, so it is
-    // safe to massage the return type like this
-    binder
-        .bind(bindingSelection.getEntrySetJakartaProviderKey())
-        .to((Key) bindingSelection.getEntrySetBinder().getSetKey());
+      // The Map.Entries are all ProviderMapEntry instances which do not allow setValue, so it is
+      // safe to massage the return type like this
+      binder
+          .bind(bindingSelection.getEntrySetJakartaProviderKey())
+          .to((Key) bindingSelection.getEntrySetBinder().getSetKey());
+    }
   }
 
   @Override
@@ -442,6 +525,11 @@ public final class RealMapBinder<K, V> implements Module {
       for (Binding<Map.Entry<K, Provider<V>>> binding :
           injector.findBindingsByType(entrySetBinder.getElementTypeLiteral())) {
         if (entrySetBinder.containsElement(binding)) {
+
+          if (binding instanceof ExposedBinding) {
+            ExposedBinding<Map.Entry<K, Provider<V>>> exposed = (ExposedBinding) binding;
+            binding = exposed.getPrivateElements().getInjector().getBinding(binding.getKey());
+          }
 
           // Protected by findBindingByType() and the fact that all providers are added by us
           // in addBinding(). It would theoretically be possible for someone to directly

--- a/core/src/com/google/inject/internal/RealMultibinder.java
+++ b/core/src/com/google/inject/internal/RealMultibinder.java
@@ -64,6 +64,15 @@ public final class RealMultibinder<T> implements Module {
     return result;
   }
 
+  /**
+   * Implementation of newSetBinder that avoids binding the set itself.
+   */
+  public static <T> RealMultibinder<T> newRealSetBinder(Binder binder, Key<T> key, boolean bindSet) {
+    RealMultibinder<T> result = new RealMultibinder<>(binder, key, bindSet);
+    binder.install(result);
+    return result;
+  }
+
   @SuppressWarnings("unchecked") // wrapping a T in a Set safely returns a Set<T>
   static <T> TypeLiteral<Set<T>> setOf(TypeLiteral<T> elementType) {
     Type type = Types.setOf(elementType.getType());
@@ -96,10 +105,17 @@ public final class RealMultibinder<T> implements Module {
 
   private final BindingSelection<T> bindingSelection;
   private final Binder binder;
+  private final boolean bindSet;
+  private boolean permitSpanInjectors;
 
   RealMultibinder(Binder binder, Key<T> key) {
+    this(binder, key, true);
+  }
+
+  RealMultibinder(Binder binder, Key<T> key, boolean bindSet) {
     this.binder = checkNotNull(binder, "binder");
     this.bindingSelection = new BindingSelection<>(key);
+    this.bindSet = bindSet;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"}) // we use raw Key to link bindings together.
@@ -107,26 +123,32 @@ public final class RealMultibinder<T> implements Module {
   public void configure(Binder binder) {
     checkConfiguration(!bindingSelection.isInitialized(), "Multibinder was already initialized");
 
-    // Bind the setKey to the provider wrapped w/ extension support.
-    binder
-        .bind(bindingSelection.getSetKey())
-        .toProvider(new RealMultibinderProvider<>(bindingSelection));
-    binder.bind(bindingSelection.getSetOfExtendsKey()).to(bindingSelection.getSetKey());
+    if (bindSet) {
+      // Bind the setKey to the provider wrapped w/ extension support.
+      binder
+          .bind(bindingSelection.getSetKey())
+          .toProvider(new RealMultibinderProvider<>(bindingSelection));
+      binder.bind(bindingSelection.getSetOfExtendsKey()).to(bindingSelection.getSetKey());
 
-    binder
-        .bind(bindingSelection.getCollectionOfProvidersKey())
-        .toProvider(new RealMultibinderCollectionOfProvidersProvider<T>(bindingSelection));
+      binder
+          .bind(bindingSelection.getCollectionOfProvidersKey())
+          .toProvider(new RealMultibinderCollectionOfProvidersProvider<T>(bindingSelection));
 
-    // The collection this exposes is internally an ImmutableList, so it's OK to massage
-    // the guice Provider to jakarta Provider in the value (since the guice Provider implements
-    // jakarta Provider).
-    binder
-        .bind(bindingSelection.getCollectionOfJakartaProvidersKey())
-        .to((Key) bindingSelection.getCollectionOfProvidersKey());
+      // The collection this exposes is internally an ImmutableList, so it's OK to massage
+      // the guice Provider to jakarta Provider in the value (since the guice Provider implements
+      // jakarta Provider).
+      binder
+          .bind(bindingSelection.getCollectionOfJakartaProvidersKey())
+          .to((Key) bindingSelection.getCollectionOfProvidersKey());
+    }
   }
 
   public void permitDuplicates() {
     binder.install(new PermitDuplicatesModule(bindingSelection.getPermitDuplicatesKey()));
+  }
+
+  public void permitSpanInjectors() {
+    this.permitSpanInjectors = true;
   }
 
   /** Adds a new entry to the set and returns the key for it. */
@@ -138,7 +160,12 @@ public final class RealMultibinder<T> implements Module {
   }
 
   public LinkedBindingBuilder<T> addBinding() {
-    return binder.bind(getKeyForNewItem());
+    Key<T> key = getKeyForNewItem();
+    LinkedBindingBuilder<T> builder = binder.bind(key);
+    if (permitSpanInjectors && binder instanceof com.google.inject.PrivateBinder) {
+      ((com.google.inject.PrivateBinder) binder).expose(key);
+    }
+    return builder;
   }
 
   // These methods are used by RealMapBinder

--- a/core/src/com/google/inject/internal/RealOptionalBinder.java
+++ b/core/src/com/google/inject/internal/RealOptionalBinder.java
@@ -40,6 +40,7 @@ import com.google.inject.multibindings.OptionalBinderBinding;
 import com.google.inject.spi.BindingTargetVisitor;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.Element;
+import com.google.inject.spi.ExposedBinding;
 import com.google.inject.spi.ProviderInstanceBinding;
 import com.google.inject.spi.ProviderWithExtensionVisitor;
 import com.google.inject.util.Types;
@@ -59,8 +60,18 @@ import jakarta.inject.Qualifier;
  */
 public final class RealOptionalBinder<T> implements Module {
   public static <T> RealOptionalBinder<T> newRealOptionalBinder(Binder binder, Key<T> type) {
+    return newRealOptionalBinder(binder, type, true);
+  }
+
+  /**
+   * Returns a new OptionalBinder.
+   *
+   * @param bindOptional if true, the Optional<T> and java.util.Optional<T> keys will be bound.
+   */
+  public static <T> RealOptionalBinder<T> newRealOptionalBinder(
+      Binder binder, Key<T> type, boolean bindOptional) {
     binder = binder.skipSources(RealOptionalBinder.class);
-    RealOptionalBinder<T> optionalBinder = new RealOptionalBinder<>(binder, type);
+    RealOptionalBinder<T> optionalBinder = new RealOptionalBinder<>(binder, type, bindOptional);
     binder.install(optionalBinder);
     return optionalBinder;
   }
@@ -140,10 +151,13 @@ public final class RealOptionalBinder<T> implements Module {
 
   private final BindingSelection<T> bindingSelection;
   private final Binder binder;
+  private final boolean bindOptional;
+  private boolean permitSpanInjectors;
 
-  private RealOptionalBinder(Binder binder, Key<T> typeKey) {
+  private RealOptionalBinder(Binder binder, Key<T> typeKey, boolean bindOptional) {
     this.bindingSelection = new BindingSelection<>(typeKey);
     this.binder = binder;
+    this.bindOptional = bindOptional;
   }
 
   /**
@@ -164,12 +178,19 @@ public final class RealOptionalBinder<T> implements Module {
    */
   Key<T> getKeyForDefaultBinding() {
     bindingSelection.checkNotInitialized();
-    addDirectTypeBinding(binder);
+    if (bindOptional) {
+      addDirectTypeBinding(binder);
+    }
     return bindingSelection.getKeyForDefaultBinding();
   }
 
   public LinkedBindingBuilder<T> setDefault() {
-    return binder.bind(getKeyForDefaultBinding());
+    Key<T> key = getKeyForDefaultBinding();
+    LinkedBindingBuilder<T> builder = binder.bind(key);
+    if (permitSpanInjectors && binder instanceof com.google.inject.PrivateBinder) {
+      ((com.google.inject.PrivateBinder) binder).expose(key);
+    }
+    return builder;
   }
 
   /**
@@ -180,56 +201,69 @@ public final class RealOptionalBinder<T> implements Module {
    */
   Key<T> getKeyForActualBinding() {
     bindingSelection.checkNotInitialized();
-    addDirectTypeBinding(binder);
+    if (bindOptional) {
+      addDirectTypeBinding(binder);
+    }
     return bindingSelection.getKeyForActualBinding();
   }
 
   public LinkedBindingBuilder<T> setBinding() {
-    return binder.bind(getKeyForActualBinding());
+    Key<T> key = getKeyForActualBinding();
+    LinkedBindingBuilder<T> builder = binder.bind(key);
+    if (permitSpanInjectors && binder instanceof com.google.inject.PrivateBinder) {
+      ((com.google.inject.PrivateBinder) binder).expose(key);
+    }
+    return builder;
+  }
+
+  public void permitSpanInjectors() {
+    this.permitSpanInjectors = true;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"}) // we use raw Key to link bindings together.
   @Override
   public void configure(Binder binder) {
     bindingSelection.checkNotInitialized();
-    Key<T> key = bindingSelection.getDirectKey();
-    TypeLiteral<T> typeLiteral = key.getTypeLiteral();
-    // Every OptionalBinder gets the following types bound
-    // * {cgcb,ju}.Optional<Provider<T>>
-    // * {cgcb,ju}.Optional<jakarta.inject.Provider<T>>
-    // * {cgcb,ju}.Optional<T>
-    // If setDefault() or setBinding() is called then also
-    // * T is bound
+    if (bindOptional) {
+      Key<T> key = bindingSelection.getDirectKey();
+      TypeLiteral<T> typeLiteral = key.getTypeLiteral();
+      // Every OptionalBinder gets the following types bound
+      // * {cgcb,ju}.Optional<Provider<T>>
+      // * {cgcb,ju}.Optional<jakarta.inject.Provider<T>>
+      // * {cgcb,ju}.Optional<T>
+      // If setDefault() or setBinding() is called then also
+      // * T is bound
 
-    // cgcb.Optional<c.g.i.Provider<T>>
-    Key<Optional<Provider<T>>> guavaOptProviderKey = key.ofType(optionalOfProvider(typeLiteral));
-    binder
-        .bind(guavaOptProviderKey)
-        .toProvider(new RealOptionalProviderProvider<>(bindingSelection));
-    // ju.Optional<c.g.i.Provider<T>>
-    Key<java.util.Optional<Provider<T>>> javaOptProviderKey =
-        key.ofType(javaOptionalOfProvider(typeLiteral));
-    binder
-        .bind(javaOptProviderKey)
-        .toProvider(new JavaOptionalProviderProvider<>(bindingSelection));
+      // cgcb.Optional<c.g.i.Provider<T>>
+      Key<Optional<Provider<T>>> guavaOptProviderKey = key.ofType(optionalOfProvider(typeLiteral));
+      binder
+          .bind(guavaOptProviderKey)
+          .toProvider(new RealOptionalProviderProvider<>(bindingSelection));
+      // ju.Optional<c.g.i.Provider<T>>
+      Key<java.util.Optional<Provider<T>>> javaOptProviderKey =
+          key.ofType(javaOptionalOfProvider(typeLiteral));
+      binder
+          .bind(javaOptProviderKey)
+          .toProvider(new JavaOptionalProviderProvider<>(bindingSelection));
 
-    // Provider is assignable to jakarta.inject.Provider and the provider that the factory contains
-    // cannot be modified so we can use some rawtypes hackery to share the same implementation.
-    // cgcb.Optional<jakarta.inject.Provider<T>>
-    binder.bind(key.ofType(optionalOfJakartaProvider(typeLiteral))).to((Key) guavaOptProviderKey);
-    // ju.Optional<jakarta.inject.Provider<T>>
-    binder
-        .bind(key.ofType(javaOptionalOfJakartaProvider(typeLiteral)))
-        .to((Key) javaOptProviderKey);
+      // Provider is assignable to jakarta.inject.Provider and the provider that the factory contains
+      // cannot be modified so we can use some rawtypes hackery to share the same implementation.
+      // cgcb.Optional<jakarta.inject.Provider<T>>
+      binder.bind(key.ofType(optionalOfJakartaProvider(typeLiteral))).to((Key) guavaOptProviderKey);
+      // ju.Optional<jakarta.inject.Provider<T>>
+      binder
+          .bind(key.ofType(javaOptionalOfJakartaProvider(typeLiteral)))
+          .to((Key) javaOptProviderKey);
 
-    // cgcb.Optional<T>
-    Key<Optional<T>> guavaOptKey = key.ofType(optionalOf(typeLiteral));
-    binder
-        .bind(guavaOptKey)
-        .toProvider(new RealOptionalKeyProvider<>(bindingSelection, guavaOptKey));
-    // ju.Optional<T>
-    Key<java.util.Optional<T>> javaOptKey = key.ofType(javaOptionalOf(typeLiteral));
-    binder.bind(javaOptKey).toProvider(new JavaOptionalProvider<>(bindingSelection, javaOptKey));
+      // cgcb.Optional<T>
+      Key<Optional<T>> guavaOptKey = key.ofType(optionalOf(typeLiteral));
+      binder
+          .bind(guavaOptKey)
+          .toProvider(new RealOptionalKeyProvider<>(bindingSelection, guavaOptKey));
+      // ju.Optional<T>
+      Key<java.util.Optional<T>> javaOptKey = key.ofType(javaOptionalOf(typeLiteral));
+      binder.bind(javaOptKey).toProvider(new JavaOptionalProvider<>(bindingSelection, javaOptKey));
+    }
   }
 
   /** Provides the binding for {@code java.util.Optional<T>}. */
@@ -662,7 +696,18 @@ public final class RealOptionalBinder<T> implements Module {
       }
       state = InitializationState.INITIALIZING;
       actualBinding = injector.getExistingBinding(getKeyForActualBinding());
+      if (actualBinding instanceof ExposedBinding) {
+        ExposedBinding<T> exposed = (ExposedBinding) actualBinding;
+        actualBinding =
+            (BindingImpl<T>) exposed.getPrivateElements().getInjector().getBinding(actualBinding.getKey());
+      }
       defaultBinding = injector.getExistingBinding(getKeyForDefaultBinding());
+      if (defaultBinding instanceof ExposedBinding) {
+        ExposedBinding<T> exposed = (ExposedBinding) defaultBinding;
+        defaultBinding =
+            (BindingImpl<T>)
+                exposed.getPrivateElements().getInjector().getBinding(defaultBinding.getKey());
+      }
       // We should never create Jit bindings, but we can use them if some other binding created it.
       BindingImpl<T> userBinding = injector.getExistingBinding(key);
       if (actualBinding != null) {

--- a/core/src/com/google/inject/multibindings/MapBinder.java
+++ b/core/src/com/google/inject/multibindings/MapBinder.java
@@ -154,6 +154,86 @@ public class MapBinder<K, V> {
         binder, TypeLiteral.get(keyType), TypeLiteral.get(valueType), annotationType);
   }
 
+  /**
+   * Returns a new mapbinder that contributes to an existing map binding (typically in a parent
+   * injector) without creating a new map binding itself. This is necessary when contributing to a
+   * MapBinder from a PrivateModule where the parent injector already has the MapBinder.
+   *
+   * @since 7.0
+   */
+  public static <K, V> MapBinder<K, V> newMapContributor(
+      Binder binder, TypeLiteral<K> keyType, TypeLiteral<V> valueType) {
+    return new MapBinder<K, V>(newRealMapBinder(binder, keyType, valueType, false));
+  }
+
+  /**
+   * Returns a new mapbinder that contributes to an existing map binding (typically in a parent
+   * injector) without creating a new map binding itself. This is necessary when contributing to a
+   * MapBinder from a PrivateModule where the parent injector already has the MapBinder.
+   *
+   * @since 7.0
+   */
+  public static <K, V> MapBinder<K, V> newMapContributor(
+      Binder binder, Class<K> keyType, Class<V> valueType) {
+    return newMapContributor(binder, TypeLiteral.get(keyType), TypeLiteral.get(valueType));
+  }
+
+  /**
+   * Returns a new mapbinder that contributes to an existing map binding (typically in a parent
+   * injector) without creating a new map binding itself. This is necessary when contributing to a
+   * MapBinder from a PrivateModule where the parent injector already has the MapBinder.
+   *
+   * @since 7.0
+   */
+  public static <K, V> MapBinder<K, V> newMapContributor(
+      Binder binder, TypeLiteral<K> keyType, TypeLiteral<V> valueType, Annotation annotation) {
+    return new MapBinder<K, V>(newRealMapBinder(binder, keyType, valueType, annotation, false));
+  }
+
+  /**
+   * Returns a new mapbinder that contributes to an existing map binding (typically in a parent
+   * injector) without creating a new map binding itself. This is necessary when contributing to a
+   * MapBinder from a PrivateModule where the parent injector already has the MapBinder.
+   *
+   * @since 7.0
+   */
+  public static <K, V> MapBinder<K, V> newMapContributor(
+      Binder binder, Class<K> keyType, Class<V> valueType, Annotation annotation) {
+    return newMapContributor(
+        binder, TypeLiteral.get(keyType), TypeLiteral.get(valueType), annotation);
+  }
+
+  /**
+   * Returns a new mapbinder that contributes to an existing map binding (typically in a parent
+   * injector) without creating a new map binding itself. This is necessary when contributing to a
+   * MapBinder from a PrivateModule where the parent injector already has the MapBinder.
+   *
+   * @since 7.0
+   */
+  public static <K, V> MapBinder<K, V> newMapContributor(
+      Binder binder,
+      TypeLiteral<K> keyType,
+      TypeLiteral<V> valueType,
+      Class<? extends Annotation> annotationType) {
+    return new MapBinder<K, V>(newRealMapBinder(binder, keyType, valueType, annotationType, false));
+  }
+
+  /**
+   * Returns a new mapbinder that contributes to an existing map binding (typically in a parent
+   * injector) without creating a new map binding itself. This is necessary when contributing to a
+   * MapBinder from a PrivateModule where the parent injector already has the MapBinder.
+   *
+   * @since 7.0
+   */
+  public static <K, V> MapBinder<K, V> newMapContributor(
+      Binder binder,
+      Class<K> keyType,
+      Class<V> valueType,
+      Class<? extends Annotation> annotationType) {
+    return newMapContributor(
+        binder, TypeLiteral.get(keyType), TypeLiteral.get(valueType), annotationType);
+  }
+
   private final RealMapBinder<K, V> delegate;
 
   private MapBinder(RealMapBinder<K, V> delegate) {
@@ -177,6 +257,18 @@ public class MapBinder<K, V> {
    */
   public MapBinder<K, V> permitDuplicates() {
     delegate.permitDuplicates();
+    return this;
+  }
+
+  /**
+   * Configures the mapbinder to automatically expose the binding for each added entry. This is useful
+   * when contributing to a parent injector's MapBinder from a PrivateModule.
+   *
+   * @return this map binder
+   * @since 7.0
+   */
+  public MapBinder<K, V> permitSpanInjectors() {
+    delegate.permitSpanInjectors();
     return this;
   }
 

--- a/core/src/com/google/inject/multibindings/Multibinder.java
+++ b/core/src/com/google/inject/multibindings/Multibinder.java
@@ -138,6 +138,87 @@ public class Multibinder<T> {
   }
 
   /**
+   * Returns a new multibinder that contributes to an existing set binding (typically in a parent
+   * injector) without creating a new set binding itself. This is necessary when contributing to a
+   * Multibinder from a PrivateModule where the parent injector already has the Multibinder.
+   *
+   * @since 7.0
+   */
+  public static <T> Multibinder<T> newSetContributor(Binder binder, TypeLiteral<T> type) {
+    return newSetContributor(binder, Key.get(type));
+  }
+
+  /**
+   * Returns a new multibinder that contributes to an existing set binding (typically in a parent
+   * injector) without creating a new set binding itself. This is necessary when contributing to a
+   * Multibinder from a PrivateModule where the parent injector already has the Multibinder.
+   *
+   * @since 7.0
+   */
+  public static <T> Multibinder<T> newSetContributor(Binder binder, Class<T> type) {
+    return newSetContributor(binder, Key.get(type));
+  }
+
+  /**
+   * Returns a new multibinder that contributes to an existing set binding (typically in a parent
+   * injector) without creating a new set binding itself. This is necessary when contributing to a
+   * Multibinder from a PrivateModule where the parent injector already has the Multibinder.
+   *
+   * @since 7.0
+   */
+  public static <T> Multibinder<T> newSetContributor(
+      Binder binder, TypeLiteral<T> type, Annotation annotation) {
+    return newSetContributor(binder, Key.get(type, annotation));
+  }
+
+  /**
+   * Returns a new multibinder that contributes to an existing set binding (typically in a parent
+   * injector) without creating a new set binding itself. This is necessary when contributing to a
+   * Multibinder from a PrivateModule where the parent injector already has the Multibinder.
+   *
+   * @since 7.0
+   */
+  public static <T> Multibinder<T> newSetContributor(
+      Binder binder, Class<T> type, Annotation annotation) {
+    return newSetContributor(binder, Key.get(type, annotation));
+  }
+
+  /**
+   * Returns a new multibinder that contributes to an existing set binding (typically in a parent
+   * injector) without creating a new set binding itself. This is necessary when contributing to a
+   * Multibinder from a PrivateModule where the parent injector already has the Multibinder.
+   *
+   * @since 7.0
+   */
+  public static <T> Multibinder<T> newSetContributor(
+      Binder binder, TypeLiteral<T> type, Class<? extends Annotation> annotationType) {
+    return newSetContributor(binder, Key.get(type, annotationType));
+  }
+
+  /**
+   * Returns a new multibinder that contributes to an existing set binding (typically in a parent
+   * injector) without creating a new set binding itself. This is necessary when contributing to a
+   * Multibinder from a PrivateModule where the parent injector already has the Multibinder.
+   *
+   * @since 7.0
+   */
+  public static <T> Multibinder<T> newSetContributor(
+      Binder binder, Class<T> type, Class<? extends Annotation> annotationType) {
+    return newSetContributor(binder, Key.get(type, annotationType));
+  }
+
+  /**
+   * Returns a new multibinder that contributes to an existing set binding (typically in a parent
+   * injector) without creating a new set binding itself. This is necessary when contributing to a
+   * Multibinder from a PrivateModule where the parent injector already has the Multibinder.
+   *
+   * @since 7.0
+   */
+  public static <T> Multibinder<T> newSetContributor(Binder binder, Key<T> key) {
+    return new Multibinder<T>(newRealSetBinder(binder, key, false));
+  }
+
+  /**
    * Returns a new multibinder that collects instances of {@code type} in a {@link Set} that is
    * itself bound with {@code annotationType}.
    */
@@ -162,6 +243,18 @@ public class Multibinder<T> {
    */
   public Multibinder<T> permitDuplicates() {
     delegate.permitDuplicates();
+    return this;
+  }
+
+  /**
+   * Configures the multibinder to automatically expose the binding for each added element. This is
+   * useful when contributing to a parent injector's Multibinder from a PrivateModule.
+   *
+   * @return this multibinder
+   * @since 7.0
+   */
+  public Multibinder<T> permitSpanInjectors() {
+    delegate.permitSpanInjectors();
     return this;
   }
 

--- a/core/src/com/google/inject/multibindings/OptionalBinder.java
+++ b/core/src/com/google/inject/multibindings/OptionalBinder.java
@@ -148,13 +148,69 @@ public class OptionalBinder<T> {
   }
 
   public static <T> OptionalBinder<T> newOptionalBinder(Binder binder, Key<T> type) {
-    return new OptionalBinder<T>(newRealOptionalBinder(binder, type));
+    return newOptionalBinder(binder, type, true);
+  }
+
+  /**
+   * Internal constructor for RealOptionalBinder to use.
+   */
+  private static <T> OptionalBinder<T> newOptionalBinder(
+      Binder binder, Key<T> type, boolean bindOptional) {
+    return new OptionalBinder<T>(newRealOptionalBinder(binder, type, bindOptional));
+  }
+
+  /**
+   * Returns a new OptionalBinder that contributes to an existing OptionalBinder binding (typically
+   * in a parent injector) without creating a new OptionalBinder binding itself. This is necessary
+   * when contributing to an OptionalBinder from a PrivateModule where the parent injector already
+   * has the OptionalBinder.
+   *
+   * @since 7.0
+   */
+  public static <T> OptionalBinder<T> newOptionalContributor(Binder binder, Class<T> type) {
+    return newOptionalContributor(binder, Key.get(type));
+  }
+
+  /**
+   * Returns a new OptionalBinder that contributes to an existing OptionalBinder binding (typically
+   * in a parent injector) without creating a new OptionalBinder binding itself. This is necessary
+   * when contributing to an OptionalBinder from a PrivateModule where the parent injector already
+   * has the OptionalBinder.
+   *
+   * @since 7.0
+   */
+  public static <T> OptionalBinder<T> newOptionalContributor(Binder binder, TypeLiteral<T> type) {
+    return newOptionalContributor(binder, Key.get(type));
+  }
+
+  /**
+   * Returns a new OptionalBinder that contributes to an existing OptionalBinder binding (typically
+   * in a parent injector) without creating a new OptionalBinder binding itself. This is necessary
+   * when contributing to an OptionalBinder from a PrivateModule where the parent injector already
+   * has the OptionalBinder.
+   *
+   * @since 7.0
+   */
+  public static <T> OptionalBinder<T> newOptionalContributor(Binder binder, Key<T> type) {
+    return newOptionalBinder(binder, type, false);
   }
 
   private final RealOptionalBinder<T> delegate;
 
   private OptionalBinder(RealOptionalBinder<T> delegate) {
     this.delegate = delegate;
+  }
+
+  /**
+   * Configures the OptionalBinder to automatically expose the binding for each added entry. This is
+   * useful when contributing to a parent injector's OptionalBinder from a PrivateModule.
+   *
+   * @return this optional binder
+   * @since 7.0
+   */
+  public OptionalBinder<T> permitSpanInjectors() {
+    delegate.permitSpanInjectors();
+    return this;
   }
 
   /**

--- a/core/test/com/google/inject/multibindings/MultibindingsSpanningInjectorsTest.java
+++ b/core/test/com/google/inject/multibindings/MultibindingsSpanningInjectorsTest.java
@@ -1,0 +1,82 @@
+package com.google.inject.multibindings;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.PrivateModule;
+import com.google.inject.TypeLiteral;
+import java.util.Map;
+import java.util.Set;
+import junit.framework.TestCase;
+
+public class MultibindingsSpanningInjectorsTest extends TestCase {
+
+  public static class MainModule extends AbstractModule {
+    @Override
+    protected void configure() {
+      Multibinder.newSetBinder(binder(), String.class).addBinding().toInstance("Main");
+      install(new ChildModule());
+    }
+  }
+
+  public static class ChildModule extends PrivateModule {
+    @Override
+    protected void configure() {
+      // Use the new API to contribute to the parent's Multibinder
+      Multibinder.newSetContributor(binder(), String.class)
+          .permitSpanInjectors()
+          .addBinding().toInstance("Private");
+    }
+  }
+
+  public void testPrivateModuleContributionExposed() {
+    Injector injector = Guice.createInjector(new MainModule());
+
+    Set<String> set = injector.getInstance(Key.get(new TypeLiteral<Set<String>>() {}));
+    
+    assertThat(set).containsExactly("Main", "Private").inOrder();
+  }
+
+  public static class PrivateModuleA extends PrivateModule {
+    @Override protected void configure() {
+      Multibinder.newSetBinder(binder(), String.class).addBinding().toInstance("A");
+    }
+  }
+
+  public static class PrivateModuleB extends PrivateModule {
+    @Override protected void configure() {
+      Multibinder.newSetBinder(binder(), String.class).addBinding().toInstance("B");
+    }
+  }
+
+  public void testSiblings() {
+     Injector injector = Guice.createInjector(new PrivateModuleA(), new PrivateModuleB());
+     // Siblings are isolated, so this just verifies we didn't break existing isolation/instantiation
+  }
+
+  public static class MapMainModule extends AbstractModule {
+    @Override
+    protected void configure() {
+      MapBinder.newMapBinder(binder(), String.class, String.class).addBinding("KeyMain").toInstance("ValueMain");
+      install(new MapChildModule());
+    }
+  }
+
+  public static class MapChildModule extends PrivateModule {
+    @Override
+    protected void configure() {
+      MapBinder.newMapContributor(binder(), String.class, String.class)
+          .permitSpanInjectors()
+          .addBinding("KeyPrivate").toInstance("ValuePrivate");
+    }
+  }
+
+  public void testMapBinderContribution() {
+    Injector injector = Guice.createInjector(new MapMainModule());
+    Map<String, String> map = injector.getInstance(Key.get(new TypeLiteral<Map<String, String>>() {}));
+    assertThat(map).containsExactly("KeyMain", "ValueMain", "KeyPrivate", "ValuePrivate");
+  }
+}

--- a/core/test/com/google/inject/multibindings/OptionalBinderSpanningInjectorsTest.java
+++ b/core/test/com/google/inject/multibindings/OptionalBinderSpanningInjectorsTest.java
@@ -1,0 +1,84 @@
+package com.google.inject.multibindings;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.base.Optional;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.PrivateModule;
+import com.google.inject.TypeLiteral;
+import junit.framework.TestCase;
+
+public class OptionalBinderSpanningInjectorsTest extends TestCase {
+
+  public void testDefaultInParentActualInChild() {
+    Injector injector = Guice.createInjector(
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            OptionalBinder.newOptionalBinder(binder(), String.class).setDefault().toInstance("Default");
+            
+            install(new PrivateModule() {
+              @Override
+              protected void configure() {
+                // Use new API to contribute to the parent's OptionalBinder
+                OptionalBinder.newOptionalContributor(binder(), String.class)
+                    .permitSpanInjectors()
+                    .setBinding().toInstance("Actual");
+              }
+            });
+          }
+        });
+
+    Optional<String> optional = injector.getInstance(Key.get(new TypeLiteral<Optional<String>>() {}));
+    assertThat(optional.get()).isEqualTo("Actual");
+  }
+
+  public void testNoDefaultInParentActualInChild() {
+    Injector injector = Guice.createInjector(
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            OptionalBinder.newOptionalBinder(binder(), String.class);
+            
+            install(new PrivateModule() {
+              @Override
+              protected void configure() {
+                OptionalBinder.newOptionalContributor(binder(), String.class)
+                    .permitSpanInjectors()
+                    .setBinding().toInstance("Actual");
+              }
+            });
+          }
+        });
+
+    Optional<String> optional = injector.getInstance(Key.get(new TypeLiteral<Optional<String>>() {}));
+    assertThat(optional.isPresent()).isTrue();
+    assertThat(optional.get()).isEqualTo("Actual");
+  }
+
+  public void testDefaultInChildActualInParent() {
+    Injector injector = Guice.createInjector(
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            OptionalBinder.newOptionalBinder(binder(), String.class).setBinding().toInstance("Actual");
+            
+            install(new PrivateModule() {
+              @Override
+              protected void configure() {
+                OptionalBinder.newOptionalContributor(binder(), String.class)
+                    .permitSpanInjectors()
+                    .setDefault().toInstance("Default");
+              }
+            });
+          }
+        });
+
+    Optional<String> optional = injector.getInstance(Key.get(new TypeLiteral<Optional<String>>() {}));
+    // Actual overrides Default even if Default is in child.
+    assertThat(optional.get()).isEqualTo("Actual");
+  }
+}


### PR DESCRIPTION
This PR introduces a new 'contributor' API for Multibinder, MapBinder, and OptionalBinder, allowing PrivateModules to contribute bindings to an extension point defined in a parent injector.

The inability for PrivateModules to contribute to multibindings has come up multiple times with various workarounds being proposed:
- https://groups.google.com/g/google-guice/c/h70a9pwD6_g?pli=1
- https://groups.google.com/g/google-guice/c/sWwT8xL1CBA
- #906
- #369
- #1272

This PR attempts to resolve this by adding a new API to contribute to existing multibindings across public and private modules without creating a new local binding within the PrivateModule

### Key Changes:
- Introduced `newSetContributor`, `newMapContributor`, and `newOptionalContributor` methods.
- Added `permitSpanInjectors()` to handle automatic key exposure in PrivateModules.
- Updated `RealMultibinder`, `RealMapBinder`, and `RealOptionalBinder` to support a non-binding container mode.
- Added reproduction and verification tests: `MultibindingsSpanningInjectorsTest` and `OptionalBinderSpanningInjectorsTest`.