### PR TITLE
Escape special chars in graphviz node subtitles

### DIFF
--- a/extensions/grapher/src/com/google/inject/grapher/graphviz/GraphvizGrapher.java
+++ b/extensions/grapher/src/com/google/inject/grapher/graphviz/GraphvizGrapher.java
@@ -141,7 +141,7 @@ public class GraphvizGrapher extends AbstractInjectorGrapher {
     html.append("<tr>").append("<td align=\"left\" port=\"header\" ");
     html.append("bgcolor=\"" + node.getHeaderBackgroundColor() + "\">");
 
-    String subtitle = Joiner.on("<br align=\"left\"/>").join(node.getSubtitles());
+    String subtitle = Joiner.on("<br align=\"left\"/>").join(htmlEscape(node.getSubtitles()));
     if (subtitle.length() != 0) {
       html.append("<font color=\"").append(node.getHeaderTextColor());
       html.append("\" point-size=\"10\">");

--- a/extensions/grapher/test/com/google/inject/grapher/AllTests.java
+++ b/extensions/grapher/test/com/google/inject/grapher/AllTests.java
@@ -16,6 +16,7 @@
 
 package com.google.inject.grapher;
 
+import com.google.inject.grapher.graphviz.GraphvizGrapherTest;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
@@ -27,6 +28,7 @@ public class AllTests {
     suite.addTestSuite(AbstractInjectorGrapherTest.class);
     suite.addTestSuite(ShortNameFactoryTest.class);
     suite.addTestSuite(TransitiveDependencyVisitorTest.class);
+    suite.addTestSuite(GraphvizGrapherTest.class);
     return suite;
   }
 }

--- a/extensions/grapher/test/com/google/inject/grapher/graphviz/GraphvizGrapherTest.java
+++ b/extensions/grapher/test/com/google/inject/grapher/graphviz/GraphvizGrapherTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.inject.grapher.graphviz;
+
+import com.google.inject.Key;
+import com.google.inject.grapher.NodeId;
+import com.google.inject.grapher.ShortNameFactory;
+import java.lang.reflect.Member;
+import junit.framework.TestCase;
+
+/** Tests for {@link GraphvizGrapher}. */
+public class GraphvizGrapherTest extends TestCase {
+
+  /**
+   * The subtitle is rendered inside an HTML table label, so special characters have to be escaped
+   * just like the title and the field names/values.
+   */
+  public void testGetNodeLabelEscapesSubtitle() {
+    GraphvizGrapher grapher =
+        new GraphvizGrapher(
+            new ShortNameFactory(),
+            new PortIdFactory() {
+              @Override
+              public String getPortId(Member member) {
+                return member.getName();
+              }
+            });
+
+    GraphvizNode node = new GraphvizNode(NodeId.newTypeId(Key.get(String.class)));
+    node.setTitle("Thing");
+    node.addSubtitle(0, "a<b> & c");
+    node.setHeaderTextColor("#ffffff");
+
+    String label = grapher.getNodeLabel(node);
+
+    assertTrue(label.contains("a&lt;b&gt; &amp; c"));
+    assertFalse(label.contains("a<b> & c"));
+  }
+}


### PR DESCRIPTION
The grapher writes node labels as Graphviz HTML tables. Title and fields were escaped, subtitles weren't. Since a subtitle can be an annotation name like @Named("a<b>"), the unescaped <...> gets parsed as a tag and the generated .dot file no longer renders.

Escapes each subtitle before joining them together, which is the same thing the title/field paths already do. Added a small regression test that puts <, > and & in a subtitle and checks the escaped output.